### PR TITLE
fix: label via.sse.disconnect with documented reason (#55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,7 +593,7 @@ interface and emits structured events for ops dashboards:
 | `via.action.latency`   | histogram | `method`           |
 | `via.render.total`     | counter   | `route`            |
 | `via.sse.connect`      | counter   |                    |
-| `via.sse.disconnect`   | counter   |                    |
+| `via.sse.disconnect`   | counter   | `reason`           |
 | `via.ctx.live`         | gauge     |                    |
 
 Adapt to Prometheus, OTel, or expvar by implementing three methods

--- a/ctx.go
+++ b/ctx.go
@@ -28,8 +28,14 @@ type Ctx struct {
 	queue      *patchQueue
 	doneChan   chan struct{}
 	disposed   bool
-	session    atomic.Pointer[session]
-	lastAccess atomic.Int64
+	// disposeReason records why the ctx was torn down — "shutdown" for
+	// app shutdown, "ttl" for the idle-TTL sweep, "client" for an
+	// explicit tab close. Set once by signalDispose alongside the
+	// doneChan close (both under mu), so the SSE drain loop can read it
+	// when it wakes on <-doneChan to label via.sse.disconnect.
+	disposeReason string
+	session       atomic.Pointer[session]
+	lastAccess    atomic.Int64
 
 	// lastSignals holds the most recent signals payload from an action
 	// POST so via.DecodeForm can read keys that aren't tracked by typed
@@ -171,6 +177,19 @@ func (ctx *Ctx) Disposed() bool {
 	default:
 		return false
 	}
+}
+
+// disposeReasonOrDefault returns the reason recorded by signalDispose,
+// or fallback if the ctx was disposed without one (e.g. a direct
+// doneChan close in a future path). Read under mu since disposeReason
+// is written under the same lock that closes doneChan.
+func (ctx *Ctx) disposeReasonOrDefault(fallback string) string {
+	ctx.mu.Lock()
+	defer ctx.mu.Unlock()
+	if ctx.disposeReason == "" {
+		return fallback
+	}
+	return ctx.disposeReason
 }
 
 // ID returns the tab id (the wire key for via_tab).

--- a/ctx.go
+++ b/ctx.go
@@ -24,10 +24,10 @@ type Ctx struct {
 	// so a user-launched goroutine that drives a broadcast (Update →
 	// broadcastRender) doesn't race with a concurrent action handler
 	// resetting the flag on entry.
-	silent     atomic.Bool
-	queue      *patchQueue
-	doneChan   chan struct{}
-	disposed   bool
+	silent   atomic.Bool
+	queue    *patchQueue
+	doneChan chan struct{}
+	disposed bool
 	// disposeReason records why the ctx was torn down — "shutdown" for
 	// app shutdown, "ttl" for the idle-TTL sweep, "client" for an
 	// explicit tab close. Set once by signalDispose alongside the

--- a/metrics.go
+++ b/metrics.go
@@ -25,6 +25,19 @@ type Metrics interface {
 	Histogram(name string, value float64, labels ...string)
 }
 
+// Disconnect reasons reported on the "reason" label of the
+// "via.sse.disconnect" counter (see the event catalogue above).
+const (
+	// disconnectClient covers the client going away on its own — the
+	// request context cancelling, a failed heartbeat/patch write, or an
+	// explicit tab-close beacon.
+	disconnectClient = "client"
+	// disconnectShutdown covers App.Shutdown disposing the ctx.
+	disconnectShutdown = "shutdown"
+	// disconnectTTL covers the idle-TTL sweep evicting the ctx.
+	disconnectTTL = "ttl"
+)
+
 // noopMetrics is the default backend. Every method is a no-op so apps
 // that haven't configured Metrics pay nothing on the hot path.
 type noopMetrics struct{}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1,6 +1,7 @@
 package via_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"slices"
@@ -118,9 +119,85 @@ func TestMetrics_emitsSSEConnectAndDisconnect(t *testing.T) {
 		2*time.Second, 10*time.Millisecond,
 		"via.sse.connect must fire when the SSE stream opens")
 
-	// Closing the stream runs runSSEStream's deferred disconnect counter.
+	// Closing the stream client-side runs runSSEStream's deferred
+	// disconnect counter. The request context cancels, so the loop exits
+	// via sse.Context().Done() and the documented "client" reason label
+	// is emitted (see the catalogue in metrics.go).
 	cancel()
-	require.Eventually(t, func() bool { return hasCounter("via.sse.disconnect:") },
+	require.Eventually(t, func() bool { return hasCounter("via.sse.disconnect:reason,client") },
 		2*time.Second, 10*time.Millisecond,
-		"via.sse.disconnect must fire when the SSE stream closes")
+		"via.sse.disconnect must fire with reason=client when the client closes the stream")
+}
+
+func TestMetrics_SSEDisconnectReason_shutdown(t *testing.T) {
+	t.Parallel()
+	// App.Shutdown disposes every live Ctx, which wakes the SSE drain
+	// loop on <-ctx.doneChan. The documented contract labels that exit
+	// "shutdown" so an ops dashboard can separate graceful shutdowns
+	// from client navigations. Without the fix the counter is emitted
+	// label-less and this assertion fails.
+	m := &captureMetrics{}
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server), via.WithMetrics(m))
+	via.Mount[metricsPage](app, "/")
+	defer server.Close()
+
+	hasCounter := func(name string) bool {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		return slices.Contains(m.counters, name)
+	}
+
+	tc := vt.NewClient(t, server, "/")
+	_, cancel := tc.SSEReady()
+	defer cancel()
+
+	require.Eventually(t, func() bool { return hasCounter("via.sse.connect:") },
+		2*time.Second, 10*time.Millisecond,
+		"via.sse.connect must fire when the SSE stream opens")
+
+	shutCtx, shutCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer shutCancel()
+	require.NoError(t, app.Shutdown(shutCtx))
+
+	require.Eventually(t, func() bool { return hasCounter("via.sse.disconnect:reason,shutdown") },
+		2*time.Second, 10*time.Millisecond,
+		"via.sse.disconnect must fire with reason=shutdown when the app shuts down")
+}
+
+func TestMetrics_SSEDisconnectReason_ttl(t *testing.T) {
+	t.Parallel()
+	// The idle-TTL sweep evicts a Ctx that has gone quiet and disposes
+	// it, waking the SSE drain loop on <-ctx.doneChan. The documented
+	// contract labels that exit "ttl". A short TTL keeps the test quick;
+	// the default 25s heartbeat never fires within the window, so the
+	// stream stays idle long enough to be swept.
+	m := &captureMetrics{}
+	var server *httptest.Server
+	app := via.New(
+		via.WithTestServer(&server),
+		via.WithMetrics(m),
+		via.WithContextTTL(40*time.Millisecond),
+	)
+	via.Mount[metricsPage](app, "/")
+	defer server.Close()
+	defer func() {
+		shutCtx, shutCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer shutCancel()
+		_ = app.Shutdown(shutCtx)
+	}()
+
+	hasCounter := func(name string) bool {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		return slices.Contains(m.counters, name)
+	}
+
+	tc := vt.NewClient(t, server, "/")
+	_, cancel := tc.SSEReady()
+	defer cancel()
+
+	require.Eventually(t, func() bool { return hasCounter("via.sse.disconnect:reason,ttl") },
+		2*time.Second, 10*time.Millisecond,
+		"via.sse.disconnect must fire with reason=ttl when the idle-TTL sweep evicts the Ctx")
 }

--- a/runtime.go
+++ b/runtime.go
@@ -210,30 +210,34 @@ func (a *App) removeExpiredContexts() {
 	}
 	a.contextRegistryMu.Unlock()
 	for _, c := range expired {
-		a.disposeCtx(c)
+		a.disposeCtx(c, disconnectTTL)
 	}
 }
 
 // signalDispose marks the ctx disposed and closes its Done channel so
 // any SSE drain loop or Stream goroutine wakes and exits. Does not run
 // OnDispose; idempotent. Used to break long-lived selects early during
-// Shutdown, before waiting for in-flight actions to drain.
-func (a *App) signalDispose(ctx *Ctx) {
+// Shutdown, before waiting for in-flight actions to drain. reason is
+// recorded so the woken SSE loop can label via.sse.disconnect; the
+// first caller wins (matching the idempotent doneChan close).
+func (a *App) signalDispose(ctx *Ctx, reason string) {
 	ctx.mu.Lock()
 	defer ctx.mu.Unlock()
 	if ctx.disposed {
 		return
 	}
 	ctx.disposed = true
+	ctx.disposeReason = reason
 	close(ctx.doneChan)
 }
 
 // disposeCtx closes the ctx (idempotent with signalDispose) and runs
 // OnDispose if defined. Serialized against in-flight actions via
 // actionMu so OnDispose sees a composition that isn't being mutated by
-// a concurrent handler.
-func (a *App) disposeCtx(ctx *Ctx) {
-	a.signalDispose(ctx)
+// a concurrent handler. reason is threaded to signalDispose to label
+// the via.sse.disconnect counter on the woken SSE loop.
+func (a *App) disposeCtx(ctx *Ctx, reason string) {
+	a.signalDispose(ctx, reason)
 
 	ctx.actionMu.Lock()
 	defer ctx.actionMu.Unlock()

--- a/server.go
+++ b/server.go
@@ -89,7 +89,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 	// Stream goroutines, user code watching Done) so they exit before
 	// we wait for action drain.
 	for _, c := range ctxs {
-		a.signalDispose(c)
+		a.signalDispose(c, disconnectShutdown)
 	}
 
 	// Step 2: drain in-flight non-SSE handlers via the http.Server.
@@ -105,7 +105,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 	// handlers that were mid-action have finished their work and OnDispose
 	// sees a quiescent composition.
 	for _, c := range ctxs {
-		a.disposeCtx(c)
+		a.disposeCtx(c, disconnectShutdown)
 	}
 
 	a.stopSweepOnce.Do(func() {

--- a/sse.go
+++ b/sse.go
@@ -52,7 +52,12 @@ func (a *App) handleSSE(w http.ResponseWriter, r *http.Request) {
 func runSSEStream(a *App, ctx *Ctx, w http.ResponseWriter, r *http.Request) {
 	m := a.metricsOrNoop()
 	m.Counter("via.sse.connect")
-	defer m.Counter("via.sse.disconnect")
+	// Default to "client": every exit path other than a server-side
+	// disposal (shutdown / TTL sweep) is the client going away — its
+	// request context cancelling or a heartbeat/patch write failing. The
+	// doneChan path overrides this with the reason recorded on disposal.
+	reason := disconnectClient
+	defer func() { m.Counter("via.sse.disconnect", "reason", reason) }()
 	// OnConnect runs once, the first time the SSE stream is opened. Bots
 	// that hit GET without ever opening the SSE never see this fire, so
 	// expensive background work (tickers, fan-out goroutines) lives here
@@ -107,6 +112,7 @@ func runSSEStream(a *App, ctx *Ctx, w http.ResponseWriter, r *http.Request) {
 		case <-sse.Context().Done():
 			return
 		case <-ctx.doneChan:
+			reason = ctx.disposeReasonOrDefault(disconnectClient)
 			return
 		case <-heartbeat:
 			setSSEWriteDeadline(w, a.cfg.sseWriteTimeout)
@@ -237,6 +243,6 @@ func (a *App) handleSSEClose(w http.ResponseWriter, r *http.Request) {
 		// they then try to operate on. disposeCtx is idempotent so
 		// the dispose-after-unregister order is safe.
 		a.unregisterCtx(tabID)
-		a.disposeCtx(ctx)
+		a.disposeCtx(ctx, disconnectClient)
 	}
 }


### PR DESCRIPTION
## Summary

- The `Metrics` event catalogue documents `via.sse.disconnect` as a counter carrying a `reason` label (`client` / `shutdown` / `ttl`), but `runSSEStream` emitted the counter with no labels — so SSE disconnects could not be broken down by cause, and any Prometheus/OTel adapter built against the documented contract received a label-less counter.
- The three reasons map to distinct exit paths. The `client` paths (request-context cancel, heartbeat/patch write failure, explicit tab-close beacon) are observable directly in the SSE loop. Server-side disposal — app shutdown vs. the idle-TTL sweep — both close `ctx.doneChan`, so the loop cannot tell them apart on its own.
- Fixed at the root cause: the disposal reason is now recorded at the single chokepoint that closes `doneChan`, rather than guessed at the point the counter is emitted.

## Changes

- `ctx.go`: add `Ctx.disposeReason`, written under `mu` alongside the `doneChan` close, plus a `disposeReasonOrDefault` accessor read under the same lock.
- `runtime.go`: `signalDispose` / `disposeCtx` now take a `reason` (first caller wins, matching the idempotent close); the idle-TTL sweep passes `ttl`.
- `server.go`: `Shutdown` passes `shutdown` to both `signalDispose` and `disposeCtx`.
- `sse.go`: `handleSSEClose` passes `client`; `runSSEStream` defaults `reason` to `client` and reads the recorded reason when it wakes on `<-ctx.doneChan`, emitting it on the disconnect counter.
- `metrics.go`: add `disconnectClient` / `disconnectShutdown` / `disconnectTTL` constants.
- `metrics_test.go`: the existing lifecycle test now asserts `reason=client`; added `TestMetrics_SSEDisconnectReason_shutdown` (via `App.Shutdown`) and `TestMetrics_SSEDisconnectReason_ttl` (via a short `WithContextTTL`).
- `README.md`: document the `reason` label in the metrics table.

Fixes #55