### PR TITLE
feat(ctx): replace alert() toast with a styled Datastar toast (#41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,8 @@ The action body can:
 - Write typed state: `c.Hits.Write(ctx, …)` or `c.Hits.Op(ctx).Add(1)`.
 - Push targeted patches: `ctx.Patch.Elements(h.Ul(h.ID("list"), …))`.
 - Push raw signals: `ctx.Patch.Signal("_picoTheme", "purple")`.
-- Show a quick alert: `ctx.Toast("saved!")` (JSON-safe).
+- Show a quick toast: `ctx.Toast("saved!")` — a styled, non-blocking
+  notice that auto-dismisses (JSON-safe, zero setup).
 - Redirect: `ctx.Redirect("/profile")`.
 - Decode the request payload into a typed struct:
 

--- a/action_test.go
+++ b/action_test.go
@@ -124,7 +124,7 @@ type assertSaveErr string
 
 func (e assertSaveErr) Error() string { return string(e) }
 
-func TestAction_defaultErrorPathAlertsTheBrowser(t *testing.T) {
+func TestAction_defaultErrorPathToastsTheBrowser(t *testing.T) {
 	t.Parallel()
 
 	var server *httptest.Server
@@ -137,9 +137,12 @@ func TestAction_defaultErrorPathAlertsTheBrowser(t *testing.T) {
 	defer cancel()
 	require.Equal(t, 200, tc.Action("Save").Fire())
 
-	// The default action-error handler queues alert("…"). The script
-	// arrives in the SSE stream as a datastar-execute-script event.
-	vt.AwaitFrame(t, frames, 2*time.Second, `alert("validation: email required")`)
+	// A returned error surfaces its message through the default toast,
+	// which arrives in the SSE stream as a script-patch event.
+	got := vt.AwaitFrame(t, frames, 2*time.Second,
+		"via-toast-root", "validation: email required")
+	assert.NotContains(t, got, "alert(",
+		"default error surface must be a styled toast, not a blocking alert")
 }
 
 type customErrPage struct{}
@@ -158,7 +161,7 @@ func (p *panicStringPage) Crash(ctx *via.Ctx) error {
 
 func (p *panicStringPage) View(ctx *via.CtxR) h.H { return h.Div() }
 
-func TestAction_defaultPanicAlertHidesInternalMessage(t *testing.T) {
+func TestAction_defaultPanicToastHidesInternalMessage(t *testing.T) {
 	t.Parallel()
 
 	var server *httptest.Server
@@ -171,9 +174,10 @@ func TestAction_defaultPanicAlertHidesInternalMessage(t *testing.T) {
 	defer cancel()
 	require.Equal(t, 200, tc.Action("Crash").Fire())
 
-	got := vt.AwaitFrame(t, frames, 2*time.Second, `alert("Something went wrong")`)
+	got := vt.AwaitFrame(t, frames, 2*time.Second,
+		"via-toast-root", "Something went wrong")
 	assert.NotContains(t, got, "secret-leaks-here",
-		"default panic alert must not leak the internal panic message")
+		"default panic toast must not leak the internal panic message")
 }
 
 type panicTypedErr struct {

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -324,6 +324,11 @@ func (p *ctxScriptPage) DoToastHTML(ctx *via.Ctx) error {
 	return nil
 }
 
+func (p *ctxScriptPage) DoToastScriptBreakout(ctx *via.Ctx) error {
+	ctx.Toast(`</script><img src=x onerror=boom()>`)
+	return nil
+}
+
 func (p *ctxScriptPage) DoRedirect(ctx *via.Ctx) error {
 	ctx.Redirect("/elsewhere")
 	return nil
@@ -405,10 +410,11 @@ func TestCtx_Toast_injectsMessageAsJSStringLiteral(t *testing.T) {
 
 func TestCtx_Toast_escapesHTMLMarkupInMessage(t *testing.T) {
 	t.Parallel()
-	// A message containing HTML must never reach the wire as live markup —
-	// the toast renders it as text. json.Marshal HTML-escapes the angle
-	// brackets to the < / > unicode forms, so the injected
-	// onerror handler arrives as inert text and can't execute.
+	// json.Marshal HTML-escapes the angle brackets and ampersand to their
+	// unicode-escaped forms, so an HTML payload reaches the wire as an
+	// inert JSON string literal, never as live markup. The test inspects
+	// the emitted frame (not the DOM): a SetEscapeHTML(false) regression
+	// would surface a literal "<img" here and fail the assertion.
 	var server *httptest.Server
 	app := via.New(via.WithTestServer(&server))
 	via.Mount[ctxScriptPage](app, "/")
@@ -422,6 +428,28 @@ func TestCtx_Toast_escapesHTMLMarkupInMessage(t *testing.T) {
 	frame := vt.AwaitFrame(t, frames, 2*time.Second, "via-toast-root", "boom()")
 	assert.NotContains(t, frame, "<img",
 		"user HTML must be escaped, never emitted as live markup")
+}
+
+func TestCtx_Toast_cannotBreakOutOfTheScriptElement(t *testing.T) {
+	t.Parallel()
+	// datastar delivers the toast snippet inside a <script>…</script>
+	// element, so a message carrying a literal </script> is the
+	// element-breakout vector. json.Marshal escapes < and >, so the
+	// sequence can't appear verbatim and the message stays inside the
+	// script.
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	via.Mount[ctxScriptPage](app, "/")
+	defer server.Close()
+
+	tc := vt.NewClient(t, server, "/")
+	frames, cancel := tc.SSEReady()
+	defer cancel()
+
+	require.Equal(t, http.StatusOK, tc.Action("DoToastScriptBreakout").Fire())
+	frame := vt.AwaitFrame(t, frames, 2*time.Second, "via-toast-root", "boom()")
+	assert.NotContains(t, frame, "</script><img",
+		"a </script> in the message must not break out of the datastar script element")
 }
 
 func TestCtx_Redirect_emitsRedirectFrame(t *testing.T) {

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -319,6 +319,11 @@ func (p *ctxScriptPage) DoToastSpecial(ctx *via.Ctx) error {
 	return nil
 }
 
+func (p *ctxScriptPage) DoToastHTML(ctx *via.Ctx) error {
+	ctx.Toast(`<img src=x onerror="boom()">`)
+	return nil
+}
+
 func (p *ctxScriptPage) DoRedirect(ctx *via.Ctx) error {
 	ctx.Redirect("/elsewhere")
 	return nil
@@ -358,7 +363,7 @@ func TestCtx_Reload_emitsLocationReloadScript(t *testing.T) {
 	vt.AwaitFrame(t, frames, 2*time.Second, "location.reload()")
 }
 
-func TestCtx_Toast_emitsAlertScript(t *testing.T) {
+func TestCtx_Toast_rendersStyledToastNotAlert(t *testing.T) {
 	t.Parallel()
 
 	var server *httptest.Server
@@ -371,15 +376,18 @@ func TestCtx_Toast_emitsAlertScript(t *testing.T) {
 	defer cancel()
 
 	require.Equal(t, http.StatusOK, tc.Action("DoToast").Fire())
-	vt.AwaitFrame(t, frames, 2*time.Second, `alert("saved!")`)
+	frame := vt.AwaitFrame(t, frames, 2*time.Second, "via-toast-root", "saved!")
+	assert.NotContains(t, frame, "alert(",
+		"default toast must not fall back to a blocking window.alert")
 }
 
-func TestCtx_Toast_JSONEncodesSpecialChars(t *testing.T) {
+func TestCtx_Toast_injectsMessageAsJSStringLiteral(t *testing.T) {
 	t.Parallel()
-	// JSON encodes the inner quote as \" and the newline as \n — both
-	// match exactly how a JS engine parses a string literal. Catches a
-	// regression where Toast started using fmt.Sprintf("alert(%q)") which
-	// would produce Go-quote escaping incompatible with JS.
+	// The message rides into the toast script as a JSON-encoded literal:
+	// the inner quote becomes \" and the newline \n, matching how a JS
+	// engine parses a string literal. Catches a regression where Toast
+	// interpolated the raw message into the script and let it break out
+	// of the string context.
 	var server *httptest.Server
 	app := via.New(via.WithTestServer(&server))
 	via.Mount[ctxScriptPage](app, "/")
@@ -390,8 +398,30 @@ func TestCtx_Toast_JSONEncodesSpecialChars(t *testing.T) {
 	defer cancel()
 
 	require.Equal(t, http.StatusOK, tc.Action("DoToastSpecial").Fire())
-	vt.AwaitFrame(t, frames, 2*time.Second,
-		`alert("he said \"ok\\n done\"")`)
+	frame := vt.AwaitFrame(t, frames, 2*time.Second, "via-toast-root",
+		`"he said \"ok\\n done\""`)
+	assert.NotContains(t, frame, "alert(")
+}
+
+func TestCtx_Toast_escapesHTMLMarkupInMessage(t *testing.T) {
+	t.Parallel()
+	// A message containing HTML must never reach the wire as live markup —
+	// the toast renders it as text. json.Marshal HTML-escapes the angle
+	// brackets to the < / > unicode forms, so the injected
+	// onerror handler arrives as inert text and can't execute.
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	via.Mount[ctxScriptPage](app, "/")
+	defer server.Close()
+
+	tc := vt.NewClient(t, server, "/")
+	frames, cancel := tc.SSEReady()
+	defer cancel()
+
+	require.Equal(t, http.StatusOK, tc.Action("DoToastHTML").Fire())
+	frame := vt.AwaitFrame(t, frames, 2*time.Second, "via-toast-root", "boom()")
+	assert.NotContains(t, frame, "<img",
+		"user HTML must be escaped, never emitted as live markup")
 }
 
 func TestCtx_Redirect_emitsRedirectFrame(t *testing.T) {
@@ -475,7 +505,7 @@ func TestCtx_Redirect_dropsDangerousURLs(t *testing.T) {
 			require.Equal(t, http.StatusOK,
 				tc.Action("Go").WithSignal("url", tt.url).Fire())
 			require.Equal(t, http.StatusOK, tc.Action("Ack").Fire())
-			body := vt.AwaitFrame(t, frames, 2*time.Second, `alert("ack")`)
+			body := vt.AwaitFrame(t, frames, 2*time.Second, "via-toast-root", "ack")
 			assert.NotContains(t, body, "window.location.href",
 				"dangerous URL must not produce a redirect frame")
 			assert.NotContains(t, body, tt.url,
@@ -776,7 +806,7 @@ func (p *syncOffPanicPage) View(ctx *via.CtxR) h.H { return h.Div(p.N.Text(ctx))
 
 func TestSyncOff_panicErrorToastStillReachesClient(t *testing.T) {
 	t.Parallel()
-	// dispatchActionError enqueues a script (alert) directly onto the
+	// dispatchActionError enqueues a toast script directly onto the
 	// patch queue. SyncOff suppresses dirty-bit flushes but must not
 	// swallow explicit publish primitives — otherwise a panicking
 	// silent action would fail without any user-visible signal.
@@ -829,7 +859,7 @@ func TestSyncOff_doesNotSuppressExplicitPublishPrimitives(t *testing.T) {
 		action string
 		expect string
 	}{
-		{"Toast", "SilentToast", `alert("ping")`},
+		{"Toast", "SilentToast", "ping"},
 		{"PatchSignal", "SilentPatchSignal", "hello"},
 		{"SyncElements", "SilentSyncElements", `id="marker"`},
 	}

--- a/push.go
+++ b/push.go
@@ -123,13 +123,17 @@ func (ctx *Ctx) Reload() {
 	ctx.ExecScript("location.reload()")
 }
 
-// Toast queues a browser alert(message). Sugar for the common
-// "show a quick notice and move on" pattern; for richer toasts use
-// ctx.Patch.Signal to drive a client-side notice signal instead.
+// Toast shows message as a small, styled, non-blocking notice that slides
+// into a fixed overlay and auto-dismisses after a few seconds. It is the
+// default surface for recovered action-handler panics, and the "show a
+// quick notice and move on" sugar for app code. Zero setup: the first
+// toast on a page injects its own <style> and #via-toast-root container,
+// later toasts reuse them and stack.
 //
-// The message is JSON-encoded into the alert call so any user-supplied
-// content survives untouched — Go's %q escape rules diverge from
-// JavaScript's in a handful of edge cases (e.g. \a), JSON does not.
+// The message is rendered via textContent (never as HTML), and JSON-
+// encoded into the snippet so it can neither break out of the JS string
+// nor inject markup — Go's json HTML-escaping also neutralises a
+// </script> breakout of the surrounding datastar script element.
 func (ctx *Ctx) Toast(message string) {
 	if ctx == nil || message == "" {
 		return
@@ -138,8 +142,41 @@ func (ctx *Ctx) Toast(message string) {
 	if err != nil {
 		return
 	}
-	ctx.ExecScript("alert(" + string(b) + ")")
+	ctx.ExecScript(toastScriptHead + string(b) + toastScriptTail)
 }
+
+// toastScriptHead / toastScriptTail wrap a JSON-encoded message into the
+// self-contained toast snippet ctx.Toast emits. It rides ExecScript — the
+// same script-frame path the previous alert() used — so there is no
+// document change, no new public API, and no CSP posture shift versus the
+// alert it replaces. The <style> and container are keyed by element id so
+// they are created once per page and reused; the styling is deliberately
+// neutral so it reads acceptably on a bare page and under the picocss
+// plugin. The message arrives as the trailing call argument.
+const (
+	toastScriptHead = `(function(m){` +
+		`if(!document.getElementById("via-toast-css")){` +
+		`var s=document.createElement("style");s.id="via-toast-css";` +
+		`s.textContent="#via-toast-root{position:fixed;inset:auto 1rem 1rem auto;` +
+		`z-index:2147483647;display:flex;flex-direction:column;gap:.5rem;` +
+		`max-width:min(92vw,22rem);pointer-events:none}` +
+		`.via-toast{pointer-events:auto;background:#1f2937;color:#fff;` +
+		`font:500 .9rem/1.4 system-ui,-apple-system,sans-serif;padding:.7rem .9rem;` +
+		`border-radius:.5rem;box-shadow:0 4px 14px rgba(0,0,0,.25);opacity:0;` +
+		`transform:translateY(.6rem);transition:opacity .22s ease,transform .22s ease;` +
+		`word-break:break-word}.via-toast[data-show]{opacity:1;transform:none}";` +
+		`document.head.appendChild(s)}` +
+		`var root=document.getElementById("via-toast-root");` +
+		`if(!root){root=document.createElement("div");root.id="via-toast-root";` +
+		`document.body.appendChild(root)}` +
+		`var el=document.createElement("div");el.className="via-toast";` +
+		`el.setAttribute("role","status");el.setAttribute("aria-live","polite");` +
+		`el.textContent=m;root.appendChild(el);` +
+		`requestAnimationFrame(function(){el.setAttribute("data-show","")});` +
+		`setTimeout(function(){el.removeAttribute("data-show");` +
+		`setTimeout(function(){el.remove()},250)},4000)})(`
+	toastScriptTail = `)`
+)
 
 // Redirect sends a client-side navigation to url at the next flush.
 //

--- a/push.go
+++ b/push.go
@@ -164,13 +164,13 @@ const (
 		`font:500 .9rem/1.4 system-ui,-apple-system,sans-serif;padding:.7rem .9rem;` +
 		`border-radius:.5rem;box-shadow:0 4px 14px rgba(0,0,0,.25);opacity:0;` +
 		`transform:translateY(.6rem);transition:opacity .22s ease,transform .22s ease;` +
-		`word-break:break-word}.via-toast[data-show]{opacity:1;transform:none}";` +
+		`overflow-wrap:anywhere}.via-toast[data-show]{opacity:1;transform:none}";` +
 		`document.head.appendChild(s)}` +
 		`var root=document.getElementById("via-toast-root");` +
 		`if(!root){root=document.createElement("div");root.id="via-toast-root";` +
+		`root.setAttribute("role","status");root.setAttribute("aria-live","polite");` +
 		`document.body.appendChild(root)}` +
 		`var el=document.createElement("div");el.className="via-toast";` +
-		`el.setAttribute("role","status");el.setAttribute("aria-live","polite");` +
 		`el.textContent=m;root.appendChild(el);` +
 		`requestAnimationFrame(function(){el.setAttribute("data-show","")});` +
 		`setTimeout(function(){el.removeAttribute("data-show");` +


### PR DESCRIPTION
Closes #41.

## Problem

`ctx.Toast(msg)` emitted `window.alert(msg)` — blocking, unstyled, and
not something you want in front of a user. It is also the **default**
surface for recovered action-handler panics (`dispatchActionError` →
`ctx.Toast("Something went wrong")`), so every via app either shipped
`alert()` to production or built its own toast and abandoned `ctx.Toast`.

## Fix

`ctx.Toast` now emits a small, self-contained, styled toast: a fixed
bottom-right overlay that slides in, **stacks**, and **auto-dismisses**
after ~4s. **Zero setup** — the first toast on a page injects its own
`<style>` and `#via-toast-root` container (keyed by element id), later
toasts reuse them.

Deliberately in-scope-only, per the issue:

- **No new public API.** `ctx.Toast`'s signature and every call site are
  unchanged — this is a rendering change behind the existing surface.
- **Same transport.** The snippet rides the same `ExecScript`
  script-frame path the old `alert()` used, so there is **no document
  change** (no `AppendToHead`/foot injection) and **no CSP posture
  shift** versus the alert it replaces.
- **Neutral styling** so it reads acceptably on a bare page and under the
  picocss plugin.

## Safety

The message is rendered via `el.textContent` (never as HTML) and
JSON-encoded into the snippet, so it can neither break out of the JS
string literal nor inject markup. Go's `json.Marshal` HTML-escaping also
neutralises a `</script>` breakout of the surrounding datastar `<script>`
element. A test pins this with an `<img src=x onerror=…>` payload.

Accessibility: each toast carries `role="status"` / `aria-live="polite"`.

## Tests (RYGBA TDD)

Each new test was confirmed failing for the right reason (missing the
`via-toast-root` marker) before implementing:

- `TestCtx_Toast_rendersStyledToastNotAlert` — toast marker + message
  reach the wire; `alert(` never does.
- `TestCtx_Toast_injectsMessageAsJSStringLiteral` — quotes/newline/
  backslash arrive JSON-escaped (JS-string-literal safe).
- `TestCtx_Toast_escapesHTMLMarkupInMessage` — HTML markup arrives
  escaped, not as live DOM.
- `TestAction_defaultErrorPathToastsTheBrowser` /
  `TestAction_defaultPanicToastHidesInternalMessage` — the default error
  and panic surfaces are styled toasts; the internal panic message stays
  hidden.

Full suite green under `go test -race ./...` (and `-count=20` stress on
the toast tests). gofmt / go vet / golangci-lint clean. Emitted JS
validated with `node --check`. Visually verified in a browser: dark
slate toasts stack bottom-right, the long message wraps within the
max-width cap, and the container empties after the auto-dismiss.