### PR TITLE
fix(sess): guard ctx.session with atomic.Pointer (closes #31)

### DIFF
--- a/action.go
+++ b/action.go
@@ -111,7 +111,7 @@ func (a *App) handleAction(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	if ctx.session != nil && a.sessionFromRequest(r) != ctx.session {
+	if sess := ctx.session.Load(); sess != nil && a.sessionFromRequest(r) != sess {
 		http.Error(w, "session mismatch", http.StatusForbidden)
 		return
 	}

--- a/broadcast.go
+++ b/broadcast.go
@@ -51,7 +51,7 @@ func (a *App) broadcastRender(skip *Ctx, sess *session, key string) {
 		if c == skip {
 			continue
 		}
-		if sess != nil && c.session != sess {
+		if sess != nil && c.session.Load() != sess {
 			continue
 		}
 		if !c.subscribed(key) {

--- a/ctx.go
+++ b/ctx.go
@@ -28,7 +28,7 @@ type Ctx struct {
 	queue      *patchQueue
 	doneChan   chan struct{}
 	disposed   bool
-	session    *session
+	session    atomic.Pointer[session]
 	lastAccess atomic.Int64
 
 	// lastSignals holds the most recent signals payload from an action
@@ -207,7 +207,7 @@ func (ctx *Ctx) Session() *Session {
 	if ctx == nil {
 		return &Session{}
 	}
-	return &Session{data: ctx.session, ctx: ctx, app: ctx.app}
+	return &Session{data: ctx.session.Load(), ctx: ctx, app: ctx.app}
 }
 
 // Cookie returns the value of the named cookie on the in-flight request,

--- a/render.go
+++ b/render.go
@@ -17,7 +17,7 @@ func (a *App) renderPage(d *cmpDescriptor, w http.ResponseWriter, r *http.Reques
 	cmpVal := reflect.New(d.typ)
 	ctx := newCtx(d, cmpVal, genTabID(d.route))
 	ctx.app = a
-	ctx.session = a.sessionFromRequest(r)
+	ctx.session.Store(a.sessionFromRequest(r))
 	ctx.mu.Lock()
 	ctx.w = w
 	ctx.r = r

--- a/sess.go
+++ b/sess.go
@@ -103,7 +103,7 @@ func (s *Session) Rotate() string {
 	}
 	app.sessionsMu.Unlock()
 
-	s.ctx.session = fresh
+	s.ctx.session.Store(fresh)
 	s.data = fresh
 
 	if w := s.ctx.Writer(); w != nil {

--- a/sess_test.go
+++ b/sess_test.go
@@ -3,6 +3,7 @@ package via_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -202,4 +203,59 @@ func TestRotateSession_changesCookieValue(t *testing.T) {
 	defer cancel()
 	require.Equal(t, 200, tc.Action("Login").Fire())
 	vt.AwaitFrame(t, frames, 2*time.Second, ">alice<")
+}
+
+// RotateSession data race (#31)
+
+type rotateRacePage struct {
+	User via.StateSessStr
+}
+
+func (p *rotateRacePage) View(ctx *via.CtxR) h.H { return h.Div(p.User.Text(ctx)) }
+
+func (p *rotateRacePage) Rotate(ctx *via.Ctx) error {
+	for i := 0; i < 100; i++ {
+		ctx.Session().Rotate()
+	}
+	return nil
+}
+
+func (p *rotateRacePage) WriteSess(ctx *via.Ctx) error {
+	for i := 0; i < 100; i++ {
+		_ = p.User.Update(ctx, func(string) (string, error) { return "v", nil })
+	}
+	return nil
+}
+
+func TestRotateSession_doesNotRaceWithSiblingSessionBroadcast(t *testing.T) {
+	t.Parallel()
+	// One tab rotates — writing its ctx's session pointer — while another
+	// tab's session write fans out through broadcastRender, which reads
+	// every live ctx's session pointer (before any session-equality
+	// filter), including the rotating one. The two tabs sit on distinct
+	// sessions so neither invalidates the other, isolating the pointer
+	// race: a plain *session field trips -race; the contract is that
+	// concurrent rotate + fan-out stays goroutine-safe.
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	via.Mount[rotateRacePage](app, "/")
+	defer server.Close()
+
+	tabA := vt.NewClient(t, server, "/")
+	_, cancelA := tabA.SSEReady()
+	defer cancelA()
+
+	tabB := vt.NewClient(t, server, "/")
+	_, cancelB := tabB.SSEReady()
+	defer cancelB()
+
+	var wg sync.WaitGroup
+	var statusA, statusB int
+	wg.Add(2)
+	go func() { defer wg.Done(); statusA = tabA.Action("Rotate").Fire() }()
+	go func() { defer wg.Done(); statusB = tabB.Action("WriteSess").Fire() }()
+	wg.Wait()
+
+	assert.Equal(t, http.StatusOK, statusA)
+	assert.Equal(t, http.StatusOK, statusB)
 }

--- a/sse.go
+++ b/sse.go
@@ -34,7 +34,7 @@ func (a *App) handleSSE(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
-	if ctx.session != nil && a.sessionFromRequest(r) != ctx.session {
+	if sess := ctx.session.Load(); sess != nil && a.sessionFromRequest(r) != sess {
 		w.WriteHeader(http.StatusForbidden)
 		return
 	}
@@ -229,7 +229,7 @@ func (a *App) handleSSEClose(w http.ResponseWriter, r *http.Request) {
 	}
 	tabID := strings.TrimSpace(string(body))
 	if ctx, ok := a.getCtx(tabID); ok {
-		if ctx.session != nil && a.sessionFromRequest(r) != ctx.session {
+		if sess := ctx.session.Load(); sess != nil && a.sessionFromRequest(r) != sess {
 			return
 		}
 		// Unregister first so concurrent action handlers see "not

--- a/statesess.go
+++ b/statesess.go
@@ -30,11 +30,15 @@ func (s *StateSess[T]) Read(rc readCtx) T {
 		return zero
 	}
 	ctx := rc.rctx()
-	if ctx == nil || ctx.session == nil {
+	if ctx == nil {
+		return zero
+	}
+	sess := ctx.session.Load()
+	if sess == nil {
 		return zero
 	}
 	ctx.trackRead(s.wireKey)
-	v, ok := ctx.session.data.Load(s.wireKey)
+	v, ok := sess.data.Load(s.wireKey)
 	if !ok {
 		return zero
 	}
@@ -61,10 +65,11 @@ func (s *StateSess[T]) Update(ctx *Ctx, fn func(T) (T, error)) error {
 	if ctx == nil {
 		panic("via: StateSess.Update called with nil *Ctx")
 	}
-	if fn == nil || ctx.session == nil || ctx.app == nil {
+	sess := ctx.session.Load()
+	if fn == nil || sess == nil || ctx.app == nil {
 		return nil
 	}
-	_, err := ctx.session.data.Update(s.wireKey, func(old any) (any, error) {
+	_, err := sess.data.Update(s.wireKey, func(old any) (any, error) {
 		t, _ := old.(T)
 		return fn(t)
 	})
@@ -72,7 +77,7 @@ func (s *StateSess[T]) Update(ctx *Ctx, fn func(T) (T, error)) error {
 		return err
 	}
 	ctx.markStateDirty()
-	ctx.app.broadcastRender(ctx, ctx.session, s.wireKey)
+	ctx.app.broadcastRender(ctx, sess, s.wireKey)
 	return nil
 }
 


### PR DESCRIPTION
## What

Fixes the critical data race in #31: `Session.Rotate` wrote `s.ctx.session = fresh` outside any lock (sess.go) while `broadcastRender` (broadcast.go:54), the action/SSE session-mismatch checks (action.go, sse.go), and `Ctx.Session` (ctx.go) read `c.session` from other goroutines. Per the Go memory model this is UB; `go test -race` flags it, and an unlucky reorder could expose a stale session pointer to a fan-out path whose target was just removed from `app.sessions` by `Rotate`.

## How

Convert `Ctx.session` from `*session` to `atomic.Pointer[session]`:

- `Rotate` and the render-time assignment use `.Store()`.
- All readers (`broadcastRender`, action/SSE mismatch checks, `Ctx.Session`, `StateSess.Read`/`Update`) use `.Load()`.
- `StateSess.Update` now loads the session pointer **once** into a local. Besides being race-free, this closes a pre-existing window: the old code read `ctx.session` twice (data mutation, then `broadcastRender` arg), so a `Rotate` landing between them mutated the old session but broadcast against the new pointer — waking the wrong tab set. Loading once keeps mutation and fan-out on the same session.

Surgical, no API change — exactly the fix suggested in the issue.

## Test (TDD)

`TestRotateSession_doesNotRaceWithSiblingSessionBroadcast` (sess_test.go): two tabs on **distinct** sessions; one rotates in a loop (writing its ctx's session pointer) while the other drives `StateSess.Update`, whose `broadcastRender` reads every live ctx's session pointer *before* the session-equality filter (broadcast.go:54) — including the rotating one. Distinct sessions isolate the pointer race without either tab invalidating the other.

- Without the fix: `-race` reports `broadcast.go:54` read vs `sess.go:106` write.
- With the fix: green, including `-count=5`.

## Verification

- `go vet ./...` clean
- `gofmt -l .` clean
- `go test -race ./...` — all packages pass