### PR TITLE
test: enforce t.Parallel via paralleltest linter (closes #38)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,8 @@ version: "2"
 
 linters:
   default: standard
+  enable:
+    - paralleltest
   settings:
     errcheck:
       exclude-functions:

--- a/on/on_test.go
+++ b/on/on_test.go
@@ -208,7 +208,7 @@ func TestClick_bareBindingRendersIdentically(t *testing.T) {
 	assert.Contains(t, bufA.String(), `/_action/Inc`)
 }
 
-func TestClick_bareBindingRenderIsAllocFree(t *testing.T) {
+func TestClick_bareBindingRenderIsAllocFree(t *testing.T) { //nolint:paralleltest // AllocsPerRun must run serially
 	// AllocsPerRun forbids t.Parallel.
 	p := &internPage{}
 	node := on.Click(p.Inc)
@@ -222,7 +222,7 @@ func TestClick_bareBindingRenderIsAllocFree(t *testing.T) {
 		"rendering a cached bare binding should write pre-escaped bytes without allocating")
 }
 
-func TestClick_optionedBindingRenderIsAllocFree(t *testing.T) {
+func TestClick_optionedBindingRenderIsAllocFree(t *testing.T) { //nolint:paralleltest // AllocsPerRun must run serially
 	// AllocsPerRun forbids t.Parallel.
 	p := &internPage{}
 	node := on.Click(p.Inc, on.Debounce("200ms"))
@@ -236,7 +236,7 @@ func TestClick_optionedBindingRenderIsAllocFree(t *testing.T) {
 		"rendering an optioned binding should write pre-escaped bytes without allocating")
 }
 
-func TestClick_bareBindingAllocatesAtMostOnceAfterFirstCall(t *testing.T) {
+func TestClick_bareBindingAllocatesAtMostOnceAfterFirstCall(t *testing.T) { //nolint:paralleltest // AllocsPerRun must run serially
 	// AllocsPerRun forbids t.Parallel; the runtime asserts on it.
 	// Passing the bound method through `fn any` boxes the 2-word method
 	// value — that's an unavoidable 1 alloc at the call boundary. The

--- a/vt/vt_isolation_test.go
+++ b/vt/vt_isolation_test.go
@@ -35,7 +35,7 @@ func swapDefaultTransport(t *testing.T) *atomic.Int32 {
 	return &hits
 }
 
-func TestNewClient_usesIsolatedHTTPTransport(t *testing.T) {
+func TestNewClient_usesIsolatedHTTPTransport(t *testing.T) { //nolint:paralleltest // swaps the process-global http.DefaultTransport
 	hits := swapDefaultTransport(t)
 
 	var server *httptest.Server
@@ -51,7 +51,7 @@ func TestNewClient_usesIsolatedHTTPTransport(t *testing.T) {
 			"tests' server.Close() can't disturb each other's idle pools")
 }
 
-func TestClient_Fork_usesIsolatedHTTPTransport(t *testing.T) {
+func TestClient_Fork_usesIsolatedHTTPTransport(t *testing.T) { //nolint:paralleltest // swaps the process-global http.DefaultTransport
 	var server *httptest.Server
 	app := via.New(via.WithTestServer(&server))
 	via.Mount[tcPage](app, "/")
@@ -67,7 +67,7 @@ func TestClient_Fork_usesIsolatedHTTPTransport(t *testing.T) {
 		"Fork's http.Client must use its own Transport, not http.DefaultTransport")
 }
 
-func TestClient_SSE_usesIsolatedHTTPTransport(t *testing.T) {
+func TestClient_SSE_usesIsolatedHTTPTransport(t *testing.T) { //nolint:paralleltest // swaps the process-global http.DefaultTransport
 	var server *httptest.Server
 	app := via.New(via.WithTestServer(&server))
 	via.Mount[tcPage](app, "/")


### PR DESCRIPTION
## What

Closes #38. The issue reported table-driven subtests missing `t.Parallel()`. An AST sweep of the module shows that's **already fixed** — all 18 `t.Run` subtests call `t.Parallel()` as their first statement (the omissions were cleaned up during the #30 typed-API rewrite, after #38 was filed).

So rather than fix live offenders (there are none), this **locks the convention in** so it can't regress: enable the `paralleltest` linter (the repo already runs golangci-lint with only the `standard` set).

## How

- `.golangci.yml`: add `paralleltest` to `linters.enable`.
- Annotate the **6 legitimately-serial top-level tests** with `//nolint:paralleltest` + reason:
  - `on/on_test.go` ×3 — `testing.AllocsPerRun` measurements must run serially (parallelism perturbs alloc counts).
  - `vt/vt_isolation_test.go` ×3 — they swap the process-global `http.DefaultTransport`, so they cannot be parallel.

  Both reasons were already documented in nearby comments; the `//nolint` makes the serial choice explicit to the linter too.

## Verification

- `golangci-lint run ./...` → **0 issues** with `paralleltest` enabled.
- **Guard proven:** injecting a table-driven `t.Run` without `t.Parallel()` makes the linter fail with *"Range statement … missing the call to method parallel in test Run"* — exactly #38's pattern — then reverts to 0 issues.
- `gofmt -l .` clean; `go test -race ./...` green across all packages.

## Note on scope

No runtime/behavior change — this is test-suite + lint config only, so there's nothing browser-observable to verify; the linter run + full `-race` suite are the verification.