### PR TITLE
fix(vt): isolate http.Transport per Client to stop parallel-test flakes

### DIFF
--- a/vt/vt.go
+++ b/vt/vt.go
@@ -47,7 +47,7 @@ type Client struct {
 func NewClient(t testing.TB, server *httptest.Server, path string) *Client {
 	t.Helper()
 	jar, _ := cookiejar.New(nil)
-	httpc := &http.Client{Jar: jar, Timeout: 5 * time.Second}
+	httpc := &http.Client{Jar: jar, Timeout: 5 * time.Second, Transport: &http.Transport{}}
 	resp, err := httpc.Get(server.URL + path)
 	if err != nil {
 		t.Fatalf("vt.NewClient: GET %s: %v", path, err)
@@ -69,7 +69,7 @@ func (c *Client) TabID() string { return c.tabID }
 // StateSess behavior that spans tabs.
 func (c *Client) Fork(path string) *Client {
 	c.t.Helper()
-	httpc := &http.Client{Jar: c.jar, Timeout: 5 * time.Second}
+	httpc := &http.Client{Jar: c.jar, Timeout: 5 * time.Second, Transport: &http.Transport{}}
 	resp, err := httpc.Get(c.server.URL + path)
 	if err != nil {
 		c.t.Fatalf("vt.Client.Fork: GET %s: %v", path, err)
@@ -297,7 +297,7 @@ func (c *Client) SSE() (frames <-chan string, cancel func()) {
 	ctx, cancelF := context.WithCancel(context.Background())
 	url := c.server.URL + "/_sse?datastar=" + sseQueryParam(c.tabID)
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	sseClient := &http.Client{Jar: c.jar} // no timeout — SSE is long-lived
+	sseClient := &http.Client{Jar: c.jar, Transport: &http.Transport{}} // no timeout — SSE is long-lived
 	resp, err := sseClient.Do(req)
 	if err != nil {
 		cancelF()

--- a/vt/vt_isolation_test.go
+++ b/vt/vt_isolation_test.go
@@ -1,0 +1,84 @@
+package vt_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/go-via/via"
+	"github.com/go-via/via/vt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingRoundTripper struct {
+	inner http.RoundTripper
+	hits  *atomic.Int32
+}
+
+func (r recordingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.hits.Add(1)
+	return r.inner.RoundTrip(req)
+}
+
+// swapDefaultTransport replaces http.DefaultTransport with a recording
+// wrapper so a test can prove a constructed http.Client doesn't fall back
+// to the package-global pool. Restored via t.Cleanup; the test must not
+// call t.Parallel because the mutation is process-global.
+func swapDefaultTransport(t *testing.T) *atomic.Int32 {
+	t.Helper()
+	orig := http.DefaultTransport
+	var hits atomic.Int32
+	http.DefaultTransport = recordingRoundTripper{inner: orig, hits: &hits}
+	t.Cleanup(func() { http.DefaultTransport = orig })
+	return &hits
+}
+
+func TestNewClient_usesIsolatedHTTPTransport(t *testing.T) {
+	hits := swapDefaultTransport(t)
+
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	via.Mount[tcPage](app, "/")
+	defer server.Close()
+
+	tc := vt.NewClient(t, server, "/")
+	require.Equal(t, 200, tc.Action("Bump").Fire())
+
+	assert.Zero(t, hits.Load(),
+		"NewClient's http.Client must have its own Transport so parallel "+
+			"tests' server.Close() can't disturb each other's idle pools")
+}
+
+func TestClient_Fork_usesIsolatedHTTPTransport(t *testing.T) {
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	via.Mount[tcPage](app, "/")
+	defer server.Close()
+
+	tc := vt.NewClient(t, server, "/")
+	hits := swapDefaultTransport(t)
+
+	forked := tc.Fork("/")
+	require.Equal(t, 200, forked.Action("Bump").Fire())
+
+	assert.Zero(t, hits.Load(),
+		"Fork's http.Client must use its own Transport, not http.DefaultTransport")
+}
+
+func TestClient_SSE_usesIsolatedHTTPTransport(t *testing.T) {
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	via.Mount[tcPage](app, "/")
+	defer server.Close()
+
+	tc := vt.NewClient(t, server, "/")
+	hits := swapDefaultTransport(t)
+
+	_, cancel := tc.SSEReady()
+	defer cancel()
+
+	assert.Zero(t, hits.Load(),
+		"SSE's http.Client must use its own Transport, not http.DefaultTransport")
+}


### PR DESCRIPTION
## Summary

- Closes #40 — flaky `TestUpdate_flipsBoolSignalSurfacingInSSE` from shared `http.DefaultTransport` idle pool across parallel tests.
- `vt.NewClient`, `vt.Client.Fork`, and `vt.Client.SSE` now each construct their `http.Client` with `Transport: &http.Transport{}` so connection pools are isolated.
- Adds `vt/vt_isolation_test.go` — three tests swap `http.DefaultTransport` with a recording wrapper and assert each constructor never routes through it.

## Test plan

- [x] `go test -race -count=1 ./...` clean
- [x] `./ci-check.sh` clean: gofmt, vet, golangci-lint, govulncheck, build (incl. 11 examples), tests, alloc gates
- [x] Red phase verified: new tests deterministically fail before fix (2/2/1 hits on the recording wrapper), pass after