### PR TITLE
fix(sess): make session cookie Secure by default (closes #33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,7 +563,6 @@ deliver via the existing patch queue + SSE drain — no extra wiring.
 ```go
 app := via.New(
     via.WithLang("en"),
-    via.WithSecureCookies(),
     via.WithLogger(via.SlogLogger(slog.Default())),
     via.WithMaxRequestBody(1<<20),
     via.WithMaxContexts(10000),
@@ -604,9 +603,10 @@ Adapt to Prometheus, OTel, or expvar by implementing three methods
 - CSRF: every page mints a 256-bit `via_tab` id; action POSTs and SSE
   handshakes carry it as a signal. The id IS the CSRF token — unknown
   ids 404. Action POSTs are also session-pinned (cookie mismatch → 403).
-- Sessions: `via_session` cookie is `HttpOnly`, `SameSite=Lax`, 256-bit.
-  `WithSecureCookies()` flips on `Secure` for HTTPS. After auth state
-  changes, call `sess.Rotate(ctx)` (session-fixation defence).
+- Sessions: `via_session` cookie is `HttpOnly`, `SameSite=Lax`, 256-bit,
+  and `Secure` by default; `WithInsecureCookies()` drops `Secure` for a
+  local http:// dev loop. After auth state changes, call
+  `sess.Rotate(ctx)` (session-fixation defence).
 - CSP: `mw.CSP()` emits a strict header with a per-request nonce
   reachable via `ctx.CSPNonce()`.
 - Body limits: `WithMaxRequestBody(n)` (default 1 MiB) caps action
@@ -651,8 +651,8 @@ Every `WithX(...)` option is documented in
 [`go doc github.com/go-via/via`](https://pkg.go.dev/github.com/go-via/via)
 with its default and behaviour. Common production knobs:
 
-- `WithSecureCookies()`, `WithMaxContexts(n)`,
-  `WithLogger(SlogLogger(...))`
+- `WithMaxContexts(n)`, `WithLogger(SlogLogger(...))`,
+  `WithInsecureCookies()` (dev opt-out — `Secure` is on by default)
 - `WithMaxRequestBody(n)`, `WithSessionTTL(d)`, `WithContextTTL(d)`
 - `WithSSEHeartbeat(d)`, `WithReadHeaderTimeout(d)`,
   `WithIdleTimeout(d)`

--- a/app.go
+++ b/app.go
@@ -302,6 +302,10 @@ func New(opts ...Option) *App {
 			sseWriteTimeout: 10 * time.Second,
 			maxRequestBody:  1 << 20,
 			maxUploadSize:   32 << 20,
+			// Secure-by-default: the deployment surface (internal tools,
+			// admin dashboards) is exactly where a non-Secure cookie leaks
+			// on an http downgrade. WithInsecureCookies opts out for dev.
+			secureCookies: true,
 		},
 	}
 	for _, opt := range opts {

--- a/config.go
+++ b/config.go
@@ -91,7 +91,7 @@ func WithSSEWriteTimeout(d time.Duration) Option {
 // [WithInsecureCookies].
 func WithSecureCookies() Option {
 	return func(c *config) {
-		if c.cookieSecuritySet {
+		if c.cookieSecuritySet && !c.secureCookies {
 			panic("via: conflicting cookie security options")
 		}
 		c.secureCookies = true
@@ -106,7 +106,7 @@ func WithSecureCookies() Option {
 // Conflicts with [WithSecureCookies].
 func WithInsecureCookies() Option {
 	return func(c *config) {
-		if c.cookieSecuritySet {
+		if c.cookieSecuritySet && c.secureCookies {
 			panic("via: conflicting cookie security options")
 		}
 		c.secureCookies = false

--- a/config.go
+++ b/config.go
@@ -29,6 +29,7 @@ type config struct {
 	sseHeartbeat       time.Duration
 	sseWriteTimeout    time.Duration
 	secureCookies      bool
+	cookieSecuritySet  bool
 	testServer         **httptest.Server
 	httpServerHook     func(*http.Server)
 	readHeaderTimeout  time.Duration
@@ -85,8 +86,33 @@ func WithSSEWriteTimeout(d time.Duration) Option {
 	return func(c *config) { c.sseWriteTimeout = d }
 }
 
-// WithSecureCookies marks the session cookie Secure for HTTPS deployments.
-func WithSecureCookies() Option { return func(c *config) { c.secureCookies = true } }
+// WithSecureCookies marks the session cookie Secure. This is the default;
+// the option remains for explicit intent and conflicts with
+// [WithInsecureCookies].
+func WithSecureCookies() Option {
+	return func(c *config) {
+		if c.cookieSecuritySet {
+			panic("via: conflicting cookie security options")
+		}
+		c.secureCookies = true
+		c.cookieSecuritySet = true
+	}
+}
+
+// WithInsecureCookies clears the Secure flag so the session cookie rides
+// a plain-http origin. The Secure default is the safe production posture
+// (a framework aimed at internal tools should not ship a cookie that leaks
+// on an http downgrade); reach for this only on a local http:// dev loop.
+// Conflicts with [WithSecureCookies].
+func WithInsecureCookies() Option {
+	return func(c *config) {
+		if c.cookieSecuritySet {
+			panic("via: conflicting cookie security options")
+		}
+		c.secureCookies = false
+		c.cookieSecuritySet = true
+	}
+}
 
 // WithPlugins registers plugins. They run Register at New time.
 func WithPlugins(plugins ...Plugin) Option {

--- a/mw/mw.go
+++ b/mw/mw.go
@@ -150,8 +150,8 @@ func CSP(extra ...string) via.Middleware {
 }
 
 // HSTS returns a [via.Middleware] that sets the
-// Strict-Transport-Security response header. Pairs with
-// [via.WithSecureCookies] for HTTPS deployments. Use this only when
+// Strict-Transport-Security response header. Complements the
+// Secure-by-default session cookie for HTTPS deployments. Use this only when
 // the app is actually served over HTTPS — sending HSTS over plain
 // HTTP gets ignored, but enabling it behind a misconfigured TLS
 // terminator can lock users out for the max-age duration.
@@ -212,9 +212,9 @@ func HSTSPreload(on bool) HSTSOption {
 //
 //	app.Use(mw.RedirectHTTPS())
 //
-// The redirect is applied to every request; pair with
-// [via.WithSecureCookies] and [HSTS] for a complete TLS-only
-// deployment posture.
+// The redirect is applied to every request; pair with [HSTS] for a
+// complete TLS-only deployment posture (the session cookie is Secure
+// by default).
 //
 // Security caveat: X-Forwarded-Proto is trusted unconditionally.
 // Deploy this middleware ONLY behind a trusted reverse proxy / load

--- a/sess_test.go
+++ b/sess_test.go
@@ -40,7 +40,40 @@ func TestSession_cookieIsSetWithSecureDefaults(t *testing.T) {
 	assert.Len(t, c.Value, 64, "32 bytes hex-encoded = 64 chars")
 	assert.True(t, c.HttpOnly)
 	assert.Equal(t, "/", c.Path)
-	assert.False(t, c.Secure, "without WithSecureCookies the Secure flag is off")
+	assert.True(t, c.Secure,
+		"safe-by-default: the session cookie is Secure unless WithInsecureCookies opts out")
+}
+
+func TestSession_insecureCookiesDisablesSecureFlag(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server), via.WithInsecureCookies())
+	app.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	})
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/test")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	cookies := resp.Cookies()
+	require.NotEmpty(t, cookies)
+	assert.False(t, cookies[0].Secure,
+		"WithInsecureCookies must drop the Secure flag for local http development")
+}
+
+func TestSession_rejectsConflictingCookieOptions(t *testing.T) {
+	t.Parallel()
+
+	const want = "via: conflicting cookie security options"
+	assert.PanicsWithValue(t, want, func() {
+		via.New(via.WithSecureCookies(), via.WithInsecureCookies())
+	}, "secure-then-insecure must fail at registration, not silently override")
+	assert.PanicsWithValue(t, want, func() {
+		via.New(via.WithInsecureCookies(), via.WithSecureCookies())
+	}, "the conflict must be detected regardless of option order")
 }
 
 func TestSession_secureFlagWhenWithSecureCookiesEnabled(t *testing.T) {

--- a/sess_test.go
+++ b/sess_test.go
@@ -76,6 +76,19 @@ func TestSession_rejectsConflictingCookieOptions(t *testing.T) {
 	}, "the conflict must be detected regardless of option order")
 }
 
+func TestSession_repeatedCookieOptionIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	// Conditionally appended options can repeat the same choice; only a
+	// genuine secure-vs-insecure conflict should fail, not a redundant set.
+	assert.NotPanics(t, func() {
+		via.New(via.WithSecureCookies(), via.WithSecureCookies())
+	}, "the same option twice is redundant, not a conflict")
+	assert.NotPanics(t, func() {
+		via.New(via.WithInsecureCookies(), via.WithInsecureCookies())
+	}, "the same option twice is redundant, not a conflict")
+}
+
 func TestSession_secureFlagWhenWithSecureCookiesEnabled(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

Closes #33. The `via_session` cookie shipped with `Secure` **off** by default — production had to opt in via `WithSecureCookies()`. For a framework targeting internal tools / admin dashboards, that's the exact surface where a forgotten flag leaks the session cookie on an http downgrade (mixed content, misconfigured proxy). Safe-by-default flips the polarity.

Implements the issue's **preferred option 1**: invert the default, add an opt-out for local dev.

## How

- Default `secureCookies: true` (set in `New`'s config literal, before options run).
- New `WithInsecureCookies()` clears `Secure` for a local `http://` dev loop.
- `WithSecureCookies()` kept for explicit intent. Per the CONVENTIONS functional-options rule, the two are mutually exclusive → passing both **panics at registration** (`"via: conflicting cookie security options"`), in either order, via a `cookieSecuritySet` tracking flag.
- README updated (secure-by-default prose; production example no longer needs the redundant option).

## Why this doesn't break local dev / the test suite

Verified empirically: Go's `net/http/cookiejar` **and** modern Chrome both treat `localhost`/loopback as a secure context and send `Secure` cookies over `http://127.0.0.1`. So the `vt`-based session tests and the example apps keep working over plain-http loopback without `WithInsecureCookies()`.

## Tests (TDD)

- `TestSession_cookieIsSetWithSecureDefaults` — default → `Secure` true (was asserting false; flipped).
- `TestSession_insecureCookiesDisablesSecureFlag` — `WithInsecureCookies()` → `Secure` false.
- `TestSession_rejectsConflictingCookieOptions` — both orders panic with the exact value.
- `TestSession_secureFlagWhenWithSecureCookiesEnabled` — explicit option still → `Secure` true.

`go test -race ./...`, `go vet ./...`, `gofmt -l .` all clean.