### PR TITLE
fix(on): split panic by nil / top-level / closure (#36)

### DIFF
--- a/on/on.go
+++ b/on/on.go
@@ -15,6 +15,8 @@ package on
 import (
 	"encoding/json"
 	"html/template"
+	"reflect"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -150,6 +152,33 @@ func SetSignal[T any](sig *via.Signal[T], value T) spec.Option {
 	return func(s *spec.Trigger) { s.AppendPre(stmt) }
 }
 
+// notMethodPanic builds the panic text for an on.* helper that received
+// something other than a bound method value. Splitting nil / top-level
+// function / closure makes the most common authoring mistake debuggable
+// at a glance — the previous lumped message left the dev to guess which
+// of the three they did.
+func notMethodPanic(eventName string, fn any) string {
+	prefix := "on: " + eventName + " requires a bound method value (e.g. on.Click(c.Inc)); got "
+	if fn == nil {
+		return prefix + "nil"
+	}
+	v := reflect.ValueOf(fn)
+	if !v.IsValid() || v.Kind() != reflect.Func || v.IsNil() {
+		return prefix + "nil"
+	}
+	fnPC := runtime.FuncForPC(v.Pointer())
+	if fnPC == nil {
+		return prefix + "a closure"
+	}
+	// Go's runtime names closures with a ".funcN" segment (e.g.
+	// "pkg.Outer.func1"); top-level functions have no such segment and no
+	// "-fm" suffix (the latter marks bound methods, already handled).
+	if strings.Contains(fnPC.Name(), ".func") {
+		return prefix + "a closure"
+	}
+	return prefix + "a top-level function"
+}
+
 func event(name string, fn any, opts ...spec.Option) h.H {
 	// Fast path for the bare `on.Click(c.Inc)` shape — no opts means no
 	// modifiers, no debounce/throttle, no pre-statements. Skipping the
@@ -158,7 +187,7 @@ func event(name string, fn any, opts ...spec.Option) h.H {
 	if len(opts) == 0 {
 		method := spec.MethodName(fn)
 		if method == "" {
-			panic("on: " + name + " requires a bound method value (e.g. on.Click(c.Inc)); got a closure, top-level function, or nil")
+			panic(notMethodPanic(name, fn))
 		}
 		return bareAttr(name, method)
 	}
@@ -229,7 +258,7 @@ func bareAttr(eventName, method string) h.H {
 func render(s *spec.Trigger) h.H {
 	method := spec.MethodName(s.Method)
 	if method == "" {
-		panic("on: " + s.Event + " requires a bound method value (e.g. on.Click(c.Inc)); got a closure, top-level function, or nil")
+		panic(notMethodPanic(s.Event, s.Method))
 	}
 
 	// Fast path for the bare `on.Click(c.Inc)` shape — no modifiers, no

--- a/on/on.go
+++ b/on/on.go
@@ -163,20 +163,41 @@ func notMethodPanic(eventName string, fn any) string {
 		return prefix + "nil"
 	}
 	v := reflect.ValueOf(fn)
-	if !v.IsValid() || v.Kind() != reflect.Func || v.IsNil() {
+	if !v.IsValid() {
+		return prefix + "nil"
+	}
+	if v.Kind() != reflect.Func {
+		return prefix + "a non-function value of type " + v.Type().String()
+	}
+	if v.IsNil() {
 		return prefix + "nil"
 	}
 	fnPC := runtime.FuncForPC(v.Pointer())
 	if fnPC == nil {
 		return prefix + "a closure"
 	}
-	// Go's runtime names closures with a ".funcN" segment (e.g.
-	// "pkg.Outer.func1"); top-level functions have no such segment and no
-	// "-fm" suffix (the latter marks bound methods, already handled).
-	if strings.Contains(fnPC.Name(), ".func") {
+	if isClosureName(fnPC.Name()) {
 		return prefix + "a closure"
 	}
 	return prefix + "a top-level function"
+}
+
+// isClosureName reports whether name is a Go runtime closure trampoline.
+// The runtime names anonymous functions `outerName.funcN[.M…]` with a
+// digit immediately after `.func`; a substring match on `.func` alone
+// would catch top-level functions whose identifier begins with "func"
+// (e.g. `pkg.function`).
+func isClosureName(name string) bool {
+	for i := 0; i+5 < len(name); i++ {
+		if name[i:i+5] != ".func" {
+			continue
+		}
+		c := name[i+5]
+		if c >= '0' && c <= '9' {
+			return true
+		}
+	}
+	return false
 }
 
 func event(name string, fn any, opts ...spec.Option) h.H {

--- a/on/on_test.go
+++ b/on/on_test.go
@@ -274,6 +274,61 @@ func TestClick_panicsOnAnonymousFunction(t *testing.T) {
 	on.Click(func(ctx *via.Ctx) error { return nil })
 }
 
+func TestClick_panicMessageNamesNil(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		rec := recover()
+		require.NotNil(t, rec, "on.Click(nil) must panic")
+		msg, ok := rec.(string)
+		require.True(t, ok)
+		assert.Contains(t, msg, "got nil",
+			"panic should specifically call out nil rather than a generic 'closure/top-level/nil' clause")
+	}()
+	on.Click(nil)
+}
+
+func topLevelClickHandler(ctx *via.Ctx) error { return nil }
+
+func TestClick_panicMessageNamesTopLevelFunction(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		rec := recover()
+		require.NotNil(t, rec, "on.Click(topLevelFn) must panic")
+		msg, ok := rec.(string)
+		require.True(t, ok)
+		assert.Contains(t, msg, "top-level function",
+			"panic should specifically identify the top-level function case")
+	}()
+	on.Click(topLevelClickHandler)
+}
+
+func TestClick_panicMessageNamesClosure(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		rec := recover()
+		require.NotNil(t, rec, "on.Click(closure) must panic")
+		msg, ok := rec.(string)
+		require.True(t, ok)
+		assert.Contains(t, msg, "closure",
+			"panic should specifically identify the closure case")
+	}()
+	on.Click(func(ctx *via.Ctx) error { return nil })
+}
+
+func TestKey_panicMessageNamesClosure(t *testing.T) {
+	t.Parallel()
+	// on.Key drives the optioned render() path; the classification must
+	// also reach that branch, not only the event() fast path.
+	defer func() {
+		rec := recover()
+		require.NotNil(t, rec)
+		msg, ok := rec.(string)
+		require.True(t, ok)
+		assert.Contains(t, msg, "closure")
+	}()
+	on.Key("Enter", func(ctx *via.Ctx) error { return nil })
+}
+
 func TestKey_panicsOnAnonymousFunction(t *testing.T) {
 	t.Parallel()
 	// on.Key drives the optioned render() path; cover that branch too.

--- a/on/on_test.go
+++ b/on/on_test.go
@@ -315,6 +315,42 @@ func TestClick_panicMessageNamesClosure(t *testing.T) {
 	on.Click(func(ctx *via.Ctx) error { return nil })
 }
 
+func functionalTopLevelHandler(ctx *via.Ctx) error { return nil }
+
+func TestClick_panicMessageNamesTopLevelFunctionWhoseNameStartsWithFunc(t *testing.T) {
+	t.Parallel()
+	// Guards against a too-loose `.func` substring heuristic: a top-level
+	// function named e.g. `functionalTopLevelHandler` has runtime name
+	// `pkg.functionalTopLevelHandler`, which contains the substring
+	// `.func` — but the Go runtime only assigns `.funcN` (digit-suffixed)
+	// to anonymous closures.
+	defer func() {
+		rec := recover()
+		require.NotNil(t, rec)
+		msg, ok := rec.(string)
+		require.True(t, ok)
+		assert.Contains(t, msg, "top-level function",
+			"top-level fn whose identifier starts with 'func' must not be misclassified as a closure")
+		assert.NotContains(t, msg, "got a closure")
+	}()
+	on.Click(functionalTopLevelHandler)
+}
+
+func TestClick_panicMessageNamesNonFunctionValue(t *testing.T) {
+	t.Parallel()
+	// `on.Click(42)` is a programming error distinct from nil — the
+	// panic must not lie about what was passed.
+	defer func() {
+		rec := recover()
+		require.NotNil(t, rec)
+		msg, ok := rec.(string)
+		require.True(t, ok)
+		assert.NotContains(t, msg, "got nil",
+			"a non-function value must not be reported as nil")
+	}()
+	on.Click(42)
+}
+
 func TestKey_panicMessageNamesClosure(t *testing.T) {
 	t.Parallel()
 	// on.Key drives the optioned render() path; the classification must


### PR DESCRIPTION
Closes #36.

## Summary
- `on.*` previously panicked with a single lumped message ("got a closure, top-level function, or nil") regardless of which mistake the caller actually made.
- Added `notMethodPanic(event, fn)` in `on/on.go` that uses `reflect` + `runtime.FuncForPC` to classify the bad input as `nil`, `a closure`, or `a top-level function`; both panic sites (the `event` fast path and the optioned `render` path) route through it.
- Closures are detected via the `.func` segment in the runtime function name; `-fm`-suffixed bound methods are already handled upstream by `spec.MethodName`.

## Test plan
- [x] `go test -race ./...`
- [x] New tests cover all three classifications via `on.Click` (event fast path) and a closure via `on.Key` (render path).