### PR TITLE
fix: panic on nil *Ctx in Signal/State mutation paths

### DIFF
--- a/op.go
+++ b/op.go
@@ -8,3 +8,12 @@ package via
 type ops[T any] struct {
 	update func(func(T) (T, error)) error
 }
+
+// mustOpCtx panics if ctx is nil so the failure points at the user's
+// Op(nil) call site rather than firing later inside a verb closure
+// with a stack rooted at Signal.Update.
+func mustOpCtx(ctx *Ctx) {
+	if ctx == nil {
+		panic("via: Op called with nil *Ctx")
+	}
+}

--- a/op_test.go
+++ b/op_test.go
@@ -155,3 +155,28 @@ func TestOp_UpdateErrorRejectsTheWrite(t *testing.T) {
 	assert.Contains(t, body, `<span id="tab">100</span>`,
 		"failing Update must not commit its computed value")
 }
+
+func TestOp_panicsOnNilCtx(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		call func()
+	}{
+		{"SignalNum", func() { var s via.SignalNum[int]; _ = s.Op(nil) }},
+		{"SignalBool", func() { var s via.SignalBool; _ = s.Op(nil) }},
+		{"SignalStr", func() { var s via.SignalStr; _ = s.Op(nil) }},
+		{"SignalSlice", func() { var s via.SignalSlice[int]; _ = s.Op(nil) }},
+		{"SignalMap", func() { var s via.SignalMap[string, int]; _ = s.Op(nil) }},
+		{"StateTabNum", func() { var s via.StateTabNum[int]; _ = s.Op(nil) }},
+		{"StateSessNum", func() { var s via.StateSessNum[int]; _ = s.Op(nil) }},
+		{"StateAppNum", func() { var s via.StateAppNum[int]; _ = s.Op(nil) }},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			assert.PanicsWithValue(t,
+				"via: Op called with nil *Ctx", c.call,
+				"Op must panic eagerly so the stack points at the user's Op(nil) call site")
+		})
+	}
+}

--- a/shape_bool.go
+++ b/shape_bool.go
@@ -28,6 +28,7 @@ type SignalBool struct{ Signal[bool] }
 
 // Op returns a bool chain bound to ctx.
 func (s *SignalBool) Op(ctx *Ctx) *BoolOps {
+	mustOpCtx(ctx)
 	return &BoolOps{ops: ops[bool]{update: func(fn func(bool) (bool, error)) error { return s.Update(ctx, fn) }}}
 }
 
@@ -36,6 +37,7 @@ type StateTabBool struct{ StateTab[bool] }
 
 // Op returns a bool chain bound to ctx.
 func (s *StateTabBool) Op(ctx *Ctx) *BoolOps {
+	mustOpCtx(ctx)
 	return &BoolOps{ops: ops[bool]{update: func(fn func(bool) (bool, error)) error { return s.Update(ctx, fn) }}}
 }
 
@@ -44,6 +46,7 @@ type StateSessBool struct{ StateSess[bool] }
 
 // Op returns a bool chain bound to ctx.
 func (s *StateSessBool) Op(ctx *Ctx) *BoolOps {
+	mustOpCtx(ctx)
 	return &BoolOps{ops: ops[bool]{update: func(fn func(bool) (bool, error)) error { return s.Update(ctx, fn) }}}
 }
 
@@ -52,5 +55,6 @@ type StateAppBool struct{ StateApp[bool] }
 
 // Op returns a bool chain bound to ctx.
 func (a *StateAppBool) Op(ctx *Ctx) *BoolOps {
+	mustOpCtx(ctx)
 	return &BoolOps{ops: ops[bool]{update: func(fn func(bool) (bool, error)) error { return a.Update(ctx, fn) }}}
 }

--- a/shape_map.go
+++ b/shape_map.go
@@ -36,6 +36,7 @@ type SignalMap[K comparable, V any] struct{ Signal[map[K]V] }
 
 // Op returns a map chain bound to ctx.
 func (s *SignalMap[K, V]) Op(ctx *Ctx) *MapOps[K, V] {
+	mustOpCtx(ctx)
 	return &MapOps[K, V]{ops: ops[map[K]V]{update: func(fn func(map[K]V) (map[K]V, error)) error { return s.Update(ctx, fn) }}}
 }
 
@@ -44,6 +45,7 @@ type StateTabMap[K comparable, V any] struct{ StateTab[map[K]V] }
 
 // Op returns a map chain bound to ctx.
 func (s *StateTabMap[K, V]) Op(ctx *Ctx) *MapOps[K, V] {
+	mustOpCtx(ctx)
 	return &MapOps[K, V]{ops: ops[map[K]V]{update: func(fn func(map[K]V) (map[K]V, error)) error { return s.Update(ctx, fn) }}}
 }
 
@@ -52,6 +54,7 @@ type StateSessMap[K comparable, V any] struct{ StateSess[map[K]V] }
 
 // Op returns a map chain bound to ctx.
 func (s *StateSessMap[K, V]) Op(ctx *Ctx) *MapOps[K, V] {
+	mustOpCtx(ctx)
 	return &MapOps[K, V]{ops: ops[map[K]V]{update: func(fn func(map[K]V) (map[K]V, error)) error { return s.Update(ctx, fn) }}}
 }
 
@@ -60,5 +63,6 @@ type StateAppMap[K comparable, V any] struct{ StateApp[map[K]V] }
 
 // Op returns a map chain bound to ctx.
 func (a *StateAppMap[K, V]) Op(ctx *Ctx) *MapOps[K, V] {
+	mustOpCtx(ctx)
 	return &MapOps[K, V]{ops: ops[map[K]V]{update: func(fn func(map[K]V) (map[K]V, error)) error { return a.Update(ctx, fn) }}}
 }

--- a/shape_num.go
+++ b/shape_num.go
@@ -77,6 +77,7 @@ type SignalNum[T Number] struct{ Signal[T] }
 
 // Op returns a numeric chain bound to ctx.
 func (s *SignalNum[T]) Op(ctx *Ctx) *NumOps[T] {
+	mustOpCtx(ctx)
 	return &NumOps[T]{ops: ops[T]{update: func(fn func(T) (T, error)) error { return s.Update(ctx, fn) }}}
 }
 
@@ -85,6 +86,7 @@ type StateTabNum[T Number] struct{ StateTab[T] }
 
 // Op returns a numeric chain bound to ctx.
 func (s *StateTabNum[T]) Op(ctx *Ctx) *NumOps[T] {
+	mustOpCtx(ctx)
 	return &NumOps[T]{ops: ops[T]{update: func(fn func(T) (T, error)) error { return s.Update(ctx, fn) }}}
 }
 
@@ -93,6 +95,7 @@ type StateSessNum[T Number] struct{ StateSess[T] }
 
 // Op returns a numeric chain bound to ctx.
 func (s *StateSessNum[T]) Op(ctx *Ctx) *NumOps[T] {
+	mustOpCtx(ctx)
 	return &NumOps[T]{ops: ops[T]{update: func(fn func(T) (T, error)) error { return s.Update(ctx, fn) }}}
 }
 
@@ -101,5 +104,6 @@ type StateAppNum[T Number] struct{ StateApp[T] }
 
 // Op returns a numeric chain bound to ctx.
 func (a *StateAppNum[T]) Op(ctx *Ctx) *NumOps[T] {
+	mustOpCtx(ctx)
 	return &NumOps[T]{ops: ops[T]{update: func(fn func(T) (T, error)) error { return a.Update(ctx, fn) }}}
 }

--- a/shape_slice.go
+++ b/shape_slice.go
@@ -97,6 +97,7 @@ type SignalSlice[T any] struct{ Signal[[]T] }
 
 // Op returns a slice chain bound to ctx.
 func (s *SignalSlice[T]) Op(ctx *Ctx) *SliceOps[T] {
+	mustOpCtx(ctx)
 	return &SliceOps[T]{ops: ops[[]T]{update: func(fn func([]T) ([]T, error)) error { return s.Update(ctx, fn) }}}
 }
 
@@ -105,6 +106,7 @@ type StateTabSlice[T any] struct{ StateTab[[]T] }
 
 // Op returns a slice chain bound to ctx.
 func (s *StateTabSlice[T]) Op(ctx *Ctx) *SliceOps[T] {
+	mustOpCtx(ctx)
 	return &SliceOps[T]{ops: ops[[]T]{update: func(fn func([]T) ([]T, error)) error { return s.Update(ctx, fn) }}}
 }
 
@@ -113,6 +115,7 @@ type StateSessSlice[T any] struct{ StateSess[[]T] }
 
 // Op returns a slice chain bound to ctx.
 func (s *StateSessSlice[T]) Op(ctx *Ctx) *SliceOps[T] {
+	mustOpCtx(ctx)
 	return &SliceOps[T]{ops: ops[[]T]{update: func(fn func([]T) ([]T, error)) error { return s.Update(ctx, fn) }}}
 }
 
@@ -121,5 +124,6 @@ type StateAppSlice[T any] struct{ StateApp[[]T] }
 
 // Op returns a slice chain bound to ctx.
 func (a *StateAppSlice[T]) Op(ctx *Ctx) *SliceOps[T] {
+	mustOpCtx(ctx)
 	return &SliceOps[T]{ops: ops[[]T]{update: func(fn func([]T) ([]T, error)) error { return a.Update(ctx, fn) }}}
 }

--- a/shape_str.go
+++ b/shape_str.go
@@ -25,6 +25,7 @@ type SignalStr struct{ Signal[string] }
 
 // Op returns a string chain bound to ctx.
 func (s *SignalStr) Op(ctx *Ctx) *StrOps {
+	mustOpCtx(ctx)
 	return &StrOps{ops: ops[string]{update: func(fn func(string) (string, error)) error { return s.Update(ctx, fn) }}}
 }
 
@@ -33,6 +34,7 @@ type StateTabStr struct{ StateTab[string] }
 
 // Op returns a string chain bound to ctx.
 func (s *StateTabStr) Op(ctx *Ctx) *StrOps {
+	mustOpCtx(ctx)
 	return &StrOps{ops: ops[string]{update: func(fn func(string) (string, error)) error { return s.Update(ctx, fn) }}}
 }
 
@@ -41,6 +43,7 @@ type StateSessStr struct{ StateSess[string] }
 
 // Op returns a string chain bound to ctx.
 func (s *StateSessStr) Op(ctx *Ctx) *StrOps {
+	mustOpCtx(ctx)
 	return &StrOps{ops: ops[string]{update: func(fn func(string) (string, error)) error { return s.Update(ctx, fn) }}}
 }
 
@@ -49,5 +52,6 @@ type StateAppStr struct{ StateApp[string] }
 
 // Op returns a string chain bound to ctx.
 func (a *StateAppStr) Op(ctx *Ctx) *StrOps {
+	mustOpCtx(ctx)
 	return &StrOps{ops: ops[string]{update: func(fn func(string) (string, error)) error { return a.Update(ctx, fn) }}}
 }

--- a/signal.go
+++ b/signal.go
@@ -42,8 +42,12 @@ func (s *Signal[T]) Read(_ readCtx) T {
 // the dirty bit alone won't reach the browser without a flush.
 //
 // Sugar over Update(ctx, func(T) (T, error) { return v, nil }) — the
-// non-fallible path for "replace with a constant."
+// non-fallible path for "replace with a constant." Panics on nil ctx
+// for the same reason as Update.
 func (s *Signal[T]) Write(ctx *Ctx, v T) {
+	if ctx == nil {
+		panic("via: Signal.Write called with nil *Ctx")
+	}
 	_ = s.Update(ctx, func(T) (T, error) { return v, nil })
 }
 
@@ -52,7 +56,15 @@ func (s *Signal[T]) Write(ctx *Ctx, v T) {
 // unchanged and the error is returned. Saves a Read/Write pair on
 // transform-the-current-value patterns and is the only mutation path
 // that lets a user reject a write (validation, conflict detection).
+//
+// Panics on nil ctx: without one, the write cannot reach the browser, so
+// silently succeeding would desync server state from the client. From a
+// raw goroutine, pass the bound *Ctx and call ctx.SyncNow() at a flush
+// boundary.
 func (s *Signal[T]) Update(ctx *Ctx, fn func(T) (T, error)) error {
+	if ctx == nil {
+		panic("via: Signal.Update called with nil *Ctx")
+	}
 	if fn == nil {
 		return nil
 	}
@@ -61,9 +73,7 @@ func (s *Signal[T]) Update(ctx *Ctx, fn func(T) (T, error)) error {
 		return err
 	}
 	s.val = next
-	if ctx != nil {
-		ctx.markSignalDirty(s.slot)
-	}
+	ctx.markSignalDirty(s.slot)
 	return nil
 }
 

--- a/signal_test.go
+++ b/signal_test.go
@@ -406,3 +406,21 @@ func TestUpdate_unchangedValueProducesNoFrame(t *testing.T) {
 		// No frame at all is the success path.
 	}
 }
+
+func TestSignal_panicsOnNilCtxUpdate(t *testing.T) {
+	t.Parallel()
+	var s via.SignalNum[int]
+	assert.PanicsWithValue(t,
+		"via: Signal.Update called with nil *Ctx",
+		func() { _ = s.Update(nil, func(int) (int, error) { return 1, nil }) },
+	)
+}
+
+func TestSignal_panicsOnNilCtxWrite(t *testing.T) {
+	t.Parallel()
+	var s via.SignalNum[int]
+	assert.PanicsWithValue(t,
+		"via: Signal.Write called with nil *Ctx",
+		func() { s.Write(nil, 1) },
+	)
+}

--- a/state.go
+++ b/state.go
@@ -44,8 +44,12 @@ func (s *StateTab[T]) Read(_ readCtx) T {
 // flush.
 //
 // Sugar over Update(ctx, func(T) (T, error) { return v, nil }) — the
-// non-fallible path for "replace with a constant."
+// non-fallible path for "replace with a constant." Panics on nil ctx
+// for the same reason as Update.
 func (s *StateTab[T]) Write(ctx *Ctx, v T) {
+	if ctx == nil {
+		panic("via: StateTab.Write called with nil *Ctx")
+	}
 	_ = s.Update(ctx, func(T) (T, error) { return v, nil })
 }
 
@@ -59,7 +63,13 @@ func (s *StateTab[T]) Write(ctx *Ctx, v T) {
 //	    if n >= max { return 0, errBudget }
 //	    return n + 1, nil
 //	})
+//
+// Panics on nil ctx: without one the next flush cannot re-render, so
+// silently succeeding would desync server state from the client.
 func (s *StateTab[T]) Update(ctx *Ctx, fn func(T) (T, error)) error {
+	if ctx == nil {
+		panic("via: StateTab.Update called with nil *Ctx")
+	}
 	if fn == nil {
 		return nil
 	}
@@ -68,9 +78,7 @@ func (s *StateTab[T]) Update(ctx *Ctx, fn func(T) (T, error)) error {
 		return err
 	}
 	s.val = next
-	if ctx != nil {
-		ctx.markStateDirty()
-	}
+	ctx.markStateDirty()
 	return nil
 }
 

--- a/state_test.go
+++ b/state_test.go
@@ -166,3 +166,21 @@ func TestUpdate_appliesFnToSignal(t *testing.T) {
 // Tag-driven key resolution for State is exercised end-to-end by the
 // init-tag tests above, where mis-resolving the key would render the
 // wrong seeded value.
+
+func TestStateTab_panicsOnNilCtxUpdate(t *testing.T) {
+	t.Parallel()
+	var s via.StateTabNum[int]
+	assert.PanicsWithValue(t,
+		"via: StateTab.Update called with nil *Ctx",
+		func() { _ = s.Update(nil, func(int) (int, error) { return 1, nil }) },
+	)
+}
+
+func TestStateTab_panicsOnNilCtxWrite(t *testing.T) {
+	t.Parallel()
+	var s via.StateTabNum[int]
+	assert.PanicsWithValue(t,
+		"via: StateTab.Write called with nil *Ctx",
+		func() { s.Write(nil, 1) },
+	)
+}

--- a/stateapp.go
+++ b/stateapp.go
@@ -53,8 +53,14 @@ func (a *StateApp[T]) Read(rc readCtx) T {
 // almost always a read-modify-write race in disguise — model the
 // assignment as an Update whose fn ignores the old value if you truly
 // mean it.
+//
+// Panics on nil ctx: without one no broadcast can fan out, so silently
+// succeeding would desync server state from every live tab.
 func (a *StateApp[T]) Update(ctx *Ctx, fn func(T) (T, error)) error {
-	if fn == nil || ctx == nil || ctx.app == nil {
+	if ctx == nil {
+		panic("via: StateApp.Update called with nil *Ctx")
+	}
+	if fn == nil || ctx.app == nil {
 		return nil
 	}
 	_, err := ctx.app.appStore.Update(a.wireKey, func(old any) (any, error) {

--- a/stateapp_test.go
+++ b/stateapp_test.go
@@ -140,3 +140,12 @@ func TestApp_concurrentUpdatesDoNotLoseIncrements(t *testing.T) {
 	assert.Contains(t, final.HTML(), `<span id="visits">200</span>`,
 		"concurrent Update calls across sessions must converge to the exact final count")
 }
+
+func TestStateApp_panicsOnNilCtxUpdate(t *testing.T) {
+	t.Parallel()
+	var a via.StateAppNum[int]
+	assert.PanicsWithValue(t,
+		"via: StateApp.Update called with nil *Ctx",
+		func() { _ = a.Update(nil, func(int) (int, error) { return 1, nil }) },
+	)
+}

--- a/statesess.go
+++ b/statesess.go
@@ -54,8 +54,14 @@ func (s *StateSess[T]) Read(rc readCtx) T {
 // almost always a read-modify-write race in disguise — model the
 // assignment as an Update whose fn ignores the old value if you truly
 // mean it.
+//
+// Panics on nil ctx: without one no broadcast can fan out, so silently
+// succeeding would desync server state from every live tab.
 func (s *StateSess[T]) Update(ctx *Ctx, fn func(T) (T, error)) error {
-	if fn == nil || ctx == nil || ctx.session == nil || ctx.app == nil {
+	if ctx == nil {
+		panic("via: StateSess.Update called with nil *Ctx")
+	}
+	if fn == nil || ctx.session == nil || ctx.app == nil {
 		return nil
 	}
 	_, err := ctx.session.data.Update(s.wireKey, func(old any) (any, error) {

--- a/statesess_test.go
+++ b/statesess_test.go
@@ -212,3 +212,12 @@ func TestUpdate_StateSess_writesThroughOnFirstAndDistinctValues(t *testing.T) {
 	require.Equal(t, 200, tc.Action("Diff").Fire())
 	vt.AwaitFrame(t, frames, 2*time.Second, "red")
 }
+
+func TestStateSess_panicsOnNilCtxUpdate(t *testing.T) {
+	t.Parallel()
+	var s via.StateSessNum[int]
+	assert.PanicsWithValue(t,
+		"via: StateSess.Update called with nil *Ctx",
+		func() { _ = s.Update(nil, func(int) (int, error) { return 1, nil }) },
+	)
+}


### PR DESCRIPTION
## Summary

Closes #32. Signal/State mutation paths used to silently swallow a nil `*Ctx` — the value mutated server-side but never reached the browser, indistinguishable from success at the call site. Per `CONVENTIONS.md` "panic on programming mistakes," they now panic loudly.

- `Signal.Update`, `StateTab.Update`, `StateSess.Update`, `StateApp.Update` panic on nil ctx instead of skipping the dirty mark / broadcast.
- `Signal.Write` and `StateTab.Write` panic with their own names rather than delegating into Update's panic message (which would have read "Update" for a Write call).
- All 20 `Op(ctx)` constructors panic eagerly on nil ctx via a shared `mustOpCtx` helper. Without this, `s.Op(nil).Verb()` deferred the panic into the closure, producing a stack rooted at Update and a misattributed message; it also let `SliceOps.Filter(nil)` short-circuit before the panic could fire.
- Godoc paragraphs added on every public mutation entry point.

## Test plan

- [x] `go test -race ./...` — full suite clean
- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] TDD: 14 new panic asserts (6 direct Update/Write + 8 Op subtests) RED before fix, GREEN after
- [ ] Manual: confirm an action that does `s.Update(nil, fn)` produces an "action panicked" log entry server-side (panic is recovered by the action dispatcher and surfaced as a generic toast — fail-loud in the log, fail-soft to the user)