### PR TITLE
fix(render): recover View panics in initial render and re-render (#48)

### DIFF
--- a/render.go
+++ b/render.go
@@ -59,11 +59,31 @@ func (a *App) renderPage(d *cmpDescriptor, w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	ctx.beginRender()
-	body := ctx.viewFn(ctx.readView())
-	ctx.endRender()
+	body, ok := a.renderView(ctx, w)
+	if !ok {
+		return
+	}
 	a.writePageDocument(w, ctx, body)
 	a.metricsOrNoop().Counter("via.render.total", "route", d.route)
+}
+
+// renderView runs the page's view inside the render window, recovering a
+// panicking viewFn so it surfaces as a structured via log line plus a
+// controlled 500 rather than escaping to the embedding http.Server (naked
+// stderr stack, dropped connection). Symmetric with the OnInit / OnConnect
+// / OnDispose guards and action recovery. ok is false when the view
+// panicked, in which case the 500 has already been written and the caller
+// must not write a page document.
+func (a *App) renderView(ctx *Ctx, w http.ResponseWriter) (body h.H, ok bool) {
+	ctx.beginRender()
+	defer ctx.endRender()
+	defer func() {
+		if rec := recover(); rec != nil {
+			a.logErr(ctx, "View panicked: %v", rec)
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+		}
+	}()
+	return ctx.viewFn(ctx.readView()), true
 }
 
 func (a *App) writePageDocument(w http.ResponseWriter, ctx *Ctx, body h.H) {
@@ -161,23 +181,22 @@ func flushDirty(ctx *Ctx) {
 	ctx.queue.mu.Unlock()
 
 	if needRender {
-		buf := getRenderBuf()
-		// View runs without queue.mu held — user code is allowed to
-		// call ctx.Patch.Signal / ctx.Patch.Elements, which would deadlock
-		// on a re-entrant queue.mu acquisition.
-		ctx.beginRender()
-		body := ctx.viewFn(ctx.readView())
-		ctx.endRender()
-		_ = h.Div(h.ID(ctx.id), body).Render(buf)
+		// A panicking viewFn must not escape: this runs on the action
+		// autoflush defer (would drop the action connection) and on the
+		// broadcast SyncNow goroutine (would crash the process — no defer
+		// stack to fall back on). renderFragment recovers and logs; a
+		// panic yields "", which prepends as a no-op and is dropped by the
+		// drain's elems != "" guard, so the broken fragment never ships
+		// while the signal flush below still proceeds.
+		frag := ctx.app.renderFragment(ctx)
 		ctx.queue.mu.Lock()
 		// Prepend the auto re-render so any user-explicit Patch.Elements
 		// patches already queued (e.g. from inside the action body) end
 		// up later in the wire frame. Datastar's morph applies patches
 		// in document order with last-write-wins per id, so this keeps
 		// the user's targeted override the authoritative one.
-		ctx.queue.elements = buf.String() + ctx.queue.elements
+		ctx.queue.elements = frag + ctx.queue.elements
 		ctx.queue.mu.Unlock()
-		putRenderBuf(buf)
 	}
 
 	if hasSignals {
@@ -203,4 +222,29 @@ func flushDirty(ctx *Ctx) {
 		ctx.queue.mu.Unlock()
 	}
 	ctx.queue.notify()
+}
+
+// renderFragment re-renders the view fragment inside the render window,
+// recovering a panicking viewFn so an async re-render (action autoflush,
+// broadcast SyncNow) surfaces as a structured via log line instead of
+// escaping its goroutine — which, on the broadcast path, would crash the
+// process. There is no response writer on this path, so unlike renderView
+// the only recovery action is to log; the recovered call returns "", which
+// the caller treats as a no-op fragment.
+func (a *App) renderFragment(ctx *Ctx) string {
+	buf := getRenderBuf()
+	defer putRenderBuf(buf)
+	// View runs without queue.mu held — user code is allowed to call
+	// ctx.Patch.Signal / ctx.Patch.Elements, which would deadlock on a
+	// re-entrant queue.mu acquisition.
+	ctx.beginRender()
+	defer ctx.endRender()
+	defer func() {
+		if rec := recover(); rec != nil {
+			a.logErr(ctx, "View panicked: %v", rec)
+		}
+	}()
+	body := ctx.viewFn(ctx.readView())
+	_ = h.Div(h.ID(ctx.id), body).Render(buf)
+	return buf.String()
 }

--- a/render_test.go
+++ b/render_test.go
@@ -3,10 +3,13 @@ package via_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-via/via"
 	"github.com/go-via/via/h"
+	"github.com/go-via/via/vt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -39,4 +42,174 @@ func TestWritePageDocument_marshalFailureStillRenders(t *testing.T) {
 	// the whole page render; the document still ships, the bad signal
 	// is just omitted from the initial data-signals payload.
 	assert.Contains(t, body, "<div>")
+}
+
+type panicViewPage struct{}
+
+func (p *panicViewPage) View(ctx *via.CtxR) h.H { panic("view boom") }
+
+func TestView_panicReachesTheConfiguredLoggerNotBareStderr(t *testing.T) {
+	t.Parallel()
+
+	app, server, logger := newLoggedApp(t, via.LogError)
+	via.Mount[panicViewPage](app, "/")
+
+	resp, err := http.Get(server.URL + "/")
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	found := false
+	for _, r := range logger.snapshot() {
+		if r.level == via.LogError && strings.Contains(r.msg, "panicked") {
+			found = true
+			require.GreaterOrEqual(t, len(r.kv), 2)
+			assert.Equal(t, "via_tab", r.kv[0])
+			break
+		}
+	}
+	assert.True(t, found,
+		"a View panic must surface as a structured via log record, "+
+			"not escape to the embedding http.Server")
+}
+
+func TestView_panicProducesControlled500NotADroppedConnection(t *testing.T) {
+	t.Parallel()
+
+	app, server, _ := newLoggedApp(t, via.LogError)
+	via.Mount[panicViewPage](app, "/")
+
+	resp, err := http.Get(server.URL + "/")
+	require.NoError(t, err,
+		"View panic must yield an HTTP response, not a dropped connection")
+	body := readAll(t, resp.Body)
+	resp.Body.Close()
+
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	// The 500 must short-circuit the page document — a half-rendered
+	// envelope appended after the error body would be a corrupt response.
+	assert.NotContains(t, body, "<html",
+		"recovered render must not also emit a partial page document")
+}
+
+type rerenderPanicPage struct {
+	N via.StateTabNum[int]
+}
+
+func (p *rerenderPanicPage) Trip(ctx *via.Ctx) error {
+	return p.N.Update(ctx, func(n int) (int, error) { return n + 1, nil })
+}
+
+func (p *rerenderPanicPage) View(ctx *via.CtxR) h.H {
+	// Initial render (N==0) succeeds so the page loads; the panic only
+	// fires on the post-action re-render, which is the path under test.
+	if p.N.Read(ctx) > 0 {
+		panic("rerender boom")
+	}
+	return h.Div()
+}
+
+func TestView_panicDuringReRenderDoesNotEscapeToTheServer(t *testing.T) {
+	t.Parallel()
+
+	app, server, logger := newLoggedApp(t, via.LogError)
+	via.Mount[rerenderPanicPage](app, "/")
+
+	tc := vt.NewClient(t, server, "/")
+	assert.Equal(t, http.StatusOK, tc.Action("Trip").Fire(),
+		"the action body succeeded; only the re-render panicked, "+
+			"which must not drop the connection")
+
+	found := false
+	for _, r := range logger.snapshot() {
+		if r.level == via.LogError && strings.Contains(r.msg, "panicked") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found,
+		"a View panic on the re-render path must surface as a via log record")
+}
+
+type rerenderPanicSignalPage struct {
+	N   via.StateTabNum[int]
+	Sig via.SignalNum[int] `via:"sig"`
+}
+
+func (p *rerenderPanicSignalPage) Trip(ctx *via.Ctx) error {
+	_ = p.Sig.Update(ctx, func(int) (int, error) { return 7, nil })
+	return p.N.Update(ctx, func(n int) (int, error) { return n + 1, nil })
+}
+
+func (p *rerenderPanicSignalPage) View(ctx *via.CtxR) h.H {
+	if p.N.Read(ctx) > 0 {
+		panic("rerender boom")
+	}
+	return h.Div()
+}
+
+func TestView_panicDuringReRenderStillFlushesDirtySignals(t *testing.T) {
+	t.Parallel()
+
+	app, server, _ := newLoggedApp(t, via.LogError)
+	via.Mount[rerenderPanicSignalPage](app, "/")
+
+	tc := vt.NewClient(t, server, "/")
+	frames, cancel := tc.SSEReady()
+	defer cancel()
+
+	require.Equal(t, http.StatusOK, tc.Action("Trip").Fire())
+	// The render panicked and was swallowed — but recovering the render
+	// must not abandon the rest of the flush: the dirty signal still has
+	// to reach the browser.
+	vt.AwaitFrame(t, frames, 2*time.Second, `"sig":7`)
+}
+
+type broadcastPanicPage struct {
+	Shared via.StateAppNum[int]
+}
+
+func (p *broadcastPanicPage) Bump(ctx *via.Ctx) error {
+	return p.Shared.Update(ctx, func(n int) (int, error) { return n + 1, nil })
+}
+
+func (p *broadcastPanicPage) View(ctx *via.CtxR) h.H {
+	// Read subscribes this tab to the app key so a peer's Update wakes it
+	// for a broadcast re-render; the panic only fires once bumped.
+	if p.Shared.Read(ctx) > 0 {
+		panic("broadcast rerender boom")
+	}
+	return h.Div()
+}
+
+func TestView_panicInBroadcastReRenderIsRecoveredNotProcessCrashing(t *testing.T) {
+	t.Parallel()
+
+	app, server, logger := newLoggedApp(t, via.LogError)
+	via.Mount[broadcastPanicPage](app, "/")
+
+	// Two independent tabs share the app-scoped state. The peer re-renders
+	// on its own SyncNow goroutine (broadcast.go), which has no action
+	// handler defer to fall back on — an unrecovered panic there crashes
+	// the whole process, so the fix must live inside flushDirty itself.
+	peer := vt.NewClient(t, server, "/")
+	peerFrames, cancel := peer.SSEReady()
+	defer cancel()
+
+	writer := vt.NewClient(t, server, "/")
+	require.Equal(t, http.StatusOK, writer.Action("Bump").Fire())
+
+	require.Eventually(t, func() bool {
+		for _, r := range logger.snapshot() {
+			if r.level == via.LogError && strings.Contains(r.msg, "panicked") {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond,
+		"the broadcast goroutine's View panic must be recovered and logged")
+
+	// The peer's SSE stream must still be alive (server didn't crash and
+	// didn't tear the connection down on the swallowed render).
+	require.Equal(t, http.StatusOK, peer.Action("Bump").Fire())
+	_ = peerFrames
 }


### PR DESCRIPTION
Closes #48.

## Problem

View renders had no panic recovery, unlike action handlers (`WithActionErrorHandler`) and the `OnInit`/`OnConnect`/`OnDispose` lifecycle guards. A panic in `viewFn` escaped the framework:

- **Initial GET render** — propagated to the embedding `http.Server`: naked stderr stack + dropped connection (no controlled 500, no via log line).
- **Async re-render** (`flushDirty`) — escaped via two callers: the action autoflush defer (dropped the action POST connection) and the `go c.SyncNow()` broadcast goroutine, where an unrecovered panic **crashed the whole process**.

The asymmetry was the surprise: the same programmer mistake got wildly different treatment depending on which callback it sat in — and the precise `on.*` panic messages from #36 surface at View time, exactly where the framework didn't structure them.

## Fix

Two sibling guards wrap every `viewFn` callsite, matching the existing recovery patterns:

- `renderView` (initial GET) — recovers, logs via `a.logErr("View panicked: %v")`, writes a controlled **500**, and short-circuits the page document.
- `renderFragment` (async re-render, used by `flushDirty`) — recovers, logs, and returns `""` (a no-op prepend, dropped by the drain's `elems != ""` guard). The dirty-signal flush still proceeds. Covers both the action-autoflush and broadcast-goroutine callers centrally.

Recovery is **unconditional** (the issue's open question) — `mw.Recover` stays as the backstop for non-via handlers, plugin endpoints, and custom middleware.

## Tests

Built test-first (RYGBA TDD); each confirmed failing for the right reason before implementing (the broadcast test crashed the test binary in Red, as designed):

- `TestView_panicReachesTheConfiguredLoggerNotBareStderr`
- `TestView_panicProducesControlled500NotADroppedConnection` (also pins: no half-rendered document appended after the 500)
- `TestView_panicDuringReRenderDoesNotEscapeToTheServer`
- `TestView_panicDuringReRenderStillFlushesDirtySignals` (pins: recover wraps only the render, not the whole flush)
- `TestView_panicInBroadcastReRenderIsRecoveredNotProcessCrashing`

Full suite green under `go test -race ./...` (and `-count=20` stress on the panic tests).