### PR TITLE
fix(ctx): drop unsafe URLs in Redirect

### DIFF
--- a/ctx_test.go
+++ b/ctx_test.go
@@ -324,6 +324,22 @@ func (p *ctxScriptPage) DoRedirect(ctx *via.Ctx) error {
 	return nil
 }
 
+type redirectPage struct {
+	URL via.SignalStr `via:"url"`
+}
+
+func (p *redirectPage) Go(ctx *via.Ctx) error {
+	ctx.Redirect(p.URL.Read(ctx))
+	return nil
+}
+
+func (p *redirectPage) Ack(ctx *via.Ctx) error {
+	ctx.Toast("ack")
+	return nil
+}
+
+func (p *redirectPage) View(ctx *via.CtxR) h.H { return h.Div() }
+
 func (p *ctxScriptPage) View(ctx *via.CtxR) h.H { return h.Div() }
 
 func TestCtx_Reload_emitsLocationReloadScript(t *testing.T) {
@@ -392,6 +408,80 @@ func TestCtx_Redirect_emitsRedirectFrame(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, tc.Action("DoRedirect").Fire())
 	vt.AwaitFrame(t, frames, 2*time.Second, "/elsewhere")
+}
+
+func TestCtx_Redirect_allowsSafeURLs(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{"absolute path", "/elsewhere"},
+		{"relative path", "relative/path"},
+		{"http", "http://example.com/x"},
+		{"https", "https://example.com/x"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var server *httptest.Server
+			app := via.New(via.WithTestServer(&server))
+			via.Mount[redirectPage](app, "/")
+			defer server.Close()
+
+			tc := vt.NewClient(t, server, "/")
+			frames, cancel := tc.SSEReady()
+			defer cancel()
+
+			require.Equal(t, http.StatusOK,
+				tc.Action("Go").WithSignal("url", tt.url).Fire())
+			vt.AwaitFrame(t, frames, 2*time.Second,
+				"window.location.href", tt.url)
+		})
+	}
+}
+
+func TestCtx_Redirect_dropsDangerousURLs(t *testing.T) {
+	t.Parallel()
+	// Open-redirect / XSS vectors must not reach the client. The Redirect
+	// patch is dropped; a subsequent observable patch (Toast) confirms the
+	// SSE stream is still alive and that the dangerous URL never appears
+	// in any frame that did arrive.
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{"javascript scheme", "javascript:alert(1)"},
+		{"protocol relative", "//evil.example/path"},
+		{"data scheme", "data:text/html,<script>alert(1)</script>"},
+		{"vbscript scheme", "vbscript:msgbox"},
+		{"uppercase javascript", "JavaScript:alert(1)"},
+		{"whitespace javascript", " javascript:alert(1)"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var server *httptest.Server
+			app := via.New(via.WithTestServer(&server))
+			via.Mount[redirectPage](app, "/")
+			defer server.Close()
+
+			tc := vt.NewClient(t, server, "/")
+			frames, cancel := tc.SSEReady()
+			defer cancel()
+
+			require.Equal(t, http.StatusOK,
+				tc.Action("Go").WithSignal("url", tt.url).Fire())
+			require.Equal(t, http.StatusOK, tc.Action("Ack").Fire())
+			body := vt.AwaitFrame(t, frames, 2*time.Second, `alert("ack")`)
+			assert.NotContains(t, body, "window.location.href",
+				"dangerous URL must not produce a redirect frame")
+			assert.NotContains(t, body, tt.url,
+				"dangerous URL must not appear in any SSE frame")
+		})
+	}
 }
 
 // SyncOff — action-scoped publish suppression.

--- a/push.go
+++ b/push.go
@@ -3,6 +3,7 @@ package via
 import (
 	"encoding/json"
 	"maps"
+	"strings"
 
 	"github.com/go-via/via/h"
 )
@@ -141,8 +142,20 @@ func (ctx *Ctx) Toast(message string) {
 }
 
 // Redirect sends a client-side navigation to url at the next flush.
+//
+// Only http, https, and same-origin relative paths are honoured. URLs
+// carrying any other scheme (javascript:, data:, vbscript:, …) or a
+// protocol-relative // prefix are dropped and logged — this closes the
+// open-redirect / XSS vector when callers interpolate user input into
+// the URL (typical ?next= flows).
 func (ctx *Ctx) Redirect(url string) {
 	if ctx == nil || url == "" || ctx.queue == nil {
+		return
+	}
+	if !safeRedirectURL(url) {
+		if ctx.app != nil {
+			ctx.app.logErr(ctx, "Redirect: rejected unsafe URL %q", url)
+		}
 		return
 	}
 	q := ctx.queue
@@ -150,4 +163,24 @@ func (ctx *Ctx) Redirect(url string) {
 	q.redirect = url
 	q.mu.Unlock()
 	q.notify()
+}
+
+// safeRedirectURL reports whether url is safe for client-side navigation:
+// an http/https absolute URL or a same-origin relative path. Browsers
+// strip leading whitespace and control characters before resolving the
+// scheme, so " javascript:..." must be treated identically to the
+// untrimmed form.
+func safeRedirectURL(url string) bool {
+	trimmed := strings.TrimLeftFunc(url, func(r rune) bool { return r <= ' ' })
+	if trimmed == "" {
+		return false
+	}
+	if strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, `\\`) {
+		return false
+	}
+	if i := strings.IndexAny(trimmed, ":/?#"); i >= 0 && trimmed[i] == ':' {
+		scheme := strings.ToLower(trimmed[:i])
+		return scheme == "http" || scheme == "https"
+	}
+	return true
 }


### PR DESCRIPTION
## Summary
- `Ctx.Redirect` now validates the URL before queueing a navigation frame: only `http`, `https`, and same-origin relative paths are honoured. `javascript:`, `data:`, `vbscript:`, protocol-relative `//…`, `\\…`, and whitespace/case variants are dropped and logged via `app.logErr`.
- Leading bytes `<= ' '` are trimmed before the scheme check to match how browsers parse schemes (` javascript:…` collapses to `javascript:…`).
- Table tests cover the safe + dangerous matrix and assert that a follow-up Toast frame still reaches the client, proving the SSE stream is unaffected.

## Test plan
- [x] `go test ./...`
- [x] End-to-end verify against a live server (`/tmp/via-verify` app + curl + Brave): dangerous URLs produced no `window.location.href` frame and no browser navigation/alert; safe URLs emitted the expected redirect frame; server log shows `Redirect: rejected unsafe URL "…"` for every dropped case.