### PR TITLE
ci: avoid duplicate runs on push+PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,8 @@ name: CI
 on:
   push:
     branches:
-      - '**'
+      - main
   pull_request:
-    branches:
-      - '**'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Restrict the CI workflow's `push` trigger to `main`. Same-repo PR branches were running CI twice (once via `push`, once via `pull_request`).
- `pull_request` still fires on every branch.

## Test plan
- [ ] Open this PR — CI should run once (pull_request only).
- [ ] After merge, push to main runs CI.