### PR TITLE
docs: GitHub Pages site, live-chatroom flagship example, and a modernized README

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,60 @@
+name: Deploy docs to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/pages.yml"
+  # Build (but don't deploy) on PRs that touch the docs, so a broken site
+  # fails the PR rather than the post-merge deploy.
+  pull_request:
+    paths:
+      - "docs/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; don't cancel an in-progress run.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: docs
+      - id: pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_site
+
+  deploy:
+    needs: build
+    # Deploy only from main / manual runs — never from a pull request.
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/go-via/via)](https://goreportcard.com/report/github.com/go-via/via)
 [![CI](https://github.com/go-via/via/actions/workflows/ci.yml/badge.svg)](https://github.com/go-via/via/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Docs](https://img.shields.io/badge/docs-go--via.github.io%2Fvia-blue)](https://go-via.github.io/via)
+
+📖 **[Documentation site](https://go-via.github.io/via)** · [API reference](https://pkg.go.dev/github.com/go-via/via)
 
 Reactive web apps in pure Go. A composition is a struct. Reactive state
 is a typed field. Actions are methods. The compiler understands your UI.

--- a/README.md
+++ b/README.md
@@ -10,63 +10,65 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-go--via.github.io%2Fvia-blue)](https://go-via.github.io/via)
 
-📖 **[Documentation site](https://go-via.github.io/via)** · [API reference](https://pkg.go.dev/github.com/go-via/via)
+**Reactive web apps in pure Go.** A composition is a struct, reactive state is a typed field, actions are methods — and the compiler understands your UI. Via is the only framework, in any language, that expresses the **client/server reactive split as a Go type**: `Signal[T]` lives in the browser, `StateTab/Sess/App[T]` live only on the server. Which side owns a piece of state is a field declaration the compiler checks, not a convention you grep for. Transport is SSE only — no WebSockets, no build step, no hand-written JS.
 
-Reactive web apps in pure Go. A composition is a struct. Reactive state
-is a typed field. Actions are methods. The compiler understands your UI.
+📖 **[Documentation](https://go-via.github.io/via)** · [API reference](https://pkg.go.dev/github.com/go-via/via) · [Examples](https://go-via.github.io/via/examples)
 
-Via is the only framework — in any language — that expresses the
-client/server reactive split as a Go type. `Signal[T]` is a client
-signal, mirrored to a fine-grained Alien Signals graph in the browser
-via Datastar. `StateTab[T]`, `StateSess[T]`, `StateApp[T]` are
-server-only. Whether a piece of UI state round-trips or doesn't is a
-choice made at the field declaration, checked by the compiler, not by a
-convention you can grep for. Transport is SSE only — one stream per
-tab — so there are no WebSockets to wrestle with a corporate proxy.
+## The wow: a live chatroom in ~60 lines
 
-![Two browsers, two scopes — `StateTabNum[int]` is per-tab,
-`StateAppNum[int]` is shared across every session.](docs/counter-scope.gif)
-
-Best fit: internal tools, admin dashboards, line-of-business apps, and
-hobby projects — anywhere you would otherwise reach for Phoenix
-LiveView, Hotwire, or htmx + hand-written JS, but want to stay in Go.
-Not the right tool for offline-first PWAs, public-facing marketing
-sites, or anything that needs to scale horizontally across processes
-without sticky sessions.
-
-## The thesis: the client/server split is a Go type
-
-Reasoning: every server-rendered framework eventually faces the
-question "is this state client-owned or server-owned?" In every other
-ecosystem the answer is a convention. In Via it is the field's type.
-
-Rule: declare client-owned state as `Signal[T]`. Declare server-owned
-state as `StateTab[T]`, `StateSess[T]`, or `StateApp[T]`. The compiler
-enforces which side owns what. View helpers, actions, and lifecycle
-hooks all see the correct shape.
-
-Example:
+`Log` is one app-scoped slice. Appending to it fans a re-render out to **every connected tab across every session** — open two browsers and watch them sync. No `Broadcast`, no WebSocket, no client JS.
 
 ```go
-type Page struct {
-    // Client-owned. Lives in the browser's Alien Signals graph.
-    // Bind to <input>; mutate without a round-trip.
-    Theme via.Signal[string] `via:"theme,init=auto"`
+type Message struct{ From, Body string }
 
-    // Server-owned. Lives only in Go. Re-renders re-emit the value.
-    Hits  via.StateTab[int]
+type Room struct {
+    Log   via.StateAppSlice[Message] // shared across every session + tab
+    Name  via.SignalStr              `via:"name,init=Anon"`
+    Draft via.SignalStr              `via:"draft"`
+}
+
+func (r *Room) Send(ctx *via.Ctx) {
+    body := strings.TrimSpace(r.Draft.Read(ctx))
+    if body == "" {
+        return
+    }
+    _ = r.Log.Update(ctx, func(log []Message) ([]Message, error) {
+        return append(log, Message{From: r.Name.Read(ctx), Body: body}), nil
+    })
+    r.Draft.Write(ctx, "")
+}
+
+func (r *Room) View(ctx *via.CtxR) h.H {
+    // Reading Log here subscribes this tab; any Send anywhere re-renders it.
+    return h.Main(h.Class("container"),
+        h.H1(h.Text("Via Chat")),
+        h.Each(r.Log.Read(ctx), func(m Message) h.H {
+            return h.P(h.Strong(h.Text(m.From+": ")), h.Text(m.Body))
+        }),
+        h.Form(
+            h.Input(h.Type("text"), r.Name.Bind(), h.Placeholder("name")),
+            h.Input(h.Type("text"), r.Draft.Bind(), on.Key("Enter", r.Send)),
+            h.Button(h.Type("button"), h.Text("Send"), on.Click(r.Send)),
+        ),
+    )
 }
 ```
 
-`Theme` mutates inside the browser. Flipping it from an `<input>` does
-not POST. `Hits` mutates only through an action handler; the next flush
-diffs the View and ships targeted DOM patches over SSE.
+```bash
+go run ./internal/examples/chat   # then open http://localhost:3000 in two windows
+```
 
-## Quick start
+Full source + walkthrough: [`internal/examples/chat`](internal/examples/chat/main.go) · [tutorial](https://go-via.github.io/via/tutorial).
+
+## Install
 
 ```bash
 go get github.com/go-via/via
 ```
+
+## Quickstart: the counter
+
+`Hits` is server-owned; `Step` rides in the browser. `on.Click(c.Inc)` is a typed method reference — a typo is a compile error.
 
 ```go
 package main
@@ -105,563 +107,44 @@ func main() {
 }
 ```
 
-No template files. No build step. No hand-written JavaScript. `on.Click(c.Inc)`
-is a typed method reference — a typo is a compile error.
-
-## What Via is NOT
-
-Read this section before adopting. The non-goals are deliberate.
-
-- Not an SPA framework. Routes are server-rendered pages. The browser
-  receives HTML, not a JSON bundle.
-- Not a cluster runtime. `StateApp[T]` and `Broadcast` are
-  single-process. Horizontal scaling requires sticky sessions; App
-  state is per-pod. There is no built-in fan-out across instances.
-- Not offline-first. Disconnect the SSE stream and the tab freezes
-  until reconnect — Via is for connected sessions, not PWAs.
-- Not a JavaScript replacement. The browser still runs Datastar's
-  Alien Signals graph. Via removes hand-written JS for the reactivity
-  layer, not the runtime.
-- Not a build-step framework. There is no `via generate`. If you want
-  a code-gen template language, look at `templ`.
-- Not stable yet — pre-1.0, APIs can shift between minor versions.
-  ~12 examples. No third-party component library yet. The Datastar
-  dependency is load-bearing — Via does not vendor its own client
-  runtime.
-
-## Restart and tab survivability
-
-Be specific about what doesn't work. A live tab's state lives in
-memory on the server (the `*via.Ctx` and its `session`). It does not
-survive a process restart:
-
-- After a deploy, every client's `via_tab` is unknown to the new
-  process. The next SSE reconnect 404s and the next action POST 404s.
-- The client (Datastar) retries the SSE connection forever, so a user
-  watching a stale tab sees it freeze rather than recover. Tell users
-  to reload, or pair the deploy with a sticky load balancer that
-  drains long enough for tabs to close naturally.
-- Sessions are also in-memory; logged-in users will need to re-auth
-  unless you back the session store with something durable (not built
-  in).
-
-If you need session survivability across restarts, persist the
-`sess.Put`-stored payload (e.g. a JWT or an opaque token your auth
-layer recognizes) to a database keyed by the `via_session` cookie
-value, and rehydrate inside an `OnInit` hook.
-
-## Why Via, not X
-
-|                       | Language | Authoring                | Client runtime              | Build step             | Reactive state                |
-|-----------------------|----------|--------------------------|-----------------------------|------------------------|-------------------------------|
-| **Via**               | Go       | typed structs + `h` DSL  | Datastar (Alien Signals)    | none                   | typed fields, client + server |
-| HTMX                  | any      | HTML + `hx-*` attributes | tiny attribute interpreter  | none                   | server-only, manual           |
-| Phoenix LiveView      | Elixir   | EEx templates + macros   | morphdom + tiny JS          | none                   | `assigns` (Elixir-typed)      |
-| Hotwire (Turbo)       | Ruby     | ERB + Turbo Streams      | Turbo (WebSocket)           | none                   | server-only, untyped DOM      |
-| templ                 | Go       | `.templ` template files  | none (BYO)                  | yes (`templ generate`) | none built-in                 |
-| Datastar (direct)     | any      | HTML + `data-*` attrs    | Datastar (Alien Signals)    | none                   | client signals, manual        |
-
-Via is the only row that gives you typed end-to-end state (server +
-client) with no build step, SSE-only transport, and a fine-grained
-reactive client runtime in the same import. Pick another row if you
-want a different language, a template file format, or a different
-state-ownership split.
-
-## How reactivity runs
-
-```
-   ┌──────────────────────────┐                       ┌──────────────────────────┐
-   │  Browser                 │  ◀──── SSE patches ── │  Server (Go)             │
-   │                          │     + signal deltas   │                          │
-   │  Alien Signals graph     │                       │  Compositions            │
-   │   Signal[T] nodes        │                       │   StateTab[T]            │
-   │   data-* subscriptions   │                       │   StateSess[T]           │
-   │                          │                       │   StateApp[T]            │
-   │                          │  ────── POST ──────▶  │   per-tab action mutex   │
-   │                          │       actions         │                          │
-   └──────────────────────────┘                       └──────────────────────────┘
-        view reactivity                                  truth + side effects
-```
-
-Two reactive runtimes, one typed boundary.
-
-Server. Go owns truth. `StateTab[T]`, `StateSess[T]`, and `StateApp[T]`
-live only on the server; `Signal[T]` is mirrored. A re-render walks the
-View, diffs the resulting tree against the previous emission, and ships
-targeted element/attribute patches plus a signal-payload delta over
-SSE. The per-tab action mutex serialises writes — concurrent POSTs to
-one tab cannot race.
-
-Client. Datastar runs a fine-grained Alien Signals graph in the
-browser. `Signal[T]` values are nodes in that graph; the `data-*`
-attributes emitted by `s.Bind()`, `s.Text()`, `s.Show()`, `s.Attr()`,
-`s.Style()` are subscriptions. Mutating a signal — from an `<input>`
-edit, from `on.SetSignal`, or from a server-pushed patch — propagates
-through derived bindings without a re-render and without a round-trip.
-
-The split shows up at the field level. `Signal[int]` IS a client
-signal. `StateTab[int]` IS server-only. The author decides in the
-struct, not in the rendering code. UI state the client owns (modal
-open, current tab, filter string, derived counts) reacts instantly with
-zero SSE traffic; state the server owns (DB rows, cross-tab invariants,
-secrets) flows through actions and re-renders.
-
-## The four reactive shapes
-
-| Handle              | Scope          | Lives on        |
-|---------------------|----------------|-----------------|
-| `via.Signal[T]`     | per-tab        | client + server |
-| `via.StateTab[T]`   | per-tab        | server only     |
-| `via.StateSess[T]`  | per-session    | server only     |
-| `via.StateApp[T]`   | global         | server only     |
-
-Reads go through `Read(ctx)`; writes through `Update(ctx, fn)`.
-`Signal[T]` and `StateTab[T]` also expose `Write(ctx, v)` for direct
-sets — per-tab writes are already serialized by the action mutex.
-`Update` holds a per-key mutex across the load → fn → store sequence,
-so concurrent writers from different ctxs cannot lose increments. Wire
-keys, initial values, and the tag grammar are documented in godoc.
-
-### Typed ops via `Op(ctx)`
-
-For the common shape buckets — numeric, bool, string, slice, map — use
-the `Num` / `Bool` / `Str` / `Slice` / `Map` typed wrappers and call
-`Op(ctx)` for shape-aware verbs. Drop back to `Update(ctx, fn)` for
-custom transforms or non-bucket `T` (structs, interfaces).
-
-| Field type                          | Common verbs                                |
-|-------------------------------------|---------------------------------------------|
-| `via.StateTabNum[int]`              | `Add(n) / Sub(n) / Inc() / Dec() / Zero() / Min(lo) / Max(hi)` |
-| `via.SignalBool`                    | `Toggle() / True() / False()`               |
-| `via.StateSessStr`                  | `Append(s) / Prepend(s) / Clear()`          |
-| `via.SignalSlice[T]`                | `Append(v) / Prepend(v) / Pop() / Shift() / Take(n) / Drop(n) / Filter(pred) / Empty()` |
-| `via.StateAppMap[K,V]`              | `Put(k,v) / Delete(k) / Empty()`            |
-
-### View helpers driven by `Signal[T]`
-
-`Signal[T]` mirrors into the browser's reactive graph. The view helpers
-compile to Datastar `data-*` attributes that subscribe to it — DOM
-updates are fine-grained, no re-render, no round-trip:
-
-```go
-s.Bind()              // <input data-bind="key"> two-way binding
-s.Text()              // <span data-text="$key"></span>
-s.Show()              // data-show="$key" — toggle display by truthiness
-s.Attr("disabled")    // data-attr-disabled="$key" — drives an HTML attr
-s.Style("color")      // data-style-color="$key" — drives an inline CSS prop
-```
-
-`StateTab[T]` / `StateSess[T]` / `StateApp[T]` share `Text(ctx)`, which
-re-renders server-side instead of subscribing to a client signal.
-
-## Actions
-
-A method on the composition with signature `func(*via.Ctx) error` — or
-`func(*via.Ctx)` when nothing in the body can fail meaningfully — is
-an action. Bind it to a DOM event with the `on` sub-package:
-
-```go
-h.Button(h.Text("+"), on.Click(c.Inc))
-h.Form(on.Submit(c.Save), ...)
-h.Input(on.Input(c.Filter, on.Debounce("200ms")))
-h.Div(on.Key("Enter", c.Send))
-h.Button(h.Text("Pick blue"),
-    on.Click(c.Apply, on.SetSignal(&c.Theme, "blue")))
-```
-
-`on.SetSignal(&c.Field, value)` bundles a typed signal write with the
-action so the value updates client-side before the POST fires.
-`&c.Theme` is type-checked against the field — wrong type is a compile
-error.
-
-The action body can:
-
-- Write typed state: `c.Hits.Write(ctx, …)` or `c.Hits.Op(ctx).Add(1)`.
-- Push targeted patches: `ctx.Patch.Elements(h.Ul(h.ID("list"), …))`.
-- Push raw signals: `ctx.Patch.Signal("_picoTheme", "purple")`.
-- Show a quick toast: `ctx.Toast("saved!")` — a styled, non-blocking
-  notice that auto-dismisses (JSON-safe, zero setup).
-- Redirect: `ctx.Redirect("/profile")`.
-- Decode the request payload into a typed struct:
-
-  ```go
-  var f LoginForm
-  via.DecodeForm(ctx, &f)
-  ```
-
-Per-tab actions are serialized. Concurrent POSTs to one tab cannot
-race on State writes.
-
-For try-before-commit and bulk reconciliation flows, `ctx.SyncOff()`
-opts the whole action out of the dirty-mark/flush cycle — see godoc.
-
-## Lifecycle hooks
-
-| Method                    | Fires when                                    |
-|---------------------------|-----------------------------------------------|
-| `OnInit(ctx) error`       | Before View on the page-load request          |
-| `OnConnect(ctx) error`    | First time the SSE stream opens (one-shot)    |
-| `OnDispose(ctx)`          | Tab closed, ctx swept, or app shut down       |
-| `View(ctx) h.H`           | Required; renders the composition             |
-
-Implement any subset; `Mount` detects whichever are defined.
-
-`OnConnect` is where long-running per-tab work belongs — bots that hit
-GET without ever opening the SSE never trigger it.
-
-`via.Stream(ctx, interval, fn)` wires the most common ticker pattern:
-
-```go
-func (p *Page) OnConnect(ctx *via.Ctx) error {
-    via.Stream(ctx, time.Second, func(ctx *via.Ctx, t time.Time) {
-        p.Now.Write(ctx, t.Format("15:04:05"))
-    })
-    return nil
-}
-```
-
-`Stream` returns a `*via.Ticker` with `Pause`, `Resume`, `Stop`, and
-`SetInterval(d)` so actions can toggle the stream or change cadence at
-runtime. See `internal/examples/sysmon` for a full pause / rate-change
-UI driven by this surface.
-
-Inside actions and `via.Stream` callbacks the flush is automatic. From
-a raw goroutine you started yourself, call `ctx.SyncNow()` to force a
-re-render and push pending writes. It serialises with in-flight action
-handlers via the per-tab action mutex.
-
-## File uploads
-
-Add a `via.File` field. The action dispatcher detects multipart bodies
-and binds the named part for the duration of the action:
-
-```go
-type Page struct {
-    Avatar via.File           `via:"avatar"`
-    Note   via.Signal[string] `via:"note"`
-}
-
-func (p *Page) Upload(ctx *via.Ctx) error {
-    if !p.Avatar.Present() { return nil }
-    return p.Avatar.Save("/var/uploads/" + sanitized)
-}
-```
-
-The handle exposes `Filename()` (untrusted), `Size()`,
-`ContentType()` (untrusted), `Open()` for streaming, `Bytes()` for
-in-memory reads, and `Save(path)` for the common case (mode `0o600`,
-truncate). Text fields in the same multipart POST populate `Signal[T]`
-fields like a JSON action body.
-
-For raw streaming control (mixed parts, custom headers, files larger
-than the in-memory buffer), call `ctx.MultipartReader()`. Once read,
-typed `via.File` fields on the same action will be empty for any parts
-already advanced past.
-
-`WithMaxRequestBody(n)` caps total body size; oversized requests return
-413.
-
-## Path parameters
-
-```go
-type Profile struct {
-    UserID int    `path:"id"`
-    Slug   string `path:"slug"`
-}
-via.Mount[Profile](app, "/u/{id}/posts/{slug}")
-```
-
-Each `path:"name"` tag must match a `{name}` segment. Reflection runs
-once at Mount; per-request decoding writes directly into the typed
-field.
-
-## Sessions
-
-```go
-import "github.com/go-via/via/sess"
-
-type User struct{ Email, Name string }
-
-sess.Put(ctx, User{Email: "alice@example.com", Name: "Alice"})
-u, ok := sess.Get[User](ctx)                 // handler/action
-u, ok := sess.Get[User](r)                   // middleware
-sess.Clear[User](ctx)
-sess.Rotate(ctx)                             // after login / privilege change
-```
-
-`requireAuth` is one line of middleware:
-
-```go
-func requireAuth(w http.ResponseWriter, r *http.Request, next http.Handler) {
-    if u, ok := sess.Get[User](r); !ok || u.Email == "" {
-        http.Redirect(w, r, "/login", http.StatusSeeOther)
-        return
-    }
-    next.ServeHTTP(w, r)
-}
-```
-
-## Middleware
-
-```go
-import "github.com/go-via/via/mw"
-
-app := via.New()
-mw.Defaults(app)                // RequestID + AccessLog + Recover
-app.Use(mw.CSP())               // strict CSP with per-request nonce
-app.Use(requireAuth)            // your own
-```
-
-Factories under `via/mw`:
-
-- `mw.Defaults(app)` — RequestID + AccessLog + Recover.
-- `mw.RequestID()` — stamp `X-Request-ID` + plant on `r.Context`.
-- `mw.AccessLog(app)` — one info-line per request, with rid + status;
-  CR/LF stripped from method/path/rid so user input can't forge log
-  entries (CWE-117).
-- `mw.Recover(app)` — panic → 500 + error log (same CR/LF scrub); the
-  goroutine survives.
-- `mw.CSP(extra…)` — strict CSP header + nonce on `r.Context`.
-- `mw.HSTS(opts…)` — Strict-Transport-Security for HTTPS deploys.
-- `mw.RedirectHTTPS()` — 301 plain HTTP → https; trusts
-  `X-Forwarded-Proto` (use behind a TLS-terminating proxy).
-- `mw.RedirectHTTPSStrict()` — same redirect but ignores XFP; only
-  `r.TLS != nil` counts as secure (use for direct-bind TLS).
-
-Read it back inside actions / handlers:
-
-```go
-via.RequestIDFrom(r)             // string or ""
-via.Log(ctx).Log(via.LogInfo, "checkout", "amount", n)
-ctx.CSPNonce()                   // matches header set by mw.CSP
-```
-
-## Routing and groups
-
-```go
-via.Mount[Counter](app, "/counter/{id}")
-
-api := app.Group("/api")
-api.Use(requireAuth)
-via.Mount[Profile](api, "/profile")
-
-api.HandleFunc("POST /widgets", createWidget) // method-prefixed
-api.HandleFunc("/widgets",       listWidgets) // bare path = GET
-
-app.Routes()                                  // []RouteInfo for boot logging
-```
-
-Group patterns follow `http.ServeMux` shape: `"GET /foo"`, `"POST /foo"`,
-or just `"/foo"` (defaults to GET). Mounting two routes at the same
-path panics at registration with the offending pattern and the
-original registrar tag. `WithNotFound(h)` installs a custom 404
-handler.
-
-## Plugins
-
-```go
-app := via.New(via.WithPlugins(
-    picocss.Plugin(picocss.WithThemes(picocss.AllPicoThemes)),
-    echarts.Plugin(),
-))
-```
-
-Plugins implement `Register(*via.App)` and call any of `AppendToHead`,
-`AppendToFoot`, `AppendAttrToHTML`, `HandleFunc`, or
-`RegisterAppSignal` during boot to inject document fragments, asset
-routes, and client-driven signals. Call these only from `Register` —
-the document-mutation slices are not lock-guarded against concurrent
-appends after the server starts.
-
-Plugin packages expose `Plugin(...)` as the canonical constructor
-(never `New(...)`) so `via.WithPlugins(...)` call sites stay uniform.
-
-## Testing
-
-Tests drive the composition through HTTP — same path as a real
-browser, so the full middleware stack, session cookie, and SSE
-machinery run end-to-end. There is no "direct method" seam: assertions
-hit rendered HTML or SSE frames, never internal state.
-
-```go
-import (
-    "github.com/go-via/via"
-    "github.com/go-via/via/vt"
-)
-
-var server *httptest.Server
-app := via.New(via.WithTestServer(&server))
-via.Mount[Counter](app, "/")
-
-tc := vt.NewClient(t, server, "/")
-c := &Counter{}
-require.Equal(t, 200, tc.Action(c.Inc).Fire())   // typed: typo → compile error
-require.Equal(t, 200, tc.Action("Apply").        // string still works
-    WithSignal("step", 5).Fire())
-require.Contains(t, tc.Reload(), ">1<")
-
-frames, cancel := tc.SSE()
-defer cancel()
-vt.AwaitFrame(t, frames, 2*time.Second, ">3<")
-
-tc.Action(p.Upload).
-    WithFile("avatar", "me.png", pngBytes).
-    WithSignal("note", "from CLI").
-    Fire()
-```
-
-`tc.Action` accepts a method value (compile-time typo protection) or
-the action's name as a string. `tc.Reload` re-fetches the mounted page
-so post-action body assertions are one call. `tc.Fork(path)` opens a
-second tab on the same cookie jar — the only way to drive `StateSess`
-behaviour that spans tabs.
-
-## Performance
-
-Bench files: [`bench_test.go`](bench_test.go) (full request → SSE
-turn) and [`h/h_bench_test.go`](h/h_bench_test.go) (DSL only). Run
-`go test -bench=. -benchmem` against your target hardware — quoting
-numbers from someone else's laptop is rarely useful. `ci-check.sh`
-gates the steady-state allocation floors on `CounterRender`,
-`CounterAction`, and `CounterActionWithLogger` so regressions fail CI.
-
-`h.Static(...)` pre-renders fragments that don't depend on per-request
-state — see `BenchmarkSysmonShape_staticChrome_render` for the
-per-tick allocation delta against rebuilding the same chrome on every
-tick.
-
-## h package helpers
-
-`h` is the HTML DSL — elements, attributes, text, iteration,
-conditionals, static pre-render, custom tags. The full reference lives
-in [`docs/h-helpers.md`](docs/h-helpers.md) and in
-[`go doc github.com/go-via/via/h`](https://pkg.go.dev/github.com/go-via/via/h).
-
-```go
-h.Div(h.Class("card"),
-    h.H1(h.T("Title")),
-    h.Each(items, func(it Item) h.H { return h.Li(h.T(it.Name)) }),
-)
-```
-
-`h.Static(n)` pre-renders fragments that don't depend on per-request
-state (layout chrome, headers); every later Render writes the captured
-bytes verbatim. `h.NewTag("svg")` declares constructors for tags
-outside the built-in list (web components, SVG, MathML).
-`h.With(base, more...)` extends an existing element non-destructively.
-
-## Cross-tab broadcast
-
-```go
-app.Broadcast(`alert("Maintenance in 30 seconds.")`)
-app.BroadcastSignals(map[string]any{"_systemNotice": "site read-only"})
-app.LiveTabs()
-```
-
-`Broadcast` queues a JS snippet on every live tab; `BroadcastSignals`
-queues a signal patch. Both return the tab count they reached and
-deliver via the existing patch queue + SSE drain — no extra wiring.
-
-## Production wiring
-
-```go
-app := via.New(
-    via.WithLang("en"),
-    via.WithLogger(via.SlogLogger(slog.Default())),
-    via.WithMaxRequestBody(1<<20),
-    via.WithMaxContexts(10000),
-    via.WithSSEHeartbeat(25*time.Second),
-)
-mw.Defaults(app)
-app.Use(mw.HSTS())
-app.Use(mw.CSP())
-app.Use(mw.RedirectHTTPS())
-
-via.Mount[Home](app, "/")
-api := app.Group("/api")
-api.Use(requireAuth)
-via.Mount[Profile](api, "/profile")
-
-http.ListenAndServe(":8080", app)
-```
-
-### Operations: metrics
-
-`via.WithMetrics(m)` accepts an implementation of the `Metrics`
-interface and emits structured events for ops dashboards:
-
-| Event                  | Kind      | Labels             |
-|------------------------|-----------|--------------------|
-| `via.action.total`     | counter   | `method`           |
-| `via.action.latency`   | histogram | `method`           |
-| `via.render.total`     | counter   | `route`            |
-| `via.sse.connect`      | counter   |                    |
-| `via.sse.disconnect`   | counter   |                    |
-| `via.ctx.live`         | gauge     |                    |
-
-Adapt to Prometheus, OTel, or expvar by implementing three methods
-(`Counter`, `Gauge`, `Histogram`) that forward to your backend.
-
-## Security defaults
-
-- CSRF: every page mints a 256-bit `via_tab` id; action POSTs and SSE
-  handshakes carry it as a signal. The id IS the CSRF token — unknown
-  ids 404. Action POSTs are also session-pinned (cookie mismatch → 403).
-- Sessions: `via_session` cookie is `HttpOnly`, `SameSite=Lax`, 256-bit,
-  and `Secure` by default; `WithInsecureCookies()` drops `Secure` for a
-  local http:// dev loop. After auth state changes, call
-  `sess.Rotate(ctx)` (session-fixation defence).
-- CSP: `mw.CSP()` emits a strict header with a per-request nonce
-  reachable via `ctx.CSPNonce()`.
-- Body limits: `WithMaxRequestBody(n)` (default 1 MiB) caps action
-  POST and SSE-close bodies; oversized requests return 413.
-- Panic sanitization: action panics surface as `"Something went wrong"`
-  to the client. User-returned errors flow through unmodified.
-- Random sources: `crypto/rand.Read` failures panic rather than fall
-  back to zero-byte ids.
-
-## Examples
-
-`internal/examples/` ships:
-
-- `counter` — `StateTab[int]` + `Signal[int]` + a typed action.
-- `greeter` — `Signal[string]` mutated from two distinct actions.
-- `pathparams` — typed `path:"id"` decoding into composition fields.
-- `countercomp` — two independent counter compositions nested on one
-  page; isolation across instances.
-- `counterscope` — `StateTab[int]` (tab-local) vs `StateApp[int]`
-  (shared across every session) side-by-side.
-- `picocss` — `picocss.Plugin()` driving theme + dark-mode switching
-  on the client without a full reload.
-- `auth` — typed sessions, `requireAuth` middleware, and `sess.Rotate`
-  after login.
-- `todos` — `StateSess[T]` survives reload, `h.Each`, and
-  `on.SetSignal` for client-bundled writes.
-- `sysmon` — OnConnect-driven ticker streaming CPU / RAM / disk / net
-  into ECharts; drives an interactive pause + interval-slider UI via
-  `via.Ticker.Pause / SetInterval`.
-- `upload` — `via.File` field bound to a `multipart/form-data` `<form>`
-  POST, persisted to disk, redirect-back-to-/.
-- `feed` — append-only / bounded-ring slice stream driven by
-  `Signal[[]T].Update`, paused/cleared from actions.
-
 ```bash
 go run ./internal/examples/counter
 ```
 
-## Configuration
+![Two browsers, two scopes — StateTab is per-tab, StateApp is shared across every session.](docs/counter-scope.gif)
 
-Every `WithX(...)` option is documented in
-[`go doc github.com/go-via/via`](https://pkg.go.dev/github.com/go-via/via)
-with its default and behaviour. Common production knobs:
+## The four reactive shapes
 
-- `WithMaxContexts(n)`, `WithLogger(SlogLogger(...))`,
-  `WithInsecureCookies()` (dev opt-out — `Secure` is on by default)
-- `WithMaxRequestBody(n)`, `WithSessionTTL(d)`, `WithContextTTL(d)`
-- `WithSSEHeartbeat(d)`, `WithReadHeaderTimeout(d)`,
-  `WithIdleTimeout(d)`
-- `WithActionErrorHandler(fn)`, `WithNotFound(h)`,
-  `WithHTTPServer(hook)`
+Whether state lives on the client, the server, or both is the field's type:
+
+| Handle | Scope | Lives on |
+|---|---|---|
+| `via.Signal[T]` | per-tab | client + server |
+| `via.StateTab[T]` | per-tab | server only |
+| `via.StateSess[T]` | per-session | server only |
+| `via.StateApp[T]` | global | server only |
+
+`Read(ctx)` / `Update(ctx, fn)` everywhere; `Signal` and `StateTab` add `Write(ctx, v)`. The `Num` / `Bool` / `Str` / `Slice` / `Map` wrappers add typed `Op(ctx)` verbs (`Add`, `Toggle`, `Append`, …). [Full model →](https://go-via.github.io/via/reactive-state)
+
+## What Via is — and is not
+
+- **Is:** server-rendered pages with typed end-to-end state, a fine-grained reactive client runtime (Datastar / Alien Signals), and no build step — best for internal tools, dashboards, and line-of-business apps you'd otherwise build with LiveView, Hotwire, or htmx + hand-written JS.
+- **Is not** an SPA framework — the browser receives HTML, not a JSON bundle.
+- **Is not** a cluster runtime — `StateApp[T]` and `Broadcast` are single-process; horizontal scaling needs sticky sessions.
+- **Is not** offline-first or stable yet — drop the SSE stream and the tab freezes until the client reconnects (Datastar retries automatically), and APIs can still shift pre-1.0.
+
+## Documentation
+
+The full guide and reference live at **[go-via.github.io/via](https://go-via.github.io/via)**.
+
+- [Why Via](https://go-via.github.io/via/why-via) — the thesis, and Via vs. LiveView / Hotwire / htmx / templ.
+- [Getting started](https://go-via.github.io/via/getting-started) · [Tutorial](https://go-via.github.io/via/tutorial) — install, first composition, then build the live chatroom.
+- [Reactive state](https://go-via.github.io/via/reactive-state) — `Signal` vs `StateTab/Sess/App`, typed ops, view helpers.
+- [Actions & lifecycle](https://go-via.github.io/via/actions-and-lifecycle) — events, hooks, streaming, broadcast.
+- [Rendering](https://go-via.github.io/via/rendering) · [h helpers](https://go-via.github.io/via/h-helpers) — the HTML DSL.
+- [Routing, sessions & middleware](https://go-via.github.io/via/routing-sessions-middleware) · [File uploads](https://go-via.github.io/via/file-uploads) · [Plugins](https://go-via.github.io/via/plugins).
+- [Testing](https://go-via.github.io/via/testing) · [Production & ops](https://go-via.github.io/via/production) — config, metrics, security, deploys.
+- [Examples](https://go-via.github.io/via/examples) · [Troubleshooting](https://go-via.github.io/via/troubleshooting) · [Glossary](https://go-via.github.io/via/glossary).
 
 ## License
 

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,4 @@
+_site/
+.jekyll-cache/
+.jekyll-metadata
+.sass-cache/

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,10 @@
+source "https://rubygems.org"
+
+# Pinned so CI and local previews build the same site. just-the-docs 0.10.x
+# targets Jekyll 4; the Pages workflow uses this Gemfile rather than the
+# classic GitHub Pages gem set.
+gem "jekyll", "~> 4.4"
+gem "just-the-docs", "0.10.1"
+
+# webrick is no longer bundled with Ruby 3.x; needed for `jekyll serve`.
+gem "webrick", "~> 1.9"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -15,11 +15,27 @@ baseurl: /via
 color_scheme: dark
 search_enabled: true
 heading_anchors: true
+back_to_top: true
+back_to_top_text: "Back to top"
+
+# "Edit this page on GitHub" link in every page footer. Pages live in docs/.
+gh_edit_link: true
+gh_edit_link_text: "Edit this page on GitHub"
+gh_edit_repository: "https://github.com/go-via/via"
+gh_edit_branch: "main"
+gh_edit_source: docs
+gh_edit_view_mode: "tree"
 
 aux_links:
   GitHub: https://github.com/go-via/via
   pkg.go.dev: https://pkg.go.dev/github.com/go-via/via
 aux_links_new_tab: true
+
+nav_external_links:
+  - title: Changelog (GitHub Releases)
+    url: https://github.com/go-via/via/releases
+  - title: API reference (pkg.go.dev)
+    url: https://pkg.go.dev/github.com/go-via/via
 
 callouts:
   note:

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,38 @@
+title: Via
+description: >-
+  Reactive web apps in pure Go. Typed client/server state, no build step,
+  SSE-only transport.
+
+# Built and deployed by .github/workflows/pages.yml with a pinned
+# just-the-docs gem (see docs/Gemfile), so the theme version is locked
+# rather than tracking a remote default.
+theme: just-the-docs
+
+# Project page lives at https://go-via.github.io/via
+url: https://go-via.github.io
+baseurl: /via
+
+color_scheme: dark
+search_enabled: true
+heading_anchors: true
+
+aux_links:
+  GitHub: https://github.com/go-via/via
+  pkg.go.dev: https://pkg.go.dev/github.com/go-via/via
+aux_links_new_tab: true
+
+callouts:
+  note:
+    title: Note
+    color: blue
+  warning:
+    title: Heads up
+    color: red
+
+footer_content: >-
+  Via is MIT licensed. Pre-1.0 — APIs may shift between minor versions.
+
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - vendor

--- a/docs/_includes/head_custom.html
+++ b/docs/_includes/head_custom.html
@@ -1,0 +1,11 @@
+<!-- Social / Open Graph cards. just-the-docs includes this in <head>. -->
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="{{ site.title }}">
+<meta property="og:title" content="{% if page.title %}{{ page.title }} · {% endif %}{{ site.title }}">
+<meta property="og:description" content="{{ page.description | default: site.description | strip_newlines }}">
+<meta property="og:url" content="{{ page.url | absolute_url }}">
+<meta property="og:image" content="{{ '/counter-scope.gif' | absolute_url }}">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{% if page.title %}{{ page.title }} · {% endif %}{{ site.title }}">
+<meta name="twitter:description" content="{{ page.description | default: site.description | strip_newlines }}">
+<meta name="twitter:image" content="{{ '/counter-scope.gif' | absolute_url }}">

--- a/docs/actions-and-lifecycle.md
+++ b/docs/actions-and-lifecycle.md
@@ -1,0 +1,95 @@
+---
+title: Actions & lifecycle
+nav_order: 4
+---
+
+# Actions & lifecycle
+{: .no_toc }
+
+1. TOC
+{:toc}
+
+## Actions
+
+A method on the composition with signature `func(*via.Ctx) error` — or
+`func(*via.Ctx)` when nothing in the body can fail meaningfully — is an
+action. Bind it to a DOM event with the `on` sub-package:
+
+```go
+h.Button(h.Text("+"), on.Click(c.Inc))
+h.Form(on.Submit(c.Save), ...)
+h.Input(on.Input(c.Filter, on.Debounce("200ms")))
+h.Div(on.Key("Enter", c.Send))
+h.Button(h.Text("Pick blue"),
+    on.Click(c.Apply, on.SetSignal(&c.Theme, "blue")))
+```
+
+`on.SetSignal(&c.Field, value)` bundles a typed signal write with the action
+so the value updates client-side before the POST fires. `&c.Theme` is
+type-checked against the field — the wrong type is a compile error.
+
+Named event helpers include `Click`, `Change`, `Input`, `Submit`, `Focus`,
+`Blur`, `DblClick`, `MouseEnter`, `MouseLeave`, `Load`, and `Key`; use
+`on.Event("name", fn, ...)` for anything else. Modifiers like
+`on.Debounce`, `on.Throttle`, and `on.Prevent` attach to any of them.
+
+## What an action body can do
+
+- Write typed state: `c.Hits.Write(ctx, …)` or `c.Hits.Op(ctx).Add(1)`.
+- Push targeted patches: `ctx.Patch.Elements(h.Ul(h.ID("list"), …))`.
+- Push raw signals: `ctx.Patch.Signal("_picoTheme", "purple")`.
+- Show a quick toast: `ctx.Toast("saved!")` — a styled, non-blocking notice
+  that auto-dismisses (JSON-safe, zero setup).
+- Redirect: `ctx.Redirect("/profile")`. Only http/https/relative URLs are
+  honoured; `javascript:`, `data:`, protocol-relative `//`, and backslash
+  variants are dropped and logged (open-redirect / XSS defence).
+- Decode the request payload into a typed struct:
+
+  ```go
+  var f LoginForm
+  via.DecodeForm(ctx, &f)
+  ```
+
+Per-tab actions are serialized: concurrent POSTs to one tab cannot race on
+State writes.
+
+{: .note }
+For try-before-commit and bulk reconciliation flows, `ctx.SyncOff()` opts
+the whole action out of the dirty-mark/flush cycle — see godoc.
+
+## Lifecycle hooks
+
+| Method | Fires when |
+|---|---|
+| `OnInit(ctx) error` | Before View on the page-load request |
+| `OnConnect(ctx) error` | First time the SSE stream opens (one-shot) |
+| `OnDispose(ctx)` | Tab closed, ctx swept, or app shut down |
+| `View(ctx) h.H` | Required; renders the composition |
+
+Implement any subset; `Mount` detects whichever are defined. `OnConnect` is
+where long-running per-tab work belongs — bots that hit GET without ever
+opening the SSE never trigger it.
+
+## Streaming with `via.Stream`
+
+`via.Stream(ctx, interval, fn)` wires the most common ticker pattern:
+
+```go
+func (p *Page) OnConnect(ctx *via.Ctx) error {
+    via.Stream(ctx, time.Second, func(ctx *via.Ctx, t time.Time) {
+        p.Now.Write(ctx, t.Format("15:04:05"))
+    })
+    return nil
+}
+```
+
+`Stream` returns a `*via.Ticker` with `Pause`, `Resume`, `Stop`, and
+`SetInterval(d)` so actions can toggle the stream or change cadence at
+runtime. The controls are nil-safe and `Stop` is idempotent. See
+`internal/examples/sysmon` for a full pause / rate-change UI driven by this
+surface.
+
+Inside actions and `via.Stream` callbacks the flush is automatic. From a raw
+goroutine you started yourself, call `ctx.SyncNow()` to force a re-render and
+push pending writes — it serialises with in-flight action handlers via the
+per-tab action mutex.

--- a/docs/actions-and-lifecycle.md
+++ b/docs/actions-and-lifecycle.md
@@ -1,6 +1,7 @@
 ---
 title: Actions & lifecycle
-nav_order: 4
+parent: Guides
+nav_order: 1
 ---
 
 # Actions & lifecycle
@@ -64,7 +65,12 @@ the whole action out of the dirty-mark/flush cycle — see godoc.
 | `OnInit(ctx) error` | Before View on the page-load request |
 | `OnConnect(ctx) error` | First time the SSE stream opens (one-shot) |
 | `OnDispose(ctx)` | Tab closed, ctx swept, or app shut down |
-| `View(ctx) h.H` | Required; renders the composition |
+| `View(ctx *via.CtxR) h.H` | Required; renders the composition |
+
+`View` receives `*via.CtxR` — a **read-only** render context. You can read
+state during a render but cannot mutate it; mutations happen in actions and
+lifecycle hooks, which receive the full `*via.Ctx`. That split is enforced by
+the type, not by convention.
 
 Implement any subset; `Mount` detects whichever are defined. `OnConnect` is
 where long-running per-tab work belongs — bots that hit GET without ever

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -5,17 +5,23 @@ nav_order: 3
 
 # Examples
 
-Eleven runnable example apps ship in
+Twelve runnable example apps ship in
 [`internal/examples/`](https://github.com/go-via/via/tree/main/internal/examples).
 Each is a single `main.go` you can read in a sitting and run directly:
 
 ```bash
-go run ./internal/examples/counter
-# then open http://localhost:3000 (or the port the example prints)
+go run ./internal/examples/chat
+# open http://localhost:3000 in two browser windows — messages sync live
 ```
+
+⭐ The flagship is
+**[chat](https://github.com/go-via/via/tree/main/internal/examples/chat)** — a
+live multi-user chatroom in ~60 lines of Go, no WebSocket and no client JS,
+walked through step by step in the [tutorial](tutorial).
 
 | Example | What it teaches |
 |---|---|
+| [chat](https://github.com/go-via/via/tree/main/internal/examples/chat) ⭐ | A live multi-user chatroom: `StateAppSlice` fan-out delivers each message to every connected browser — no WebSocket, no JS. The [tutorial](tutorial) builds it. |
 | [counter](https://github.com/go-via/via/tree/main/internal/examples/counter) | `StateTab[int]` + `Signal[int]` + a typed action — the canonical first app. |
 | [greeter](https://github.com/go-via/via/tree/main/internal/examples/greeter) | A `Signal[string]` mutated from two distinct actions. |
 | [pathparams](https://github.com/go-via/via/tree/main/internal/examples/pathparams) | Typed `path:"id"` decoding into composition fields. |
@@ -23,10 +29,10 @@ go run ./internal/examples/counter
 | [counterscope](https://github.com/go-via/via/tree/main/internal/examples/counterscope) | `StateTab[int]` (tab-local) vs `StateApp[int]` (shared across every session) side by side. |
 | [picocss](https://github.com/go-via/via/tree/main/internal/examples/picocss) | `picocss.Plugin()` driving theme + dark-mode switching on the client without a reload. |
 | [auth](https://github.com/go-via/via/tree/main/internal/examples/auth) | Typed sessions, `requireAuth` middleware, and `sess.Rotate` after login. |
-| [todos](https://github.com/go-via/via/tree/main/internal/examples/todos) | `StateSess[T]` survives reload, `h.Each`, and `on.SetSignal` for client-bundled writes — the basis of the [tutorial](tutorial). |
+| [todos](https://github.com/go-via/via/tree/main/internal/examples/todos) | `StateSess[T]` survives reload, `h.Each`, and `on.SetSignal` for client-bundled writes. |
 | [sysmon](https://github.com/go-via/via/tree/main/internal/examples/sysmon) | An `OnConnect`-driven ticker streaming CPU / RAM / disk / net into ECharts, with a pause + interval-slider UI via `via.Ticker`. |
 | [upload](https://github.com/go-via/via/tree/main/internal/examples/upload) | A `via.File` field bound to a `multipart/form-data` `<form>`, persisted to disk with a redirect back. |
 | [feed](https://github.com/go-via/via/tree/main/internal/examples/feed) | An append-only / bounded-ring slice stream driven by `Signal[[]T].Update`, paused and cleared from actions. |
 
 New to Via? Read [Getting started](getting-started), then walk through the
-[todo-app tutorial](tutorial).
+[live-chatroom tutorial](tutorial).

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,32 @@
+---
+title: Examples
+nav_order: 3
+---
+
+# Examples
+
+Eleven runnable example apps ship in
+[`internal/examples/`](https://github.com/go-via/via/tree/main/internal/examples).
+Each is a single `main.go` you can read in a sitting and run directly:
+
+```bash
+go run ./internal/examples/counter
+# then open http://localhost:3000 (or the port the example prints)
+```
+
+| Example | What it teaches |
+|---|---|
+| [counter](https://github.com/go-via/via/tree/main/internal/examples/counter) | `StateTab[int]` + `Signal[int]` + a typed action — the canonical first app. |
+| [greeter](https://github.com/go-via/via/tree/main/internal/examples/greeter) | A `Signal[string]` mutated from two distinct actions. |
+| [pathparams](https://github.com/go-via/via/tree/main/internal/examples/pathparams) | Typed `path:"id"` decoding into composition fields. |
+| [countercomp](https://github.com/go-via/via/tree/main/internal/examples/countercomp) | Two independent counter compositions nested on one page; isolation across instances. |
+| [counterscope](https://github.com/go-via/via/tree/main/internal/examples/counterscope) | `StateTab[int]` (tab-local) vs `StateApp[int]` (shared across every session) side by side. |
+| [picocss](https://github.com/go-via/via/tree/main/internal/examples/picocss) | `picocss.Plugin()` driving theme + dark-mode switching on the client without a reload. |
+| [auth](https://github.com/go-via/via/tree/main/internal/examples/auth) | Typed sessions, `requireAuth` middleware, and `sess.Rotate` after login. |
+| [todos](https://github.com/go-via/via/tree/main/internal/examples/todos) | `StateSess[T]` survives reload, `h.Each`, and `on.SetSignal` for client-bundled writes — the basis of the [tutorial](tutorial). |
+| [sysmon](https://github.com/go-via/via/tree/main/internal/examples/sysmon) | An `OnConnect`-driven ticker streaming CPU / RAM / disk / net into ECharts, with a pause + interval-slider UI via `via.Ticker`. |
+| [upload](https://github.com/go-via/via/tree/main/internal/examples/upload) | A `via.File` field bound to a `multipart/form-data` `<form>`, persisted to disk with a redirect back. |
+| [feed](https://github.com/go-via/via/tree/main/internal/examples/feed) | An append-only / bounded-ring slice stream driven by `Signal[[]T].Update`, paused and cleared from actions. |
+
+New to Via? Read [Getting started](getting-started), then walk through the
+[todo-app tutorial](tutorial).

--- a/docs/file-uploads.md
+++ b/docs/file-uploads.md
@@ -1,6 +1,7 @@
 ---
 title: File uploads
-nav_order: 7
+parent: Guides
+nav_order: 4
 ---
 
 # File uploads
@@ -18,7 +19,11 @@ func (p *Page) Upload(ctx *via.Ctx) error {
     if !p.Avatar.Present() {
         return nil
     }
-    return p.Avatar.Save("/var/uploads/" + sanitized)
+    // Never build a path from the client-supplied Filename(). Generate your
+    // own collision-resistant name and keep only the (validated) extension.
+    // newID() is yours — e.g. a DB key or crypto/rand token.
+    dst := filepath.Join("/var/uploads", newID()+filepath.Ext(p.Avatar.Filename()))
+    return p.Avatar.Save(dst)
 }
 ```
 

--- a/docs/file-uploads.md
+++ b/docs/file-uploads.md
@@ -1,0 +1,56 @@
+---
+title: File uploads
+nav_order: 7
+---
+
+# File uploads
+
+Add a `via.File` field. The action dispatcher detects multipart bodies and
+binds the named part for the duration of the action:
+
+```go
+type Page struct {
+    Avatar via.File           `via:"avatar"`
+    Note   via.Signal[string] `via:"note"`
+}
+
+func (p *Page) Upload(ctx *via.Ctx) error {
+    if !p.Avatar.Present() {
+        return nil
+    }
+    return p.Avatar.Save("/var/uploads/" + sanitized)
+}
+```
+
+The handle exposes:
+
+- `Present()` — whether a part was uploaded for this field.
+- `Filename()` — client-supplied name (**untrusted** — never use as a path).
+- `Size()` — part body size in bytes.
+- `ContentType()` — client-claimed type (**untrusted**).
+- `Open()` — `multipart.File` stream; caller closes.
+- `Bytes()` — read the whole body into memory.
+- `Save(path)` — stream to disk, mode `0o600`, truncate. Use a path you
+  generated, never the client `Filename()`, to avoid path traversal.
+
+Text fields in the same multipart POST populate `Signal[T]` fields just like
+a JSON action body.
+
+## Raw streaming control
+
+For mixed parts, custom headers, or files larger than the in-memory buffer,
+call `ctx.MultipartReader()`:
+
+```go
+mr, err := ctx.MultipartReader()
+```
+
+Once read, typed `via.File` fields on the same action will be empty for any
+parts already advanced past.
+
+{: .note }
+`WithMaxRequestBody(n)` caps total body size (default 1 MiB); oversized
+requests return `413 Request Entity Too Large`.
+
+See `internal/examples/upload` for a `<form>`-driven upload persisted to
+disk with a redirect-back-to-`/`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,90 @@
+---
+title: Getting started
+nav_order: 2
+---
+
+# Getting started
+{: .no_toc }
+
+1. TOC
+{:toc}
+
+## Install
+
+```bash
+go get github.com/go-via/via
+```
+
+Via targets a current Go toolchain and has no build step, code generation,
+or template files.
+
+## Your first composition
+
+A composition is a Go struct. Reactive state is a typed field, actions are
+methods, and `View` renders it.
+
+```go
+package main
+
+import (
+    "net/http"
+
+    "github.com/go-via/via"
+    "github.com/go-via/via/h"
+    "github.com/go-via/via/on"
+)
+
+type Counter struct {
+    Hits via.StateTabNum[int]
+    Step via.SignalNum[int] `via:"step,init=1"`
+}
+
+func (c *Counter) Inc(ctx *via.Ctx) {
+    _ = c.Hits.Update(ctx, func(n int) (int, error) {
+        return n + c.Step.Read(ctx), nil
+    })
+}
+
+func (c *Counter) View(ctx *via.CtxR) h.H {
+    return h.Div(
+        h.P(h.Text("Count: "), c.Hits.Text(ctx)),
+        h.Input(h.Type("number"), c.Step.Bind()),
+        h.Button(h.Text("+"), on.Click(c.Inc)),
+    )
+}
+
+func main() {
+    app := via.New()
+    via.Mount[Counter](app, "/")
+    _ = http.ListenAndServe(":3000", app)
+}
+```
+
+```bash
+go run .
+# open http://localhost:3000
+```
+
+No template files. No build step. No hand-written JavaScript.
+`on.Click(c.Inc)` is a typed method reference — a typo is a compile error.
+
+## What just happened
+
+- `Step` is a `SignalNum[int]` — a **client** signal. The `<input>` it binds
+  to (`c.Step.Bind()`) mutates it in the browser with no round-trip.
+- `Hits` is a `StateTabNum[int]` — **server-only**, per-tab. It changes only
+  through the `Inc` action.
+- `Inc` runs server-side, reads the current client `Step`, and updates
+  `Hits`. The next flush diffs the `View` and ships a targeted DOM patch
+  over the tab's SSE stream — `c.Hits.Text(ctx)` updates in place.
+
+The whole client/server split is visible in the field types. See
+[Reactive state](reactive-state) for the full model.
+
+## Next steps
+
+- [Reactive state](reactive-state) — the four shapes, scopes, and typed ops.
+- [Actions & lifecycle](actions-and-lifecycle) — events, hooks, streaming.
+- [Rendering (h)](rendering) — the HTML DSL.
+- [Testing](testing) — drive compositions over HTTP with `vt`.
+- Browse `internal/examples/` in the repo (`go run ./internal/examples/counter`).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,7 @@
 ---
 title: Getting started
-nav_order: 2
+parent: Learn
+nav_order: 1
 ---
 
 # Getting started

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,62 @@
+---
+title: Glossary
+parent: Reference & ops
+nav_order: 5
+---
+
+# Glossary
+
+Short definitions for the vocabulary used across these docs.
+
+**Composition** — a Go struct that defines a piece of UI: reactive state as
+typed fields, actions as methods, and a `View`. Mounted at a route with
+`via.Mount[T]`.
+
+**Signal (`Signal[T]`)** — client-owned reactive state, mirrored into the
+browser's Alien Signals graph. Bind it to inputs and view helpers; it reacts
+client-side with no round-trip.
+
+**State (`StateTab[T]` / `StateSess[T]` / `StateApp[T]`)** — server-owned
+reactive state at per-tab, per-session, and global scope respectively. Lives
+only in Go; changes flow to the client through a re-render. See
+[Reactive state](reactive-state).
+
+**Alien Signals graph** — the fine-grained client-side reactivity engine
+Datastar runs in the browser. `Signal[T]` values are nodes in it; `data-*`
+attributes are subscriptions.
+
+**Datastar** — the client runtime Via targets. Via emits the `data-*`
+attributes and SSE patches that drive it; you don't write Datastar by hand.
+
+**Action** — a composition method (`func(*via.Ctx) error` or
+`func(*via.Ctx)`) bound to a DOM event with the `on` package. Runs
+server-side; per-tab actions are serialized by the action mutex.
+
+**View / render** — the `View(ctx *via.CtxR) h.H` method that produces the
+page's HTML tree. Read-only: it can read state but not mutate it.
+
+**Flush** — the moment after an action (or `via.Stream` callback) when Via
+diffs the View against the previous emission and ships the resulting
+element/attribute patches plus signal deltas over SSE.
+
+**Dirty-mark** — the internal flag set when a write changes state, telling
+the next flush that a re-render and patch are needed. `ctx.SyncOff()` opts an
+action out of this cycle.
+
+**Morph** — applying a DOM patch in place rather than replacing nodes, so
+focus, scroll, and element identity are preserved. `h.DataIgnoreMorph()`
+opts an element out.
+
+**Action mutex** — the per-tab lock that serializes action handlers (and
+`SyncNow`) so concurrent POSTs to one tab cannot race on state writes.
+
+**`via_tab` / `via_session`** — the per-tab id (also the CSRF token) and the
+session cookie. Unknown `via_tab` ids 404; the session cookie is `HttpOnly`,
+`SameSite=Lax`, and `Secure` by default. See
+[Production & ops](production#security-defaults).
+
+**SSE (Server-Sent Events)** — the one-way server→client stream Via uses for
+all live updates: one stream per tab, no WebSockets.
+
+**Ticker (`via.Ticker`)** — the handle returned by `via.Stream` to pause,
+resume, stop, or re-time a server-push loop.

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -1,0 +1,15 @@
+---
+title: Guides
+nav_order: 5
+has_children: true
+---
+
+# Guides
+
+Task-focused references for the parts of an app.
+
+- [Actions & lifecycle](actions-and-lifecycle) — events, hooks, streaming.
+- [Rendering (h)](rendering) — the HTML DSL.
+- [Routing, sessions & middleware](routing-sessions-middleware).
+- [File uploads](file-uploads) — the `via.File` field.
+- [Plugins](plugins) — picocss, echarts, and writing your own.

--- a/docs/h-helpers.md
+++ b/docs/h-helpers.md
@@ -1,6 +1,7 @@
 ---
 title: h helpers reference
-nav_order: 11
+parent: Reference & ops
+nav_order: 3
 ---
 
 # `h` package helpers
@@ -87,7 +88,7 @@ chrome := h.Static(h.Fragment(
         h.Ul(h.Li(h.Strong(h.T("System Monitor"))))),
 ))
 
-func (p *Page) View(ctx *via.Ctx) h.H {
+func (p *Page) View(ctx *via.CtxR) h.H {
     return h.Div(chrome, p.body(ctx))
 }
 ```

--- a/docs/h-helpers.md
+++ b/docs/h-helpers.md
@@ -1,3 +1,8 @@
+---
+title: h helpers reference
+nav_order: 11
+---
+
 # `h` package helpers
 
 Full reference for [`github.com/go-via/via/h`](https://pkg.go.dev/github.com/go-via/via/h).

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,37 +11,62 @@ a typed field. Actions are methods. The compiler understands your UI.
 {: .fs-6 .fw-300 }
 
 [Get started](getting-started){: .btn .btn-primary .mr-2 }
+[Why Via?](why-via){: .btn .mr-2 }
 [View on GitHub](https://github.com/go-via/via){: .btn }
-[API reference](https://pkg.go.dev/github.com/go-via/via){: .btn }
 
 ---
+
+A complete Via app — a counter whose **step** is client-owned and whose
+**count** is server-owned. No template files, no build step, no hand-written
+JavaScript:
+
+```go
+type Counter struct {
+    Hits via.StateTabNum[int]                     // server-owned, per tab
+    Step via.SignalNum[int] `via:"step,init=1"`   // client-owned, in the browser
+}
+
+func (c *Counter) Inc(ctx *via.Ctx) {
+    _ = c.Hits.Update(ctx, func(n int) (int, error) {
+        return n + c.Step.Read(ctx), nil
+    })
+}
+
+func (c *Counter) View(ctx *via.CtxR) h.H {
+    return h.Div(
+        h.P(h.Text("Count: "), c.Hits.Text(ctx)),
+        h.Input(h.Type("number"), c.Step.Bind()),
+        h.Button(h.Text("+"), on.Click(c.Inc)),
+    )
+}
+```
+
+[Build and run it →](getting-started){: .btn .btn-outline }
+
+## What makes Via different
 
 Via is the only framework — in any language — that expresses the
 client/server reactive split as a Go type. `Signal[T]` is a client signal,
 mirrored to a fine-grained Alien Signals graph in the browser via Datastar.
-`StateTab[T]`, `StateSess[T]`, `StateApp[T]` are server-only. Whether a
-piece of UI state round-trips or doesn't is a choice made at the field
-declaration, checked by the compiler, not by a convention you can grep for.
-Transport is SSE only — one stream per tab — so there are no WebSockets to
-wrestle with a corporate proxy.
+`StateTab[T]`, `StateSess[T]`, `StateApp[T]` are server-only. Whether a piece
+of UI state round-trips or doesn't is a choice made at the field declaration,
+checked by the compiler, not by a convention you can grep for. Transport is
+SSE only — one stream per tab — so there are no WebSockets to wrestle with a
+corporate proxy.
 
 ![Two browsers, two scopes — StateTabNum[int] is per-tab, StateAppNum[int]
 is shared across every session.](counter-scope.gif)
 
-**Best fit:** internal tools, admin dashboards, line-of-business apps, and
-hobby projects — anywhere you would otherwise reach for Phoenix LiveView,
-Hotwire, or htmx + hand-written JS, but want to stay in Go.
-
 ## The thesis: the client/server split is a Go type
 
-Every server-rendered framework eventually faces the question "is this
-state client-owned or server-owned?" In every other ecosystem the answer
-is a convention. In Via it is the field's type.
+Every server-rendered framework eventually faces the question "is this state
+client-owned or server-owned?" In every other ecosystem the answer is a
+convention. In Via it is the field's type.
 
 Declare client-owned state as `Signal[T]`. Declare server-owned state as
-`StateTab[T]`, `StateSess[T]`, or `StateApp[T]`. The compiler enforces
-which side owns what. View helpers, actions, and lifecycle hooks all see
-the correct shape.
+`StateTab[T]`, `StateSess[T]`, or `StateApp[T]`. The compiler enforces which
+side owns what. View helpers, actions, and lifecycle hooks all see the
+correct shape.
 
 ```go
 type Page struct {
@@ -55,10 +80,9 @@ type Page struct {
 ```
 
 `Theme` mutates inside the browser — flipping it from an `<input>` does not
-POST. `Hits` mutates only through an action handler; the next flush diffs
-the View and ships targeted DOM patches over SSE.
-
-The four reactive shapes are covered in [Reactive state](reactive-state).
+POST. `Hits` mutates only through an action handler; the next flush diffs the
+View and ships targeted DOM patches over SSE. The four reactive shapes are
+covered in [Reactive state](reactive-state).
 
 ## How reactivity runs
 
@@ -81,39 +105,10 @@ view reactivity. UI state the client owns (modal open, current tab, filter
 string) reacts instantly with zero SSE traffic; state the server owns (DB
 rows, cross-tab invariants, secrets) flows through actions and re-renders.
 
-## What Via is NOT
+## Where to go next
 
-Read this before adopting. The non-goals are deliberate.
-
-- **Not an SPA framework.** Routes are server-rendered pages. The browser
-  receives HTML, not a JSON bundle.
-- **Not a cluster runtime.** `StateApp[T]` and `Broadcast` are
-  single-process. Horizontal scaling requires sticky sessions; App state is
-  per-pod. There is no built-in fan-out across instances.
-- **Not offline-first.** Disconnect the SSE stream and the tab freezes
-  until reconnect — Via is for connected sessions, not PWAs.
-- **Not a JavaScript replacement.** The browser still runs Datastar's Alien
-  Signals graph. Via removes hand-written JS for the reactivity layer, not
-  the runtime.
-- **Not a build-step framework.** There is no `via generate`. If you want a
-  code-gen template language, look at `templ`.
-- **Not stable yet** — pre-1.0, APIs can shift between minor versions. The
-  Datastar dependency is load-bearing.
-
-See [Production & ops](production#restart-and-tab-survivability) for what
-does and doesn't survive a process restart.
-
-## Why Via, not X
-
-| | Language | Authoring | Client runtime | Build step | Reactive state |
-|---|---|---|---|---|---|
-| **Via** | Go | typed structs + `h` DSL | Datastar (Alien Signals) | none | typed fields, client + server |
-| HTMX | any | HTML + `hx-*` attributes | tiny attribute interpreter | none | server-only, manual |
-| Phoenix LiveView | Elixir | EEx templates + macros | morphdom + tiny JS | none | `assigns` (Elixir-typed) |
-| Hotwire (Turbo) | Ruby | ERB + Turbo Streams | Turbo (WebSocket) | none | server-only, untyped DOM |
-| templ | Go | `.templ` template files | none (BYO) | yes (`templ generate`) | none built-in |
-| Datastar (direct) | any | HTML + `data-*` attrs | Datastar (Alien Signals) | none | client signals, manual |
-
-Via is the only row that gives you typed end-to-end state (server + client)
-with no build step, SSE-only transport, and a fine-grained reactive client
-runtime in the same import.
+- **New here?** [Getting started](getting-started), then the
+  [todo-app tutorial](tutorial).
+- **Evaluating Via?** [Why Via](why-via) — the comparison matrix and the
+  deliberate non-goals.
+- **Want working code?** Browse the [examples](examples).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,119 @@
+---
+title: Home
+nav_order: 1
+---
+
+# Via
+{: .fs-9 }
+
+Reactive web apps in pure Go. A composition is a struct. Reactive state is
+a typed field. Actions are methods. The compiler understands your UI.
+{: .fs-6 .fw-300 }
+
+[Get started](getting-started){: .btn .btn-primary .mr-2 }
+[View on GitHub](https://github.com/go-via/via){: .btn }
+[API reference](https://pkg.go.dev/github.com/go-via/via){: .btn }
+
+---
+
+Via is the only framework — in any language — that expresses the
+client/server reactive split as a Go type. `Signal[T]` is a client signal,
+mirrored to a fine-grained Alien Signals graph in the browser via Datastar.
+`StateTab[T]`, `StateSess[T]`, `StateApp[T]` are server-only. Whether a
+piece of UI state round-trips or doesn't is a choice made at the field
+declaration, checked by the compiler, not by a convention you can grep for.
+Transport is SSE only — one stream per tab — so there are no WebSockets to
+wrestle with a corporate proxy.
+
+![Two browsers, two scopes — StateTabNum[int] is per-tab, StateAppNum[int]
+is shared across every session.](counter-scope.gif)
+
+**Best fit:** internal tools, admin dashboards, line-of-business apps, and
+hobby projects — anywhere you would otherwise reach for Phoenix LiveView,
+Hotwire, or htmx + hand-written JS, but want to stay in Go.
+
+## The thesis: the client/server split is a Go type
+
+Every server-rendered framework eventually faces the question "is this
+state client-owned or server-owned?" In every other ecosystem the answer
+is a convention. In Via it is the field's type.
+
+Declare client-owned state as `Signal[T]`. Declare server-owned state as
+`StateTab[T]`, `StateSess[T]`, or `StateApp[T]`. The compiler enforces
+which side owns what. View helpers, actions, and lifecycle hooks all see
+the correct shape.
+
+```go
+type Page struct {
+    // Client-owned. Lives in the browser's Alien Signals graph.
+    // Bind to <input>; mutate without a round-trip.
+    Theme via.Signal[string] `via:"theme,init=auto"`
+
+    // Server-owned. Lives only in Go. Re-renders re-emit the value.
+    Hits  via.StateTab[int]
+}
+```
+
+`Theme` mutates inside the browser — flipping it from an `<input>` does not
+POST. `Hits` mutates only through an action handler; the next flush diffs
+the View and ships targeted DOM patches over SSE.
+
+The four reactive shapes are covered in [Reactive state](reactive-state).
+
+## How reactivity runs
+
+```
+   ┌──────────────────────────┐                       ┌──────────────────────────┐
+   │  Browser                 │  ◀──── SSE patches ── │  Server (Go)             │
+   │                          │     + signal deltas   │                          │
+   │  Alien Signals graph     │                       │  Compositions            │
+   │   Signal[T] nodes        │                       │   StateTab[T]            │
+   │   data-* subscriptions   │                       │   StateSess[T]           │
+   │                          │                       │   StateApp[T]            │
+   │                          │  ────── POST ──────▶  │   per-tab action mutex   │
+   │                          │       actions         │                          │
+   └──────────────────────────┘                       └──────────────────────────┘
+        view reactivity                                  truth + side effects
+```
+
+Two reactive runtimes, one typed boundary. Go owns truth; the client owns
+view reactivity. UI state the client owns (modal open, current tab, filter
+string) reacts instantly with zero SSE traffic; state the server owns (DB
+rows, cross-tab invariants, secrets) flows through actions and re-renders.
+
+## What Via is NOT
+
+Read this before adopting. The non-goals are deliberate.
+
+- **Not an SPA framework.** Routes are server-rendered pages. The browser
+  receives HTML, not a JSON bundle.
+- **Not a cluster runtime.** `StateApp[T]` and `Broadcast` are
+  single-process. Horizontal scaling requires sticky sessions; App state is
+  per-pod. There is no built-in fan-out across instances.
+- **Not offline-first.** Disconnect the SSE stream and the tab freezes
+  until reconnect — Via is for connected sessions, not PWAs.
+- **Not a JavaScript replacement.** The browser still runs Datastar's Alien
+  Signals graph. Via removes hand-written JS for the reactivity layer, not
+  the runtime.
+- **Not a build-step framework.** There is no `via generate`. If you want a
+  code-gen template language, look at `templ`.
+- **Not stable yet** — pre-1.0, APIs can shift between minor versions. The
+  Datastar dependency is load-bearing.
+
+See [Production & ops](production#restart-and-tab-survivability) for what
+does and doesn't survive a process restart.
+
+## Why Via, not X
+
+| | Language | Authoring | Client runtime | Build step | Reactive state |
+|---|---|---|---|---|---|
+| **Via** | Go | typed structs + `h` DSL | Datastar (Alien Signals) | none | typed fields, client + server |
+| HTMX | any | HTML + `hx-*` attributes | tiny attribute interpreter | none | server-only, manual |
+| Phoenix LiveView | Elixir | EEx templates + macros | morphdom + tiny JS | none | `assigns` (Elixir-typed) |
+| Hotwire (Turbo) | Ruby | ERB + Turbo Streams | Turbo (WebSocket) | none | server-only, untyped DOM |
+| templ | Go | `.templ` template files | none (BYO) | yes (`templ generate`) | none built-in |
+| Datastar (direct) | any | HTML + `data-*` attrs | Datastar (Alien Signals) | none | client signals, manual |
+
+Via is the only row that gives you typed end-to-end state (server + client)
+with no build step, SSE-only transport, and a fine-grained reactive client
+runtime in the same import.

--- a/docs/index.md
+++ b/docs/index.md
@@ -107,8 +107,8 @@ rows, cross-tab invariants, secrets) flows through actions and re-renders.
 
 ## Where to go next
 
-- **New here?** [Getting started](getting-started), then the
-  [todo-app tutorial](tutorial).
+- **New here?** [Getting started](getting-started), then build a
+  [live chatroom](tutorial) in ~60 lines.
 - **Evaluating Via?** [Why Via](why-via) — the comparison matrix and the
   deliberate non-goals.
 - **Want working code?** Browse the [examples](examples).

--- a/docs/learn.md
+++ b/docs/learn.md
@@ -10,5 +10,5 @@ Start here. Install Via and build your first composition, then build
 something real, and learn the reactive model that ties it together.
 
 - [Getting started](getting-started) — install + a runnable counter.
-- [Tutorial: build a todo app](tutorial) — sessions, forms, and list rendering.
+- [Tutorial: live chatroom](tutorial) — build live multi-user chat in ~60 lines.
 - [Reactive state](reactive-state) — the four shapes, scopes, and typed ops.

--- a/docs/learn.md
+++ b/docs/learn.md
@@ -1,0 +1,14 @@
+---
+title: Learn
+nav_order: 4
+has_children: true
+---
+
+# Learn
+
+Start here. Install Via and build your first composition, then build
+something real, and learn the reactive model that ties it together.
+
+- [Getting started](getting-started) — install + a runnable counter.
+- [Tutorial: build a todo app](tutorial) — sessions, forms, and list rendering.
+- [Reactive state](reactive-state) — the four shapes, scopes, and typed ops.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,6 +1,7 @@
 ---
 title: Plugins
-nav_order: 8
+parent: Guides
+nav_order: 5
 ---
 
 # Plugins

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,74 @@
+---
+title: Plugins
+nav_order: 8
+---
+
+# Plugins
+
+```go
+app := via.New(via.WithPlugins(
+    picocss.Plugin(picocss.WithThemes(picocss.AllPicoThemes)),
+    echarts.Plugin(),
+))
+```
+
+Plugins implement `Register(*via.App)` and call any of `AppendToHead`,
+`AppendToFoot`, `AppendAttrToHTML`, `HandleFunc`, or `RegisterAppSignal`
+during boot to inject document fragments, asset routes, and client-driven
+signals.
+
+{: .warning }
+Call these only from `Register` — the document-mutation slices are not
+lock-guarded against concurrent appends after the server starts.
+
+Plugin packages expose `Plugin(...)` as the canonical constructor (never
+`New(...)`) so `via.WithPlugins(...)` call sites stay uniform.
+
+## Bundled plugins
+
+### picocss
+
+`picocss.Plugin()` wires the [Pico CSS](https://picocss.com) framework:
+theme + dark-mode switching driven by client signals (no full reload),
+served from a plugin asset route with ETag revalidation and gzip
+negotiation. Options include `WithThemes(...)`, `WithDefaultTheme(...)`,
+`WithClassless()`, `WithColorClasses()`, and `WithDarkMode()` /
+`WithLightMode()`. `picocss.ThemeRef()` / `DarkModeRef()` return the Datastar
+signal references for inline expressions.
+
+```go
+h.Button(h.Text("Blue"),
+    h.DataOnClick(picocss.ThemeRef()+" = 'blue'"))
+```
+
+See `internal/examples/picocss` for client-side theme switching.
+
+### echarts
+
+`echarts.Plugin()` integrates [Apache ECharts](https://echarts.apache.org).
+Hold a `*echarts.Chart` on the page, build it in `OnInit`, mount it in
+`View`, and update it from actions or a `via.Stream` ticker:
+
+```go
+type Page struct {
+    Chart *echarts.Chart
+}
+
+func (p *Page) OnInit(ctx *via.Ctx) error {
+    if p.Chart == nil {
+        p.Chart = echarts.NewChart(
+            echarts.WithElementID("cpu"),
+            echarts.WithTitle("CPU"),
+            echarts.WithDimensions("100%", "300px"),
+        )
+    }
+    return nil
+}
+
+func (p *Page) Refresh(ctx *via.Ctx) error {
+    return p.Chart.SetSeries(ctx, echarts.Line("CPU", [][]any{ {0, 12}, {1, 18} }))
+}
+```
+
+See `internal/examples/sysmon` for a live system monitor streaming into
+ECharts.

--- a/docs/production.md
+++ b/docs/production.md
@@ -1,0 +1,126 @@
+---
+title: Production & ops
+nav_order: 10
+---
+
+# Production & ops
+{: .no_toc }
+
+1. TOC
+{:toc}
+
+## Production wiring
+
+```go
+app := via.New(
+    via.WithLang("en"),
+    via.WithLogger(via.SlogLogger(slog.Default())),
+    via.WithMaxRequestBody(1<<20),
+    via.WithMaxContexts(10000),
+    via.WithSSEHeartbeat(25*time.Second),
+)
+mw.Defaults(app)
+app.Use(mw.HSTS())
+app.Use(mw.CSP())
+app.Use(mw.RedirectHTTPS())
+
+via.Mount[Home](app, "/")
+api := app.Group("/api")
+api.Use(requireAuth)
+via.Mount[Profile](api, "/profile")
+
+http.ListenAndServe(":8080", app)
+```
+
+## Configuration
+
+Every `WithX(...)` option is documented in
+[godoc](https://pkg.go.dev/github.com/go-via/via) with its default and
+behaviour. Common production knobs:
+
+- `WithMaxContexts(n)`, `WithLogger(SlogLogger(...))`,
+  `WithInsecureCookies()` (dev opt-out — `Secure` is on by default)
+- `WithMaxRequestBody(n)`, `WithSessionTTL(d)`, `WithContextTTL(d)`
+- `WithSSEHeartbeat(d)`, `WithReadHeaderTimeout(d)`, `WithIdleTimeout(d)`
+- `WithActionErrorHandler(fn)`, `WithNotFound(h)`, `WithHTTPServer(hook)`
+
+## Security defaults
+
+- **CSRF:** every page mints a 256-bit `via_tab` id; action POSTs and SSE
+  handshakes carry it as a signal. The id **is** the CSRF token — unknown
+  ids 404. Action POSTs are also session-pinned (cookie mismatch → 403).
+- **Sessions:** the `via_session` cookie is `HttpOnly`, `SameSite=Lax`,
+  256-bit, and `Secure` by default; `WithInsecureCookies()` drops `Secure`
+  for a local http:// dev loop. After auth-state changes call
+  `sess.Rotate(ctx)` (session-fixation defence).
+- **CSP:** `mw.CSP()` emits a strict header with a per-request nonce
+  reachable via `ctx.CSPNonce()`.
+- **Body limits:** `WithMaxRequestBody(n)` (default 1 MiB) caps action POST
+  and SSE-close bodies; oversized requests return 413.
+- **Open redirects:** `ctx.Redirect` rejects `javascript:`/`data:`/
+  protocol-relative/backslash and whitespace-only URLs.
+- **Panic sanitization:** action panics surface as `"Something went wrong"`
+  to the client; user-returned errors flow through unmodified.
+- **Random sources:** `crypto/rand.Read` failures panic rather than fall
+  back to predictable zero-byte ids.
+
+## Metrics
+
+`via.WithMetrics(m)` accepts an implementation of the `Metrics` interface
+and emits structured events for ops dashboards:
+
+| Event | Kind | Labels |
+|---|---|---|
+| `via.action.total` | counter | `method` |
+| `via.action.latency` | histogram | `method` |
+| `via.render.total` | counter | `route` |
+| `via.sse.connect` | counter | |
+| `via.sse.disconnect` | counter | |
+| `via.ctx.live` | gauge | |
+
+Adapt to Prometheus, OTel, or expvar by implementing three methods
+(`Counter`, `Gauge`, `Histogram`) that forward to your backend. The default
+backend discards every event, so apps that don't configure metrics pay no
+allocation cost.
+
+## Cross-tab broadcast
+
+```go
+app.Broadcast(`alert("Maintenance in 30 seconds.")`)
+app.BroadcastSignals(map[string]any{"_systemNotice": "site read-only"})
+app.LiveTabs()
+```
+
+`Broadcast` queues a JS snippet on every live tab; `BroadcastSignals` queues
+a signal patch. Both return the tab count they reached and deliver via the
+existing patch queue + SSE drain — no extra wiring. Single-process only.
+
+## Restart and tab survivability
+
+A live tab's state lives in memory on the server (the `*via.Ctx` and its
+session). It does **not** survive a process restart:
+
+- After a deploy, every client's `via_tab` is unknown to the new process.
+  The next SSE reconnect 404s and the next action POST 404s.
+- Datastar retries the SSE connection forever, so a user watching a stale
+  tab sees it freeze rather than recover. Tell users to reload, or pair the
+  deploy with a sticky load balancer that drains long enough for tabs to
+  close naturally.
+- Sessions are also in-memory; logged-in users re-auth unless you back the
+  session store with something durable.
+
+For session survivability, persist the `sess.Put`-stored payload (e.g. a JWT
+or opaque token) to a database keyed by the `via_session` cookie value, and
+rehydrate inside an `OnInit` hook.
+
+## Performance
+
+Benchmarks: `bench_test.go` (full request → SSE turn) and
+`h/h_bench_test.go` (DSL only). Run `go test -bench=. -benchmem` against your
+target hardware — quoting numbers from someone else's laptop is rarely
+useful. `ci-check.sh` gates the steady-state allocation floors on
+`CounterRender`, `CounterAction`, and `CounterActionWithLogger` so
+regressions fail CI.
+
+`h.Static(...)` pre-renders fragments that don't depend on per-request state
+— see [Rendering](rendering#static-pre-render).

--- a/docs/production.md
+++ b/docs/production.md
@@ -1,6 +1,7 @@
 ---
 title: Production & ops
-nav_order: 10
+parent: Reference & ops
+nav_order: 2
 ---
 
 # Production & ops

--- a/docs/reactive-state.md
+++ b/docs/reactive-state.md
@@ -1,5 +1,6 @@
 ---
 title: Reactive state
+parent: Learn
 nav_order: 3
 ---
 
@@ -25,6 +26,22 @@ field's type — not a convention.
   to inputs and view helpers; it reacts client-side with no round-trip.
 - `StateTab[T]` / `StateSess[T]` / `StateApp[T]` live only in Go. They
   change through actions, and a re-render re-emits the value over SSE.
+
+Scope at a glance — one process, many sessions, many tabs:
+
+```
+   App (one process) ── StateApp[T] ............... shared by everyone
+    │
+    ├─ Session A (one browser) ── StateSess[T] ..... shared by that user's tabs
+    │   ├─ Tab 1 ── Signal[T] (client) + StateTab[T] (server)
+    │   └─ Tab 2 ── Signal[T] + StateTab[T]   ← its own copy
+    │
+    └─ Session B (another browser) ── StateSess[T]
+        └─ Tab 1 ── Signal[T] + StateTab[T]
+```
+
+`Signal[T]` also lives in the browser; the three `State*` shapes never leave
+the server.
 
 ## Reads, writes, and updates
 
@@ -96,8 +113,8 @@ re-renders server-side instead of subscribing to a client signal.
 The `via:"name,init=..."` tag sets the wire key and an initial value.
 A tagless field uses the lower-cased field name as its key. `init=` values
 are decoded into the field's type (int, uint, float, bool, string). Wire
-keys, initial values, and the full tag grammar are documented in
-[godoc](https://pkg.go.dev/github.com/go-via/via).
+keys, initial values, and the full tag grammar are documented on the
+[`Signal` type in godoc](https://pkg.go.dev/github.com/go-via/via#Signal).
 
 ```go
 type Page struct {

--- a/docs/reactive-state.md
+++ b/docs/reactive-state.md
@@ -1,0 +1,108 @@
+---
+title: Reactive state
+nav_order: 3
+---
+
+# Reactive state
+{: .no_toc }
+
+1. TOC
+{:toc}
+
+## The four reactive shapes
+
+Whether a piece of state lives on the client, the server, or both is the
+field's type — not a convention.
+
+| Handle | Scope | Lives on |
+|---|---|---|
+| `via.Signal[T]` | per-tab | client + server |
+| `via.StateTab[T]` | per-tab | server only |
+| `via.StateSess[T]` | per-session | server only |
+| `via.StateApp[T]` | global | server only |
+
+- `Signal[T]` is mirrored into the browser's Alien Signals graph. Bind it
+  to inputs and view helpers; it reacts client-side with no round-trip.
+- `StateTab[T]` / `StateSess[T]` / `StateApp[T]` live only in Go. They
+  change through actions, and a re-render re-emits the value over SSE.
+
+## Reads, writes, and updates
+
+Reads go through `Read(ctx)`; writes through `Update(ctx, fn)`. `Signal[T]`
+and `StateTab[T]` also expose `Write(ctx, v)` for direct sets — per-tab
+writes are already serialized by the action mutex.
+
+```go
+n := c.Hits.Read(ctx)
+
+c.Hits.Write(ctx, 0)                       // Signal / StateTab only
+
+err := c.Hits.Update(ctx, func(n int) (int, error) {
+    return n + 1, nil                      // load → fn → store, under a per-key mutex
+})
+```
+
+`Update` holds a per-key mutex across the load → fn → store sequence, so
+concurrent writers from different ctxs cannot lose increments. If `fn`
+returns an error the store is left unchanged, no broadcast fires, and the
+error is returned.
+
+{: .note }
+`StateApp[T]` has no `Write` — a blind write on shared state is almost
+always a read-modify-write race in disguise. Model the assignment as an
+`Update` whose `fn` ignores the old value if you truly mean it. Calling
+`Update` with a nil `*Ctx` panics: without one, no broadcast can fan out.
+
+## Typed ops via `Op(ctx)`
+
+For the common shape buckets — numeric, bool, string, slice, map — use the
+`Num` / `Bool` / `Str` / `Slice` / `Map` typed wrappers and call `Op(ctx)`
+for shape-aware verbs. Drop back to `Update(ctx, fn)` for custom transforms
+or non-bucket `T` (structs, interfaces).
+
+| Field type | Common verbs |
+|---|---|
+| `via.StateTabNum[int]` | `Add(n) / Sub(n) / Inc() / Dec() / Zero() / Min(lo) / Max(hi)` |
+| `via.SignalBool` | `Toggle() / True() / False()` |
+| `via.StateSessStr` | `Append(s) / Prepend(s) / Clear()` |
+| `via.SignalSlice[T]` | `Append(v) / Prepend(v) / Pop() / Shift() / Take(n) / Drop(n) / Filter(pred) / Empty()` |
+| `via.StateAppMap[K,V]` | `Put(k,v) / Delete(k) / Empty()` |
+
+```go
+c.Hits.Op(ctx).Add(1)
+c.Open.Op(ctx).Toggle()
+c.Items.Op(ctx).Append(item)
+```
+
+## View helpers driven by `Signal[T]`
+
+`Signal[T]` mirrors into the browser's reactive graph. These helpers compile
+to Datastar `data-*` attributes that subscribe to it — DOM updates are
+fine-grained, with no re-render and no round-trip:
+
+```go
+s.Bind()              // <input data-bind="key"> two-way binding
+s.Text()              // <span data-text="$key"></span>
+s.Show()              // data-show="$key" — toggle display by truthiness
+s.Attr("disabled")    // data-attr-disabled="$key" — drives an HTML attr
+s.Style("color")      // data-style-color="$key" — drives an inline CSS prop
+```
+
+`StateTab[T]` / `StateSess[T]` / `StateApp[T]` share `Text(ctx)`, which
+re-renders server-side instead of subscribing to a client signal.
+
+## Wire keys and init values
+
+The `via:"name,init=..."` tag sets the wire key and an initial value.
+A tagless field uses the lower-cased field name as its key. `init=` values
+are decoded into the field's type (int, uint, float, bool, string). Wire
+keys, initial values, and the full tag grammar are documented in
+[godoc](https://pkg.go.dev/github.com/go-via/via).
+
+```go
+type Page struct {
+    Theme via.Signal[string]    `via:"theme,init=auto"`
+    Step  via.SignalNum[int]    `via:"step,init=1"`
+    Open  via.SignalBool        // key defaults to "open"
+}
+```

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,13 @@
+---
+title: Reference & ops
+nav_order: 6
+has_children: true
+---
+
+# Reference & ops
+
+- [Testing](testing) — drive compositions over HTTP with `vt`.
+- [Production & ops](production) — wiring, config, metrics, security, deploys.
+- [h helpers reference](h-helpers) — every symbol in the `h` DSL.
+- [Troubleshooting](troubleshooting) — symptom → cause → fix.
+- [Glossary](glossary) — the vocabulary (signals, compositions, flush, morph).

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -1,0 +1,88 @@
+---
+title: Rendering (h)
+nav_order: 5
+---
+
+# Rendering with the `h` DSL
+{: .no_toc }
+
+1. TOC
+{:toc}
+
+`h` is the HTML DSL — elements, attributes, text, iteration, conditionals,
+static pre-render, and custom tags, all as Go. `View` returns an `h.H`.
+
+```go
+h.Div(h.Class("card"),
+    h.H1(h.T("Title")),
+    h.Each(items, func(it Item) h.H { return h.Li(h.T(it.Name)) }),
+)
+```
+
+Text and attribute values are HTML-escaped. The full per-symbol reference is
+in [h helpers reference](h-helpers) and in
+[`go doc .../h`](https://pkg.go.dev/github.com/go-via/via/h).
+
+## Elements, attributes, text
+
+Elements are constructors (`h.Div`, `h.Span`, `h.Button`, …) that take any
+mix of attribute and child nodes; attributes are reordered into the open
+tag automatically. `h.Text` / `h.T` escape their input; `h.Textf` formats;
+`h.Raw` passes pre-trusted markup through unescaped.
+
+```go
+h.Input(h.Type("email"), h.Placeholder("you@example.com"), h.Required())
+h.A(h.Href("/docs"), h.T("Docs"))
+```
+
+## Iteration and conditionals
+
+```go
+h.Each(items, func(it Item) h.H { return h.Li(h.T(it.Name)) })
+h.EachIndexed(items, func(i int, it Item) h.H { ... })
+h.If(loggedIn, h.Span(h.T("Welcome")))
+h.IfElse(ok, yesNode, noNode)
+h.Switch(key, cases, defaultNode)
+h.Fragment(nodeA, nodeB)   // group nodes without a wrapper element
+```
+
+`Fragment` is transparent to its parent element: attributes inside a
+fragment still land in the parent's open tag.
+
+## Static pre-render
+
+`h.Static(n)` pre-renders a fragment that doesn't depend on per-request
+state (layout chrome, headers); every later Render writes the captured bytes
+verbatim. See `BenchmarkSysmonShape_staticChrome_render` for the per-tick
+allocation delta against rebuilding the same chrome on every tick.
+
+```go
+var chrome = h.Static(h.Header(h.H1(h.T("Dashboard"))))
+```
+
+## Custom tags and extension
+
+```go
+h.NewTag("my-widget")   // constructor for tags outside the built-in list
+h.NewVoidTag("br-ish")  // self-closing variant
+h.With(base, more...)   // extend an existing element non-destructively
+```
+
+`h.NewTag` covers web components, SVG, and MathML. `h.With` returns a new
+element with extra children/attributes appended, leaving the base unchanged.
+
+## Datastar attribute helpers
+
+Beyond the `Signal[T]` view helpers ([Reactive state](reactive-state)), the
+`h` package exposes raw Datastar bindings for frontend-only behaviour:
+
+```go
+h.DataOnClick("$open = !$open")          // data-on:click
+h.DataClass("active", "$tab === 'home'") // data-class:active
+h.DataShow("$open")                      // data-show
+h.DataInit("$progress = '100%'")         // data-init (bare % is not mangled)
+h.DataIgnoreMorph()                      // skip morphing this element
+```
+
+Use `on.Click(method)` for server actions; use `h.DataOnClick(expr)` for
+client-only signal mutations.

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -1,6 +1,7 @@
 ---
 title: Rendering (h)
-nav_order: 5
+parent: Guides
+nav_order: 2
 ---
 
 # Rendering with the `h` DSL

--- a/docs/routing-sessions-middleware.md
+++ b/docs/routing-sessions-middleware.md
@@ -1,0 +1,116 @@
+---
+title: Routing, sessions & middleware
+nav_order: 6
+---
+
+# Routing, sessions & middleware
+{: .no_toc }
+
+1. TOC
+{:toc}
+
+## Routing and groups
+
+```go
+via.Mount[Counter](app, "/counter/{id}")
+
+api := app.Group("/api")
+api.Use(requireAuth)
+via.Mount[Profile](api, "/profile")
+
+api.HandleFunc("POST /widgets", createWidget) // method-prefixed
+api.HandleFunc("/widgets",       listWidgets) // bare path = GET
+
+app.Routes()                                  // []RouteInfo for boot logging
+```
+
+Group patterns follow the `http.ServeMux` shape: `"GET /foo"`, `"POST /foo"`,
+or just `"/foo"` (defaults to GET; an unrecognised method token is treated
+as a path). Mounting two routes at the same path panics at registration with
+the offending pattern and the original registrar tag. `WithNotFound(h)`
+installs a custom 404 handler.
+
+## Path parameters
+
+```go
+type Profile struct {
+    UserID int    `path:"id"`
+    Slug   string `path:"slug"`
+}
+via.Mount[Profile](app, "/u/{id}/posts/{slug}")
+```
+
+Each `path:"name"` tag must match a `{name}` segment. Reflection runs once at
+Mount; per-request decoding writes directly into the typed field. Query
+parameters decode the same way via the `query:"name"` tag.
+
+## Sessions
+
+Per-browser session storage, keyed by Go type, lives in `via/sess`:
+
+```go
+import "github.com/go-via/via/sess"
+
+type User struct{ Email, Name string }
+
+sess.Put(ctx, User{Email: "alice@example.com", Name: "Alice"})
+u, ok := sess.Get[User](ctx)                 // handler / action
+u, ok := sess.Get[User](r)                   // middleware (*http.Request)
+sess.Clear[User](ctx)
+sess.Rotate(ctx)                             // after login / privilege change
+```
+
+`sess.Rotate` issues a fresh session id and copies the data across — call it
+after any auth-state change to defend against session fixation.
+
+`requireAuth` is one line of middleware:
+
+```go
+func requireAuth(w http.ResponseWriter, r *http.Request, next http.Handler) {
+    if u, ok := sess.Get[User](r); !ok || u.Email == "" {
+        http.Redirect(w, r, "/login", http.StatusSeeOther)
+        return
+    }
+    next.ServeHTTP(w, r)
+}
+```
+
+{: .warning }
+Sessions are in-memory and do not survive a process restart. To persist
+across restarts, store the `sess.Put` payload in a durable store keyed by
+the `via_session` cookie and rehydrate in `OnInit`.
+
+## Middleware
+
+```go
+import "github.com/go-via/via/mw"
+
+app := via.New()
+mw.Defaults(app)                // RequestID + AccessLog + Recover
+app.Use(mw.CSP())               // strict CSP with per-request nonce
+app.Use(requireAuth)            // your own
+```
+
+Factories under `via/mw`:
+
+- `mw.Defaults(app)` — RequestID + AccessLog + Recover.
+- `mw.RequestID()` — stamp `X-Request-ID` + plant on `r.Context`.
+- `mw.AccessLog(app)` — one info-line per request, with rid + status; CR/LF
+  stripped from method/path/rid so user input can't forge log entries
+  (CWE-117).
+- `mw.Recover(app)` — panic → 500 + error log (same CR/LF scrub); the
+  goroutine survives.
+- `mw.CSP(extra…)` — strict CSP header + nonce on `r.Context`.
+- `mw.HSTS(opts…)` — Strict-Transport-Security for HTTPS deploys.
+- `mw.RedirectHTTPS()` — 301 plain HTTP → https; trusts `X-Forwarded-Proto`
+  (use behind a TLS-terminating proxy).
+- `mw.RedirectHTTPSStrict()` — same redirect but ignores XFP; only
+  `r.TLS != nil` counts as secure (use for direct-bind TLS).
+
+Read middleware output back inside actions / handlers:
+
+```go
+via.RequestIDFrom(r)             // string or ""
+via.Log(ctx).Log(via.LogInfo, "checkout", "amount", n)
+ctx.CSPNonce()                   // matches header set by mw.CSP
+```

--- a/docs/routing-sessions-middleware.md
+++ b/docs/routing-sessions-middleware.md
@@ -1,6 +1,7 @@
 ---
 title: Routing, sessions & middleware
-nav_order: 6
+parent: Guides
+nav_order: 3
 ---
 
 # Routing, sessions & middleware

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,62 @@
+---
+title: Testing
+nav_order: 9
+---
+
+# Testing
+
+Tests drive the composition through HTTP — the same path as a real browser,
+so the full middleware stack, session cookie, and SSE machinery run
+end-to-end. There is no "direct method" seam: assertions hit rendered HTML
+or SSE frames, never internal state. The harness lives in `via/vt`.
+
+```go
+import (
+    "github.com/go-via/via"
+    "github.com/go-via/via/vt"
+)
+
+var server *httptest.Server
+app := via.New(via.WithTestServer(&server))
+via.Mount[Counter](app, "/")
+
+tc := vt.NewClient(t, server, "/")
+c := &Counter{}
+require.Equal(t, 200, tc.Action(c.Inc).Fire())   // typed: typo → compile error
+require.Equal(t, 200, tc.Action("Apply").        // string still works
+    WithSignal("step", 5).Fire())
+require.Contains(t, tc.Reload(), ">1<")
+
+frames, cancel := tc.SSE()
+defer cancel()
+vt.AwaitFrame(t, frames, 2*time.Second, ">3<")
+
+tc.Action(p.Upload).
+    WithFile("avatar", "me.png", pngBytes).
+    WithSignal("note", "from CLI").
+    Fire()
+```
+
+## API
+
+- `vt.NewClient(t, server, path)` — performs the initial GET (acquiring the
+  `via_tab` id + session cookie on a shared jar) and returns a `*Client`.
+- `tc.Action(target)` — accepts a **method value** (compile-time typo
+  protection) or the action's **name** as a string. Chain `.WithSignal`,
+  `.WithFile`, then `.Fire()` (returns the HTTP status).
+- `tc.HTML()` / `tc.Reload()` — the initial / re-fetched page body, so
+  post-action body assertions are one call.
+- `tc.SSE()` / `tc.SSEReady()` — open the tab's SSE stream; `SSEReady`
+  blocks until the server handshake so there's no timing guess.
+- `vt.AwaitFrame(t, frames, timeout, needles...)` — wait until all needles
+  appear across the accumulated frames; returns the matched content.
+- `tc.Fork(path)` — a second tab on the same cookie jar — the only way to
+  drive `StateSess` behaviour that spans tabs.
+
+## Conventions
+
+Tests enter through exported symbols (use `package foo_test`), assert on
+observable output (HTML / SSE frames / status / errors), and call
+`t.Parallel()` wherever there's no shared mutable state. Use real or stub
+implementations over mocks for interfaces you own; reserve mocks for true
+system boundaries.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,6 +1,7 @@
 ---
 title: Testing
-nav_order: 9
+parent: Reference & ops
+nav_order: 1
 ---
 
 # Testing

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,86 @@
+---
+title: Troubleshooting
+parent: Reference & ops
+nav_order: 4
+---
+
+# Troubleshooting
+{: .no_toc }
+
+Symptom → cause → fix for the things that trip people up first.
+
+1. TOC
+{:toc}
+
+## Nothing happens on `http://localhost` — actions don't fire
+
+**Cause:** the `via_session` cookie is `Secure` by default, so the browser
+won't send it over plain `http://`. Without the cookie the action POST is
+session-mismatched.
+
+**Fix:** opt out of `Secure` for local development only:
+
+```go
+app := via.New(via.WithInsecureCookies())
+```
+
+Never ship `WithInsecureCookies()` to production — it drops the `Secure` flag.
+
+## The tab freezes / actions 404 after a redeploy
+
+**Cause:** a tab's state lives in memory on the server. After a restart, the
+client's `via_tab` is unknown to the new process: the next SSE reconnect 404s
+and the next action POST 404s. Datastar retries the SSE forever, so the tab
+appears frozen rather than erroring.
+
+**Fix:** tell users to reload after a deploy, or drain behind a sticky load
+balancer long enough for tabs to close. For session survival across restarts,
+persist the `sess.Put` payload to a durable store keyed by the `via_session`
+cookie and rehydrate in `OnInit`. See
+[Production & ops](production#restart-and-tab-survivability).
+
+## `on.Click(c.DoThing)` won't compile
+
+**Cause:** `DoThing` isn't a valid action. An action must be a method on the
+composition with signature `func(*via.Ctx) error` or `func(*via.Ctx)`.
+
+**Fix:** check the receiver and signature. The typed `on.Click(c.DoThing)`
+form is deliberately strict — a typo or wrong signature is a compile error
+(that's the feature). The string form `on.Click("DoThing")` also exists.
+
+## `OnConnect` never runs
+
+**Cause:** `OnConnect` fires the first time the **SSE stream** opens, not on
+the page GET. A crawler or a `curl` that fetches HTML without opening the SSE
+never triggers it.
+
+**Fix:** that's intended — put cheap setup in `OnInit` (runs on the GET) and
+expensive per-tab work (tickers, fan-out goroutines) in `OnConnect`.
+
+## A `Mount` call panics at startup
+
+**Cause:** registration-time errors panic by design — e.g. two routes at the
+same path, a `path:"name"` tag with no matching `{name}` segment, or a
+composition with no `View` method.
+
+**Fix:** read the panic message; it names the offending pattern and the
+registrar. Registration mistakes are programming errors, so they fail loudly
+at boot rather than at request time.
+
+## An oversized upload / POST returns 413
+
+**Cause:** `WithMaxRequestBody(n)` (default 1 MiB) caps action POST and
+SSE-close bodies.
+
+**Fix:** raise the limit for routes that accept large uploads:
+`via.New(via.WithMaxRequestBody(20 << 20))`.
+
+## State doesn't update across tabs
+
+**Cause:** `StateTab[T]` is per-tab and `StateSess[T]` is per-session.
+A second browser tab on the same session shares `StateSess`/`StateApp` but
+has its own `StateTab`.
+
+**Fix:** pick the scope you mean — [Reactive state](reactive-state). In tests,
+`tc.Fork(path)` opens a second tab on the same cookie jar to exercise
+cross-tab `StateSess` behaviour.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,0 +1,125 @@
+---
+title: "Tutorial: build a todo app"
+parent: Learn
+nav_order: 2
+---
+
+# Tutorial: build a todo app
+{: .no_toc }
+
+The [counter](getting-started) showed the shape of a composition. This builds
+something with real moving parts: a **session-backed** todo list that
+survives a reload, an input bound to a client signal, list rendering with
+`h.Each`, and two actions. About 20 minutes.
+
+The finished app mirrors
+[`internal/examples/todos`](https://github.com/go-via/via/tree/main/internal/examples/todos).
+
+1. TOC
+{:toc}
+
+## 1. The composition
+
+Two fields capture the whole client/server split:
+
+```go
+type Todos struct {
+    // Server-owned, per session: survives a reload, scoped to the browser.
+    Items via.StateSess[[]string]
+
+    // Client-owned: the text being typed, bound to the <input>.
+    Draft via.SignalStr `via:"draft"`
+}
+```
+
+`Items` is `StateSess` because the list is server truth that should outlive a
+page reload but stay private to one user's session. `Draft` is a `Signal`
+because the in-progress text is pure client state — typing it should not POST.
+
+## 2. The view
+
+```go
+func (t *Todos) View(ctx *via.CtxR) h.H {
+    return h.Div(
+        h.Input(t.Draft.Bind(), h.Placeholder("What needs doing?")),
+        h.Button(h.Text("Add"), on.Click(t.Add)),
+        h.Button(h.Text("Clear"), on.Click(t.Clear)),
+        h.Ul(h.Each(t.Items.Read(ctx), func(item string) h.H {
+            return h.Li(h.Text(item))
+        })),
+    )
+}
+```
+
+`t.Draft.Bind()` is two-way: keystrokes update the client signal with no
+round-trip. `h.Each` renders one `<li>` per item; because `Items` is
+server-owned, the list re-renders server-side and ships a DOM patch over SSE
+whenever it changes.
+
+{: .note }
+`View` takes `*via.CtxR` — a read-only render context. You can `Read` state
+here but not mutate it. Mutations live in actions (next), which take the
+full `*via.Ctx`.
+
+## 3. The actions
+
+```go
+func (t *Todos) Add(ctx *via.Ctx) error {
+    text := strings.TrimSpace(t.Draft.Read(ctx))
+    if text == "" {
+        return nil
+    }
+    if err := t.Items.Update(ctx, func(cur []string) ([]string, error) {
+        return append(cur, text), nil
+    }); err != nil {
+        return err
+    }
+    t.Draft.Write(ctx, "") // clear the input client-side after a successful add
+    return nil
+}
+
+func (t *Todos) Clear(ctx *via.Ctx) error {
+    return t.Items.Update(ctx, func([]string) ([]string, error) {
+        return nil, nil
+    })
+}
+```
+
+`Add` reads the current client `Draft`, appends to the server list under
+`Update`'s per-key mutex, then writes `Draft` back to `""` — that empty value
+flushes to the browser and clears the input. `Clear` replaces the list with
+`nil`. Both are ordinary methods; `on.Click` binds them with compile-time
+typo protection.
+
+## 4. Wire it up
+
+```go
+func main() {
+    app := via.New()
+    via.Mount[Todos](app, "/")
+    _ = http.ListenAndServe(":3000", app)
+}
+```
+
+```bash
+go run .
+# open http://localhost:3000
+```
+
+Add a few items, then **reload the page**. The list is still there — that's
+`StateSess` surviving the reload via the `via_session` cookie. Open a private
+window and you get an empty list: the session scope is per-browser.
+
+## 5. Where to go next
+
+- **Bundle a client write with the action.** `on.SetSignal(&t.Draft, "")`
+  sets a signal *before* the POST fires — handy when the value should change
+  client-side regardless of the server result. (Here we cleared *after* a
+  successful add instead, so an empty draft isn't lost on error.)
+- **Typed ops.** Swap `StateSess[[]string]` for `via.StateSessSlice[string]`
+  and call `t.Items.Op(ctx).Append(text)` / `.Empty()` instead of `Update`.
+  See [Reactive state](reactive-state#typed-ops-via-opctx).
+- **Remove a single item.** Add a per-row button that bundles the row's index
+  with `on.SetSignal`, then read it in a `Remove` action.
+- **Style it.** Add `picocss.Plugin()` ([Plugins](plugins)) for instant CSS.
+- **Test it.** Drive the actions over HTTP with `vt` ([Testing](testing)).

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,125 +1,137 @@
 ---
-title: "Tutorial: build a todo app"
+title: "Tutorial: live chatroom"
 parent: Learn
 nav_order: 2
 ---
 
-# Tutorial: build a todo app
+# Tutorial: a live chatroom in ~60 lines
 {: .no_toc }
 
-The [counter](getting-started) showed the shape of a composition. This builds
-something with real moving parts: a **session-backed** todo list that
-survives a reload, an input bound to a client signal, list rendering with
-`h.Each`, and two actions. About 20 minutes.
+The [counter](getting-started) showed the shape of a composition. Now build
+the thing that usually means WebSockets, a message bus, and a pile of client
+JS — a **live multi-user chatroom**. In Via it falls out of one app-scoped
+field: a line typed in any browser appears instantly in every other connected
+browser. No WebSocket, no `Broadcast` call, no hand-written JavaScript.
 
-The finished app mirrors
-[`internal/examples/todos`](https://github.com/go-via/via/tree/main/internal/examples/todos).
+The finished app is
+[`internal/examples/chat`](https://github.com/go-via/via/tree/main/internal/examples/chat)
+— about 60 lines.
 
 1. TOC
 {:toc}
 
-## 1. The composition
-
-Two fields capture the whole client/server split:
+## 1. The room is one shared field
 
 ```go
-type Todos struct {
-    // Server-owned, per session: survives a reload, scoped to the browser.
-    Items via.StateSess[[]string]
+type Message struct{ From, Body string }
 
-    // Client-owned: the text being typed, bound to the <input>.
+type Room struct {
+    // App-scoped: ONE log shared by every session and every tab.
+    Log via.StateAppSlice[Message]
+
+    // Tab-local client signals, two-way bound to inputs. Name rides along
+    // on each message this tab sends.
+    Name  via.SignalStr `via:"name,init=Anon"`
     Draft via.SignalStr `via:"draft"`
 }
 ```
 
-`Items` is `StateSess` because the list is server truth that should outlive a
-page reload but stay private to one user's session. `Draft` is a `Signal`
-because the in-progress text is pure client state — typing it should not POST.
+`Log` is `StateAppSlice` — **global** server state. That single choice is the
+whole trick: when any action appends to an app-scoped value, Via re-renders
+*every tab that read it*, across every session. `Name` and `Draft` are client
+signals bound to text inputs, so typing them costs no round-trip.
 
 ## 2. The view
 
 ```go
-func (t *Todos) View(ctx *via.CtxR) h.H {
-    return h.Div(
-        h.Input(t.Draft.Bind(), h.Placeholder("What needs doing?")),
-        h.Button(h.Text("Add"), on.Click(t.Add)),
-        h.Button(h.Text("Clear"), on.Click(t.Clear)),
-        h.Ul(h.Each(t.Items.Read(ctx), func(item string) h.H {
-            return h.Li(h.Text(item))
-        })),
+func (r *Room) View(ctx *via.CtxR) h.H {
+    return h.Main(h.Class("container"),
+        h.H1(h.Text("Via Chat")),
+        h.Article(h.Style("max-height:60vh;overflow-y:auto"),
+            h.Each(r.Log.Read(ctx), func(m Message) h.H {
+                return h.P(h.Strong(h.Text(m.From+": ")), h.Text(m.Body))
+            }),
+        ),
+        h.Form(
+            h.Input(h.Type("text"), r.Name.Bind(), h.Placeholder("name")),
+            h.Input(h.Type("text"), r.Draft.Bind(),
+                h.Placeholder("message…"), on.Key("Enter", r.Send)),
+            h.Button(h.Type("button"), h.Text("Send"), on.Click(r.Send)),
+        ),
     )
 }
 ```
 
-`t.Draft.Bind()` is two-way: keystrokes update the client signal with no
-round-trip. `h.Each` renders one `<li>` per item; because `Items` is
-server-owned, the list re-renders server-side and ships a DOM patch over SSE
-whenever it changes.
+Reading `r.Log.Read(ctx)` here is what **subscribes** this tab to the log —
+that's why a `Send` from anyone re-renders it. `on.Key("Enter", r.Send)` sends
+on Enter; the button sends on click.
 
-{: .note }
-`View` takes `*via.CtxR` — a read-only render context. You can `Read` state
-here but not mutate it. Mutations live in actions (next), which take the
-full `*via.Ctx`.
-
-## 3. The actions
+## 3. The send action
 
 ```go
-func (t *Todos) Add(ctx *via.Ctx) error {
-    text := strings.TrimSpace(t.Draft.Read(ctx))
-    if text == "" {
-        return nil
+func (r *Room) Send(ctx *via.Ctx) {
+    body := strings.TrimSpace(r.Draft.Read(ctx))
+    if body == "" {
+        return
     }
-    if err := t.Items.Update(ctx, func(cur []string) ([]string, error) {
-        return append(cur, text), nil
-    }); err != nil {
-        return err
+    name := strings.TrimSpace(r.Name.Read(ctx))
+    if name == "" {
+        name = "Anon"
     }
-    t.Draft.Write(ctx, "") // clear the input client-side after a successful add
-    return nil
-}
-
-func (t *Todos) Clear(ctx *via.Ctx) error {
-    return t.Items.Update(ctx, func([]string) ([]string, error) {
-        return nil, nil
+    _ = r.Log.Update(ctx, func(log []Message) ([]Message, error) {
+        log = append(log, Message{From: name, Body: body})
+        if len(log) > 50 { // keep a recent window so the room can't grow forever
+            log = log[len(log)-50:]
+        }
+        return log, nil
     })
+    r.Draft.Write(ctx, "") // clear the input
 }
 ```
 
-`Add` reads the current client `Draft`, appends to the server list under
-`Update`'s per-key mutex, then writes `Draft` back to `""` — that empty value
-flushes to the browser and clears the input. `Clear` replaces the list with
-`nil`. Both are ordinary methods; `on.Click` binds them with compile-time
-typo protection.
+`Update` appends under a per-key mutex — concurrent senders can't lose
+messages — then Via diffs the View and ships the new `<p>` to every subscribed
+tab over SSE. Writing `Draft` back to `""` clears the sender's input.
 
-## 4. Wire it up
+## 4. Run it
 
 ```go
 func main() {
-    app := via.New()
-    via.Mount[Todos](app, "/")
+    app := via.New(via.WithPlugins(picocss.Plugin()))
+    via.Mount[Room](app, "/")
     _ = http.ListenAndServe(":3000", app)
 }
 ```
 
 ```bash
-go run .
-# open http://localhost:3000
+go run ./internal/examples/chat
+# open http://localhost:3000 in TWO browser windows
 ```
 
-Add a few items, then **reload the page**. The list is still there — that's
-`StateSess` surviving the reload via the `via_session` cookie. Open a private
-window and you get an empty list: the session scope is per-browser.
+Type in one window; the message appears in both — live. That is the entire
+chatroom.
 
-## 5. Where to go next
+## 5. Why it's live — and what it cost
 
-- **Bundle a client write with the action.** `on.SetSignal(&t.Draft, "")`
-  sets a signal *before* the POST fires — handy when the value should change
-  client-side regardless of the server result. (Here we cleared *after* a
-  successful add instead, so an empty draft isn't lost on error.)
-- **Typed ops.** Swap `StateSess[[]string]` for `via.StateSessSlice[string]`
-  and call `t.Items.Op(ctx).Append(text)` / `.Empty()` instead of `Update`.
-  See [Reactive state](reactive-state#typed-ops-via-opctx).
-- **Remove a single item.** Add a per-row button that bundles the row's index
-  with `on.SetSignal`, then read it in a `Remove` action.
-- **Style it.** Add `picocss.Plugin()` ([Plugins](plugins)) for instant CSS.
-- **Test it.** Drive the actions over HTTP with `vt` ([Testing](testing)).
+The realtime sync is not in your code; it's the framework. `StateApp*` is
+server-owned **global** state, and an `Update` to it fans a re-render out to
+every connected tab ([Reactive state](reactive-state)). You wrote a struct, a
+view, and one action — no WebSocket, no subscription bookkeeping, no client
+JS. (`StateApp` is single-process and has no tenant isolation, so this is one
+global room — see the [non-goals](why-via).)
+
+That cross-session fan-out is exactly what the example's test
+`TestChat_messageFansOutAcrossSessions` asserts end-to-end: two separate
+sessions, a `Send` from one, the message live on the other's stream. See
+[Testing](testing).
+
+## 6. Where to go next
+
+- **Per-room channels.** Swap the one `StateAppSlice` for a
+  `StateAppMap[string, []Message]` keyed by room name.
+- **Persistence.** App state is in-memory; back the log with a DB and
+  rehydrate in `OnInit`
+  ([Production & ops](production#restart-and-tab-survivability)).
+- **Presence / typing indicators.** Another app-scoped value, same pattern.
+- **Style it** further with [picocss](plugins), or **test it** with
+  [`vt`](testing).

--- a/docs/why-via.md
+++ b/docs/why-via.md
@@ -1,0 +1,59 @@
+---
+title: Why Via
+nav_order: 2
+---
+
+# Why Via
+{: .no_toc }
+
+1. TOC
+{:toc}
+
+Via expresses the client/server reactive split as a **Go type**. `Signal[T]`
+is a client signal mirrored into the browser; `StateTab[T]`, `StateSess[T]`,
+and `StateApp[T]` are server-only. Whether a piece of UI state round-trips is
+a decision made at the field declaration and checked by the compiler — not a
+convention you can grep for. See [Reactive state](reactive-state) for the
+model, or [Getting started](getting-started) to try it.
+
+## Why Via, not X
+
+| | Language | Authoring | Client runtime | Build step | Reactive state |
+|---|---|---|---|---|---|
+| **Via** | Go | typed structs + `h` DSL | Datastar (Alien Signals) | none | typed fields, client + server |
+| HTMX | any | HTML + `hx-*` attributes | tiny attribute interpreter | none | server-only, manual |
+| Phoenix LiveView | Elixir | EEx templates + macros | morphdom + tiny JS | none | `assigns` (Elixir-typed) |
+| Hotwire (Turbo) | Ruby | ERB + Turbo Streams | Turbo (WebSocket) | none | server-only, untyped DOM |
+| templ | Go | `.templ` template files | none (BYO) | yes (`templ generate`) | none built-in |
+| Datastar (direct) | any | HTML + `data-*` attrs | Datastar (Alien Signals) | none | client signals, manual |
+
+Via is the only row that gives you typed end-to-end state (server + client)
+with no build step, SSE-only transport, and a fine-grained reactive client
+runtime in the same import. Pick another row if you want a different
+language, a template file format, or a different state-ownership split.
+
+**Best fit:** internal tools, admin dashboards, line-of-business apps, and
+hobby projects — anywhere you would otherwise reach for Phoenix LiveView,
+Hotwire, or htmx + hand-written JS, but want to stay in Go.
+
+## What Via is NOT
+
+Read this before adopting. The non-goals are deliberate.
+
+- **Not an SPA framework.** Routes are server-rendered pages. The browser
+  receives HTML, not a JSON bundle.
+- **Not a cluster runtime.** `StateApp[T]` and `Broadcast` are
+  single-process. Horizontal scaling requires sticky sessions; App state is
+  per-pod. There is no built-in fan-out across instances.
+- **Not offline-first.** Disconnect the SSE stream and the tab freezes until
+  reconnect — Via is for connected sessions, not PWAs.
+- **Not a JavaScript replacement.** The browser still runs Datastar's Alien
+  Signals graph. Via removes hand-written JS for the reactivity layer, not
+  the runtime.
+- **Not a build-step framework.** There is no `via generate`. If you want a
+  code-gen template language, look at `templ`.
+- **Not stable yet** — pre-1.0, APIs can shift between minor versions. The
+  Datastar dependency is load-bearing.
+
+What does and doesn't survive a process restart is spelled out in
+[Production & ops](production#restart-and-tab-survivability).

--- a/internal/examples/chat/main.go
+++ b/internal/examples/chat/main.go
@@ -1,0 +1,88 @@
+// Chat is a live multi-user chatroom in one file. The message log is a
+// single app-scoped slice; appending to it fans a re-render out to every
+// connected tab across every session — so a line typed in one browser
+// shows up instantly in all the others. No Broadcast, no WebSocket, no
+// hand-written JS. Open it in two browsers side by side to watch it sync.
+//
+//	go run ./internal/examples/chat
+//	open http://localhost:3000
+package main
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/go-via/via"
+	"github.com/go-via/via/h"
+	"github.com/go-via/via/on"
+	"github.com/go-via/via/plugins/picocss"
+)
+
+// recentWindow caps the shared log so a long-lived room can't grow the
+// app store — and every fan-out render — without bound.
+const recentWindow = 50
+
+type Message struct {
+	From, Body string
+}
+
+type Room struct {
+	// Log is app-scoped: one room shared across every session and tab.
+	// Update fans the new line out to every tab that read it in View.
+	Log via.StateAppSlice[Message]
+	// Name and Draft are tab-local and two-way bound to their inputs, so
+	// the latest client values are injected before Send runs. Name rides
+	// along on every message this tab sends.
+	Name  via.SignalStr `via:"name,init=Anon"`
+	Draft via.SignalStr `via:"draft"`
+}
+
+func (r *Room) Send(ctx *via.Ctx) {
+	body := strings.TrimSpace(r.Draft.Read(ctx))
+	if body == "" {
+		return
+	}
+	name := strings.TrimSpace(r.Name.Read(ctx))
+	if name == "" {
+		name = "Anon"
+	}
+	_ = r.Log.Update(ctx, func(log []Message) ([]Message, error) {
+		log = append(log, Message{From: name, Body: body})
+		if len(log) > recentWindow {
+			log = log[len(log)-recentWindow:]
+		}
+		return log, nil
+	})
+	r.Draft.Write(ctx, "")
+}
+
+func (r *Room) View(ctx *via.CtxR) h.H {
+	// Reading Log here subscribes this tab; any Send anywhere re-renders it.
+	return h.Main(h.Class("container"),
+		h.H1(h.Text("Via Chat")),
+		h.P(h.Small(h.Text("Open another browser — messages appear live in both."))),
+		h.Article(h.Style("max-height:60vh;overflow-y:auto"),
+			h.Each(r.Log.Read(ctx), func(m Message) h.H {
+				return h.P(h.Strong(h.Text(m.From+": ")), h.Text(m.Body))
+			}),
+		),
+		// Send is type=button + on.Click so the form's native submit can't
+		// race the Datastar action POST (see internal/examples/todos).
+		h.Form(h.Style("display:grid;grid-template-columns:auto 1fr auto;gap:0.5rem"),
+			h.Input(h.Type("text"), r.Name.Bind(),
+				h.Style("max-width:8rem"), h.Placeholder("name")),
+			h.Input(h.Type("text"), r.Draft.Bind(),
+				h.Placeholder("message…"), on.Key("Enter", r.Send)),
+			h.Button(h.Type("button"), h.Text("Send"), on.Click(r.Send)),
+		),
+	)
+}
+
+func main() {
+	app := via.New(
+		via.WithTitle("Via Chat"),
+		via.WithPlugins(picocss.Plugin()),
+	)
+	via.Mount[Room](app, "/")
+	_ = http.ListenAndServe(":3000", app)
+}

--- a/internal/examples/chat/main_test.go
+++ b/internal/examples/chat/main_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-via/via"
+	"github.com/go-via/via/vt"
+	"github.com/stretchr/testify/require"
+)
+
+// The whole pitch of this example: a message sent from one browser appears
+// live in every other connected browser, with no per-example wiring — it
+// falls out of StateApp's cross-session re-render fan-out. Prove it with two
+// independent sessions (separate cookie jars).
+func TestChat_messageFansOutAcrossSessions(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	via.Mount[Room](app, "/")
+	defer server.Close()
+
+	alice := vt.NewClient(t, server, "/")
+	bob := vt.NewClient(t, server, "/") // a different session
+
+	bobFrames, cancel := bob.SSEReady()
+	defer cancel()
+
+	require.Equal(t, http.StatusOK, alice.Action("Send").
+		WithSignal("name", "alice").
+		WithSignal("draft", "hello bob").Fire())
+
+	vt.AwaitFrame(t, bobFrames, 2*time.Second, "alice: ", "hello bob")
+}


### PR DESCRIPTION
## What's in this PR

Three connected pieces of documentation/DX work.

### 1. A GitHub Pages docs site (`docs/`)
A just-the-docs Jekyll site published to **https://go-via.github.io/via** (built/deployed by `.github/workflows/pages.yml`; builds on PRs, deploys from main). Grouped nav (Learn / Guides / Reference & ops), search, edit-on-GitHub, social cards. Content reorganized from the README into navigable pages, then hardened against a documentation/DX expert review (added a tutorial, examples index, troubleshooting, glossary; fixed a `View` signature accuracy bug; scope diagram; etc.).

### 2. A flagship example: live multi-user chatroom (`internal/examples/chat`)
~60 lines — a `StateAppSlice[Message]` whose `Update` fans each message out to **every connected browser across sessions**, no `Broadcast`/WebSocket/JS. Replaces the todo app as the Learn tutorial and is the starred example. Includes `TestChat_messageFansOutAcrossSessions` proving cross-session delivery end-to-end.

### 3. A modernized README (668 → 151 lines)
Cut to a hook — pitch + thesis, the chatroom wow, the counter quickstart, the four reactive shapes, a short is/is-not, and a docs-link map. Every reference section now points into the docs site.

## Verification
- `go test -race ./...` green (incl. the new chat fan-out test); `go vet` + `golangci-lint` clean.
- Pages Jekyll build passes in CI; all docs links + assets resolve.
- No production library code changed (only a new example under `internal/examples`).

On merge, the docs publish to https://go-via.github.io/via/.