### PR TITLE
fix: prefer assert.Contains for response bodies (#37)

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -123,7 +123,7 @@ func TestApp_Handle_routesCustomPath(t *testing.T) {
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "custom-handle", string(body))
+	assert.Contains(t, string(body), "custom-handle")
 }
 
 func TestApp_ServeHTTP_dispatchesThroughHandler(t *testing.T) {

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -224,7 +224,7 @@ func TestRecover_panicAfterPartialWriteKeepsServerAlive(t *testing.T) {
 	resp2.Body.Close()
 	assert.Equal(t, http.StatusOK, resp2.StatusCode,
 		"server should survive panic after partial write")
-	assert.Equal(t, "alive", body2)
+	assert.Contains(t, body2, "alive")
 }
 
 type ridProbePage struct{}

--- a/server_test.go
+++ b/server_test.go
@@ -217,7 +217,7 @@ func TestHandleStatic_servesFromFS(t *testing.T) {
 	require.NoError(t, err)
 	defer resp2.Body.Close()
 	body2, _ := io.ReadAll(resp2.Body)
-	assert.Equal(t, "hello", strings.TrimSpace(string(body2)),
+	assert.Contains(t, string(body2), "hello",
 		"nested files should serve under the same prefix")
 }
 


### PR DESCRIPTION
Closes #37 

This PR aligns a few tests with CONVENTIONS.md by avoiding brittle full-body
`assert.Equal` checks when substring presence is the contract.

Changes:
- Use `assert.Contains` for response body assertions in `app_test.go`,
  `middleware_test.go`, and `server_test.go`.

> [!NOTE]
>- `file_test.go` was intentionally left unchanged because it verifies a binary
>  upload is persisted exactly (byte-for-byte). Using `Contains` there would
>  weaken the test and could miss truncation/corruption.

