### PR TITLE
fix: panic at Mount on unknown via-tag options (#35)

### DIFF
--- a/composition_test.go
+++ b/composition_test.go
@@ -205,3 +205,27 @@ func TestMount_panicsWithTypeNameWhenCisAnInterface(t *testing.T) {
 	}()
 	via.Mount[via.Composition](app, "/")
 }
+
+type typoOptionPage struct {
+	Step via.SignalNum[int] `via:"step,initi=5"`
+}
+
+func (p *typoOptionPage) View(ctx *via.CtxR) h.H { return h.Div() }
+
+func TestMount_panicsOnUnknownViaTagOption(t *testing.T) {
+	t.Parallel()
+
+	app := via.New()
+	defer func() {
+		rec := recover()
+		require.NotNil(t, rec, "Mount with typo'd via-tag option must panic")
+		msg, _ := rec.(string)
+		assert.Contains(t, msg, "initi=5",
+			"panic must echo the offending segment so the user can find the typo")
+		assert.Contains(t, msg, "Step",
+			"panic must name the offending field")
+		assert.Contains(t, msg, "typoOptionPage",
+			"panic must name the composition type")
+	}()
+	via.Mount[typoOptionPage](app, "/typo")
+}

--- a/walker.go
+++ b/walker.go
@@ -1,6 +1,7 @@
 package via
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 )
@@ -36,7 +37,11 @@ func walkStruct(d *cmpDescriptor, typ reflect.Type, indexPath []int, pathPrefix 
 		fieldPath := make([]int, len(indexPath)+1)
 		copy(fieldPath, indexPath)
 		fieldPath[len(indexPath)] = i
-		switch role := classifyField(f); role {
+		role := classifyField(f)
+		if role != roleNone {
+			validateViaTagOptions(typ, f)
+		}
+		switch role {
 		case roleSignal, roleState:
 			kind := kindSignal
 			if role == roleState {
@@ -190,6 +195,30 @@ func parseLocalID(f reflect.StructField) string {
 		}
 	}
 	return lowerFirst(f.Name)
+}
+
+func validateViaTagOptions(owner reflect.Type, f reflect.StructField) {
+	tag := f.Tag.Get("via")
+	if tag == "" {
+		return
+	}
+	first := true
+	for part := range strings.SplitSeq(tag, ",") {
+		if first {
+			first = false
+			continue
+		}
+		if part == "" {
+			continue
+		}
+		if strings.HasPrefix(part, "init=") {
+			continue
+		}
+		panic(fmt.Sprintf(
+			"via: %s.%s has unknown via-tag option %q (only `init=…` is recognised)",
+			owner.Name(), f.Name, part,
+		))
+	}
 }
 
 func parseInitTag(f reflect.StructField) string {


### PR DESCRIPTION
Closes #35.

## Summary
- A typo'd option key in a `via:"…"` struct tag (e.g. `via:"step,initi=5"`) was silently dropped, leaving the field at its zero value at runtime.
- Mount now panics at registration time, naming the composition type, the offending field, and the unrecognised segment.
- Only `init=…` is accepted after the wire-name segment.

## Test plan
- [x] `go test -race ./...`
- [x] New `TestMount_panicsOnUnknownViaTagOption` asserts the panic surfaces type, field, and bad segment.