### PR TITLE
fix: float32 formatting, CI alloc gate, CSP-nonced SSE pushes, sess.Clear(CtxR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,24 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-go--via.github.io%2Fvia-blue)](https://go-via.github.io/via)
 
-**Reactive web apps in pure Go.** A composition is a struct, reactive state is a typed field, actions are methods — and the compiler understands your UI. Via is the only framework, in any language, that expresses the **client/server reactive split as a Go type**: `Signal[T]` lives in the browser, `StateTab/Sess/App[T]` live only on the server. Which side owns a piece of state is a field declaration the compiler checks, not a convention you grep for. Transport is SSE only — no WebSockets, no build step, no hand-written JS.
+**Reactive web apps in pure Go.** A composition is a struct, reactive state
+is a typed field, actions are methods — and the compiler understands your UI.
+Via is the only framework, in any language, that expresses the
+**client/server reactive split as a Go type**: `Signal[T]` lives in the
+browser, `StateTab/Sess/App[T]` live only on the server. Which side owns a
+piece of state is a field declaration the compiler checks, not a convention
+you grep for. Transport is SSE only — no WebSockets, no build step, no
+hand-written JS.
 
-📖 **[Documentation](https://go-via.github.io/via)** · [API reference](https://pkg.go.dev/github.com/go-via/via) · [Examples](https://go-via.github.io/via/examples)
+📖 **[Documentation](https://go-via.github.io/via)** ·
+[API reference](https://pkg.go.dev/github.com/go-via/via) ·
+[Examples](https://go-via.github.io/via/examples)
 
-## The wow: a live chatroom in ~60 lines
+## Quickstart: a live chatroom in ~60 lines
 
-`Log` is one app-scoped slice. Appending to it fans a re-render out to **every connected tab across every session** — open two browsers and watch them sync. No `Broadcast`, no WebSocket, no client JS.
+`Log` is one app-scoped slice. Appending to it fans a re-render out to
+**every connected tab across every session** — open two browsers and watch
+them sync. No `Broadcast`, no WebSocket, no client JS.
 
 ```go
 type Message struct{ From, Body string }
@@ -58,7 +69,9 @@ func (r *Room) View(ctx *via.CtxR) h.H {
 go run ./internal/examples/chat   # then open http://localhost:3000 in two windows
 ```
 
-Full source + walkthrough: [`internal/examples/chat`](internal/examples/chat/main.go) · [tutorial](https://go-via.github.io/via/tutorial).
+Full source + walkthrough:
+[`internal/examples/chat`](internal/examples/chat/main.go) ·
+[tutorial](https://go-via.github.io/via/tutorial).
 
 ## Install
 
@@ -68,7 +81,8 @@ go get github.com/go-via/via
 
 ## Quickstart: the counter
 
-`Hits` is server-owned; `Step` rides in the browser. `on.Click(c.Inc)` is a typed method reference — a typo is a compile error.
+`Hits` is server-owned; `Step` rides in the browser. `on.Click(c.Inc)` is a
+typed method reference — a typo is a compile error.
 
 ```go
 package main
@@ -117,34 +131,57 @@ go run ./internal/examples/counter
 
 Whether state lives on the client, the server, or both is the field's type:
 
-| Handle | Scope | Lives on |
-|---|---|---|
-| `via.Signal[T]` | per-tab | client + server |
-| `via.StateTab[T]` | per-tab | server only |
-| `via.StateSess[T]` | per-session | server only |
-| `via.StateApp[T]` | global | server only |
+| Handle             | Scope       | Lives on        |
+| ------------------ | ----------- | --------------- |
+| `via.Signal[T]`    | per-tab     | client + server |
+| `via.StateTab[T]`  | per-tab     | server only     |
+| `via.StateSess[T]` | per-session | server only     |
+| `via.StateApp[T]`  | global      | server only     |
 
-`Read(ctx)` / `Update(ctx, fn)` everywhere; `Signal` and `StateTab` add `Write(ctx, v)`. The `Num` / `Bool` / `Str` / `Slice` / `Map` wrappers add typed `Op(ctx)` verbs (`Add`, `Toggle`, `Append`, …). [Full model →](https://go-via.github.io/via/reactive-state)
+`Read(ctx)` / `Update(ctx, fn)` everywhere; `Signal` and `StateTab` add
+`Write(ctx, v)`. The `Num` / `Bool` / `Str` / `Slice` / `Map` wrappers add
+typed `Op(ctx)` verbs (`Add`, `Toggle`, `Append`, …).
+[Full model →](https://go-via.github.io/via/reactive-state)
 
 ## What Via is — and is not
 
-- **Is:** server-rendered pages with typed end-to-end state, a fine-grained reactive client runtime (Datastar / Alien Signals), and no build step — best for internal tools, dashboards, and line-of-business apps you'd otherwise build with LiveView, Hotwire, or htmx + hand-written JS.
+- **Is:** server-rendered pages with typed end-to-end state, a fine-grained
+  reactive client runtime (Datastar / Alien Signals), and no build step —
+  best for internal tools, dashboards, and line-of-business apps you'd
+  otherwise build with LiveView, Hotwire, or htmx + hand-written JS.
 - **Is not** an SPA framework — the browser receives HTML, not a JSON bundle.
-- **Is not** a cluster runtime — `StateApp[T]` and `Broadcast` are single-process; horizontal scaling needs sticky sessions.
-- **Is not** offline-first or stable yet — drop the SSE stream and the tab freezes until the client reconnects (Datastar retries automatically), and APIs can still shift pre-1.0.
+- **Is not** a cluster runtime — `StateApp[T]` and `Broadcast` are
+  single-process; horizontal scaling needs sticky sessions.
+- **Is not** offline-first or stable yet — drop the SSE stream and the tab
+  freezes until the client reconnects (Datastar retries automatically), and
+  APIs can still shift pre-1.0.
 
 ## Documentation
 
-The full guide and reference live at **[go-via.github.io/via](https://go-via.github.io/via)**.
+The full guide and reference live at
+**[go-via.github.io/via](https://go-via.github.io/via)**.
 
-- [Why Via](https://go-via.github.io/via/why-via) — the thesis, and Via vs. LiveView / Hotwire / htmx / templ.
-- [Getting started](https://go-via.github.io/via/getting-started) · [Tutorial](https://go-via.github.io/via/tutorial) — install, first composition, then build the live chatroom.
-- [Reactive state](https://go-via.github.io/via/reactive-state) — `Signal` vs `StateTab/Sess/App`, typed ops, view helpers.
-- [Actions & lifecycle](https://go-via.github.io/via/actions-and-lifecycle) — events, hooks, streaming, broadcast.
-- [Rendering](https://go-via.github.io/via/rendering) · [h helpers](https://go-via.github.io/via/h-helpers) — the HTML DSL.
-- [Routing, sessions & middleware](https://go-via.github.io/via/routing-sessions-middleware) · [File uploads](https://go-via.github.io/via/file-uploads) · [Plugins](https://go-via.github.io/via/plugins).
-- [Testing](https://go-via.github.io/via/testing) · [Production & ops](https://go-via.github.io/via/production) — config, metrics, security, deploys.
-- [Examples](https://go-via.github.io/via/examples) · [Troubleshooting](https://go-via.github.io/via/troubleshooting) · [Glossary](https://go-via.github.io/via/glossary).
+- [Why Via](https://go-via.github.io/via/why-via) — the thesis, and Via vs.
+  LiveView / Hotwire / htmx / templ.
+- [Getting started](https://go-via.github.io/via/getting-started) ·
+  [Tutorial](https://go-via.github.io/via/tutorial) — install, your first
+  composition, then build the live chatroom.
+- [Reactive state](https://go-via.github.io/via/reactive-state) — `Signal`
+  vs `StateTab/Sess/App`, typed ops, view helpers.
+- [Actions & lifecycle](https://go-via.github.io/via/actions-and-lifecycle)
+  — events, hooks, streaming, broadcast.
+- [Rendering](https://go-via.github.io/via/rendering) ·
+  [h helpers](https://go-via.github.io/via/h-helpers) — the HTML DSL.
+- [Routing & sessions](https://go-via.github.io/via/routing-sessions-middleware)
+  — routing, groups, sessions, auth, the middleware stack.
+- [File uploads](https://go-via.github.io/via/file-uploads) — `via.File`.
+- [Plugins](https://go-via.github.io/via/plugins) — picocss, echarts.
+- [Testing](https://go-via.github.io/via/testing) ·
+  [Production & ops](https://go-via.github.io/via/production) — `vt`; config,
+  metrics, security, deploys.
+- [Examples](https://go-via.github.io/via/examples) ·
+  [Troubleshooting](https://go-via.github.io/via/troubleshooting) ·
+  [Glossary](https://go-via.github.io/via/glossary).
 
 ## License
 

--- a/ci-check.sh
+++ b/ci-check.sh
@@ -76,8 +76,15 @@ echo "== CI: Allocation gates =="
 #   BenchmarkCounterRender-20    1000   95012 ns/op   29200 B/op   206 allocs/op
 # Pull the allocs column for the named benchmarks and fail if it
 # exceeds the threshold for that bench.
-bench_out=$(go test ./. -run='^$' -bench='^BenchmarkCounter' -benchtime=200x -benchmem 2>&1 || true)
+# Capture the bench exit status explicitly: a compile error, panic, or
+# missing benchmark must fail the gate, not skip it (fail closed).
+bench_status=0
+bench_out=$(go test ./. -run='^$' -bench='^BenchmarkCounter' -benchtime=200x -benchmem 2>&1) || bench_status=$?
 echo "$bench_out"
+if [ "$bench_status" -ne 0 ]; then
+  echo "ERROR: allocation benchmarks failed to run (exit $bench_status); perf gate cannot be evaluated"
+  exit 1
+fi
 
 check_alloc() {
   local name=$1
@@ -85,14 +92,14 @@ check_alloc() {
   local line
   line=$(echo "$bench_out" | grep -E "^${name}-" || true)
   if [ -z "$line" ]; then
-    echo "WARN: bench $name not found in output, skipping gate"
-    return 0
+    echo "ERROR: bench $name not found in output; perf gate cannot be evaluated"
+    return 1
   fi
   local got
   got=$(echo "$line" | awk '{for(i=1;i<=NF;i++) if($i=="allocs/op") print $(i-1)}')
   if [ -z "$got" ]; then
-    echo "WARN: could not parse allocs/op from $line"
-    return 0
+    echo "ERROR: could not parse allocs/op from: $line"
+    return 1
   fi
   if [ "$got" -gt "$threshold" ]; then
     echo "ERROR: $name regressed to $got allocs/op (threshold: $threshold)"

--- a/csp.go
+++ b/csp.go
@@ -34,6 +34,39 @@ func (ctx *Ctx) CSPNonce() string {
 	return ctx.cspNonce
 }
 
+// captureCSPNonce records the request's strict-CSP nonce on ctx so the
+// SSE push path can nonce server-injected <script> elements with the same
+// value the page document was served under. It is read-only — it never
+// generates a nonce — and writes a dedicated field (not the lazy CSPNonce
+// cache), so a page served without a CSP middleware leaves docNonce empty
+// even if a View calls CSPNonce(), and pushed scripts stay attribute-free.
+// Called once at page render; the first non-empty value wins, so a later
+// action/SSE request's (distinct, per-request) nonce can't clobber it.
+func (ctx *Ctx) captureCSPNonce(r *http.Request) {
+	if ctx == nil || r == nil {
+		return
+	}
+	v, ok := r.Context().Value(cspNonceKey{}).(string)
+	if !ok || v == "" {
+		return
+	}
+	ctx.mu.Lock()
+	if ctx.docNonce == "" {
+		ctx.docNonce = v
+	}
+	ctx.mu.Unlock()
+}
+
+// documentCSPNonce returns the nonce the page document was served under, or
+// "" if no CSP middleware threaded one. Unlike CSPNonce it never generates
+// a value — the push path must use the document's real nonce or nothing,
+// never a freshly minted one the browser's policy wouldn't recognise.
+func (ctx *Ctx) documentCSPNonce() string {
+	ctx.mu.Lock()
+	defer ctx.mu.Unlock()
+	return ctx.docNonce
+}
+
 type cspNonceKey struct{}
 
 // RequestWithCSPNonce returns r with nonce stored in its context so

--- a/csp_push_test.go
+++ b/csp_push_test.go
@@ -1,0 +1,166 @@
+package via_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-via/via"
+	"github.com/go-via/via/h"
+	"github.com/go-via/via/vt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type cspPushPage struct{}
+
+func (p *cspPushPage) PopToast(ctx *via.Ctx) error {
+	ctx.Toast("hi")
+	return nil
+}
+
+func (p *cspPushPage) GoRedirect(ctx *via.Ctx) error {
+	ctx.Redirect("/elsewhere")
+	return nil
+}
+
+func (p *cspPushPage) View(ctx *via.CtxR) h.H {
+	return h.Div(h.Text("push"))
+}
+
+// pathKeyedNonce gives the page GET ("/") the nonce "pagenonce" and every
+// other request (the /_sse handshake, the /_action POST) the nonce
+// "reqnonce". A script pushed over SSE is injected into the page document,
+// so it must carry the document's nonce ("pagenonce") — not the nonce of
+// the SSE or action request that happens to trigger the push.
+func pathKeyedNonce() via.Middleware {
+	return func(w http.ResponseWriter, r *http.Request, next http.Handler) {
+		n := "reqnonce"
+		if r.URL.Path == "/" {
+			n = "pagenonce"
+		}
+		w.Header().Set("Content-Security-Policy",
+			"script-src 'self' 'nonce-"+n+"'")
+		next.ServeHTTP(w, via.RequestWithCSPNonce(r, n))
+	}
+}
+
+func TestPushedToast_carriesPageNonceNotRequestNonce(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	app.Use(pathKeyedNonce())
+	via.Mount[cspPushPage](app, "/")
+	defer server.Close()
+
+	tc := vt.NewClient(t, server, "/")
+	frames, cancel := tc.SSEReady()
+	defer cancel()
+	require.Equal(t, http.StatusOK, tc.Action("PopToast").Fire())
+
+	frame := vt.AwaitFrame(t, frames, 2*time.Second, `nonce="pagenonce"`)
+	assert.NotContains(t, frame, `nonce="reqnonce"`,
+		"a pushed script must use the page-document nonce, not the SSE/action request nonce")
+}
+
+func TestPushedRedirect_carriesPageNonce(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	app.Use(pathKeyedNonce())
+	via.Mount[cspPushPage](app, "/")
+	defer server.Close()
+
+	tc := vt.NewClient(t, server, "/")
+	frames, cancel := tc.SSEReady()
+	defer cancel()
+	require.Equal(t, http.StatusOK, tc.Action("GoRedirect").Fire())
+
+	frame := vt.AwaitFrame(t, frames, 2*time.Second, `nonce="pagenonce"`)
+	assert.Contains(t, frame, "window.location.href",
+		"redirect rides datastar ExecuteScript, which needs the nonce too")
+	assert.NotContains(t, frame, `nonce="reqnonce"`)
+}
+
+func TestPushedScript_hasNoNonceWithoutCSP(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	via.Mount[cspPushPage](app, "/")
+	defer server.Close()
+
+	tc := vt.NewClient(t, server, "/")
+	frames, cancel := tc.SSEReady()
+	defer cancel()
+	require.Equal(t, http.StatusOK, tc.Action("PopToast").Fire())
+
+	frame := vt.AwaitFrame(t, frames, 2*time.Second, "via-toast")
+	assert.NotContains(t, frame, "nonce=",
+		"with no CSP middleware no nonce is captured, so pushed scripts stay attribute-free")
+}
+
+type cspPushNonceViewPage struct{}
+
+func (p *cspPushNonceViewPage) PopToast(ctx *via.Ctx) error {
+	ctx.Toast("hi")
+	return nil
+}
+
+func (p *cspPushNonceViewPage) View(ctx *via.CtxR) h.H {
+	// Embedding the nonce lazily generates and caches one even with no CSP
+	// middleware; the push path must read the document nonce (still empty),
+	// not that minted value.
+	return h.Div(h.ID("n"), h.Text(ctx.CSPNonce()))
+}
+
+func TestPushedScript_ignoresViewMintedNonceWithoutCSP(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	via.Mount[cspPushNonceViewPage](app, "/")
+	defer server.Close()
+
+	tc := vt.NewClient(t, server, "/")
+	frames, cancel := tc.SSEReady()
+	defer cancel()
+	require.Equal(t, http.StatusOK, tc.Action("PopToast").Fire())
+
+	frame := vt.AwaitFrame(t, frames, 2*time.Second, "via-toast")
+	assert.NotContains(t, frame, "nonce=",
+		"a View-minted nonce with no CSP policy must not leak onto pushed scripts")
+}
+
+func TestPushedScript_escapesNonceAttribute(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	// Only reachable if an app threads a non-base64 nonce through the
+	// exported RequestWithCSPNonce; the SSE sink must escape it rather than
+	// let a quote break out into a new attribute.
+	app.Use(func(w http.ResponseWriter, r *http.Request, next http.Handler) {
+		if r.URL.Path == "/" {
+			next.ServeHTTP(w, via.RequestWithCSPNonce(r, `x" onerror="boom`))
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+	via.Mount[cspPushPage](app, "/")
+	defer server.Close()
+
+	tc := vt.NewClient(t, server, "/")
+	frames, cancel := tc.SSEReady()
+	defer cancel()
+	require.Equal(t, http.StatusOK, tc.Action("PopToast").Fire())
+
+	frame := vt.AwaitFrame(t, frames, 2*time.Second, "via-toast")
+	assert.NotContains(t, frame, `onerror="boom`,
+		"a quote in the nonce must be escaped, not break out into a live attribute")
+	assert.Contains(t, frame, "&#34;",
+		"the quote is HTML-escaped at the SSE sink")
+}

--- a/ctx.go
+++ b/ctx.go
@@ -43,6 +43,7 @@ type Ctx struct {
 	lastSignals map[string]any
 
 	cspNonce string // lazily generated per-request CSP nonce
+	docNonce string // page document's CSP nonce, captured at render for the push path
 
 	connectOnce sync.Once // guards OnConnect dispatch
 

--- a/encoding.go
+++ b/encoding.go
@@ -36,7 +36,13 @@ func encodeScalar(v reflect.Value) ([]byte, error) {
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		return strconv.AppendUint(nil, v.Uint(), 10), nil
 	case reflect.Float32, reflect.Float64:
-		return strconv.AppendFloat(nil, v.Float(), 'g', -1, 64), nil
+		// reflect.Value.Float widens a float32 to float64; formatting at
+		// bitSize 64 would surface the widening (float32(0.1) → 0.10000000149011612).
+		bits := 64
+		if v.Kind() == reflect.Float32 {
+			bits = 32
+		}
+		return strconv.AppendFloat(nil, v.Float(), 'g', -1, bits), nil
 	}
 	return json.Marshal(v.Interface())
 }

--- a/render.go
+++ b/render.go
@@ -22,6 +22,10 @@ func (a *App) renderPage(d *cmpDescriptor, w http.ResponseWriter, r *http.Reques
 	ctx.w = w
 	ctx.r = r
 	ctx.mu.Unlock()
+	// Capture the document's CSP nonce now, while the page request is in
+	// hand, so server-pushed scripts drained over the (later, separate) SSE
+	// request can carry the nonce the browser will actually honor.
+	ctx.captureCSPNonce(r)
 	// Writer / Request are scoped to the synchronous render only — any
 	// goroutine the user launches from OnInit must not see a dangling
 	// reference to a writer that's already been released back to the

--- a/sess/sess.go
+++ b/sess/sess.go
@@ -13,8 +13,9 @@
 //	sess.Clear[User](ctx)
 //	sess.Rotate(ctx)
 //
-// Get and Clear also accept *http.Request, so middleware can check
-// the session before any composition is rendered:
+// Get and Clear also accept *via.CtxR (inside a render) and
+// *http.Request, so middleware can check the session before any
+// composition is rendered:
 //
 //	func requireAuth(w http.ResponseWriter, r *http.Request, next http.Handler) {
 //	    if u, ok := sess.Get[User](r); !ok || u.Email == "" {
@@ -47,9 +48,10 @@ func Put[T any](ctx *via.Ctx, v T) {
 }
 
 // Get reads the typed value stored with [Put], returning the zero
-// value of T and false if nothing matches. src may be a *via.Ctx or
-// an *http.Request — the latter form lets middleware check the
-// session before any composition is rendered.
+// value of T and false if nothing matches. src may be a *via.Ctx, a
+// *via.CtxR (for reads during a render), or an *http.Request — the last
+// form lets middleware check the session before any composition is
+// rendered.
 func Get[T any](src any) (T, bool) {
 	var zero T
 	var s *via.Session
@@ -71,11 +73,15 @@ func Get[T any](src any) (T, bool) {
 	return t, ok
 }
 
-// Clear removes the value stored under T's key from the session.
-// src may be a *via.Ctx or an *http.Request.
+// Clear removes the value stored under T's key from the session. src may
+// be a *via.Ctx, a *via.CtxR, or an *http.Request — the same kinds [Get]
+// accepts, so a value read during a render can be cleared from the same
+// render.
 func Clear[T any](src any) {
 	switch v := src.(type) {
 	case *via.Ctx:
+		v.Session().Delete(typeKey[T]())
+	case *via.CtxR:
 		v.Session().Delete(typeKey[T]())
 	case *http.Request:
 		via.RequestSession(v).Delete(typeKey[T]())

--- a/sess/sess_test.go
+++ b/sess/sess_test.go
@@ -111,6 +111,38 @@ func TestPutSess_andClearSess_roundTrip(t *testing.T) {
 		"a fresh session should not see the previous user's data")
 }
 
+type clearViaRenderPage struct{}
+
+func (p *clearViaRenderPage) Store(ctx *via.Ctx) error {
+	sess.Put(ctx, sessUser{Name: "alice"})
+	return nil
+}
+
+func (p *clearViaRenderPage) View(ctx *via.CtxR) h.H {
+	// Clear accepts the same context kinds as Get; a render holds a *CtxR,
+	// so clearing here must actually remove the value, not silently no-op.
+	sess.Clear[sessUser](ctx)
+	if _, ok := sess.Get[sessUser](ctx); ok {
+		return h.Div(h.ID("s"), h.Text("present"))
+	}
+	return h.Div(h.ID("s"), h.Text("absent"))
+}
+
+func TestClearSess_viaCtxRRemovesValue(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	via.Mount[clearViaRenderPage](app, "/")
+	defer server.Close()
+
+	tc := vt.NewClient(t, server, "/")
+	require.Equal(t, 200, tc.Action("Store").Fire())
+	body := tc.Reload()
+	assert.Contains(t, body, `<div id="s">absent</div>`,
+		"sess.Clear must remove the value when called with a *via.CtxR, mirroring Get")
+}
+
 type loginPage struct {
 	UserID via.StateSessStr
 }

--- a/signal_test.go
+++ b/signal_test.go
@@ -330,6 +330,34 @@ func TestSignalInit_decodesUintAndFloatFromTagStrings(t *testing.T) {
 	assert.Contains(t, html, `&#34;f&#34;:2.5`, "float init= string must decode")
 }
 
+type signalFloat32Page struct {
+	Rate via.SignalNum[float32] `via:"rate,init=0.1"`
+}
+
+func (p *signalFloat32Page) View(ctx *via.CtxR) h.H {
+	return h.Div(p.Rate.Text())
+}
+
+func TestSignalEncode_float32WireValueHasNoFloat64Noise(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	via.Mount[signalFloat32Page](app, "/")
+	defer server.Close()
+
+	tc := vt.NewClient(t, server, "/")
+
+	// The data-signals payload is HTML-escaped in the <meta> attribute, so a
+	// clean float32 reads as &#34;rate&#34;:0.1; bitSize 64 would surface the
+	// float64 widening of float32(0.1).
+	html := tc.HTML()
+	assert.Contains(t, html, `&#34;rate&#34;:0.1`,
+		"float32 signal must wire-encode at its own precision")
+	assert.NotContains(t, html, "0.10000000149011612",
+		"reflect.Value.Float widens float32; bitSize 64 leaks the expansion")
+}
+
 func TestSignalAction_coercesUintFloatBoolFromJSONPayload(t *testing.T) {
 	t.Parallel()
 

--- a/sse.go
+++ b/sse.go
@@ -3,6 +3,7 @@ package via
 import (
 	"encoding/json"
 	"errors"
+	"html"
 	"io"
 	"net/http"
 	"strings"
@@ -169,8 +170,9 @@ func drainQueue(sse *datastar.ServerSentEventGenerator, ctx *Ctx, w http.Respons
 	q.redirect = ""
 	q.mu.Unlock()
 
+	nonceOpts := ctx.scriptNonceOpts()
 	if redirect != "" {
-		return sse.Redirect(redirect)
+		return sse.Redirect(redirect, nonceOpts...)
 	}
 	if elems != "" {
 		if err := sse.PatchElements(elems); err != nil {
@@ -193,11 +195,28 @@ func drainQueue(sse *datastar.ServerSentEventGenerator, ctx *Ctx, w http.Respons
 		recycleSignalsMap(q, signals)
 	}
 	if scripts != "" {
-		if err := sse.ExecuteScript(scripts); err != nil {
+		if err := sse.ExecuteScript(scripts, nonceOpts...); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// scriptNonceOpts threads the page document's captured CSP nonce onto the
+// <script> elements datastar injects for ExecuteScript / Redirect, so they
+// survive a strict `script-src 'nonce-…'` policy. Returns nil when no nonce
+// was captured (no CSP middleware), keeping the push attribute-free. The
+// value is HTML-escaped at this sink — mirroring the document render path
+// (the h builder escapes attributes) — so a non-base64 nonce threaded via
+// the exported RequestWithCSPNonce can't break out of the attribute.
+func (ctx *Ctx) scriptNonceOpts() []datastar.ExecuteScriptOption {
+	n := ctx.documentCSPNonce()
+	if n == "" {
+		return nil
+	}
+	return []datastar.ExecuteScriptOption{
+		datastar.WithExecuteScriptAttributes(`nonce="` + html.EscapeString(n) + `"`),
+	}
 }
 
 // recycleSignalsMap returns m to the queue for reuse if no producer

--- a/state.go
+++ b/state.go
@@ -132,7 +132,13 @@ func scalarString(v reflect.Value) string {
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		return strconv.FormatUint(v.Uint(), 10)
 	case reflect.Float32, reflect.Float64:
-		return strconv.FormatFloat(v.Float(), 'g', -1, 64)
+		// reflect.Value.Float widens a float32 to float64; formatting at
+		// bitSize 64 would surface the widening (float32(0.1) → 0.10000000149011612).
+		bits := 64
+		if v.Kind() == reflect.Float32 {
+			bits = 32
+		}
+		return strconv.FormatFloat(v.Float(), 'g', -1, bits)
 	}
 	b, _ := json.Marshal(v.Interface())
 	return string(b)

--- a/state_test.go
+++ b/state_test.go
@@ -137,6 +137,28 @@ func TestStateTabText_rendersBoolUintFloatAndCompositeKinds(t *testing.T) {
 		"a composite StateTab value falls back to JSON (nil slice → null)")
 }
 
+type stateFloat32TextPage struct {
+	Rate via.StateTabNum[float32] `via:"rate,init=0.1"`
+}
+
+func (p *stateFloat32TextPage) View(ctx *via.CtxR) h.H {
+	return h.Div(h.Span(h.ID("rate"), p.Rate.Text(ctx)))
+}
+
+func TestStateTabText_rendersFloat32WithoutFloat64Noise(t *testing.T) {
+	t.Parallel()
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	via.Mount[stateFloat32TextPage](app, "/")
+	defer server.Close()
+
+	body := getBody(t, server, "/")
+	assert.Contains(t, body, `<span id="rate">0.1</span>`,
+		"float32 must format at its own precision, not widen to float64")
+	assert.NotContains(t, body, "0.10000000149011612",
+		"reflect.Value.Float widens float32; bitSize 64 leaks the expansion")
+}
+
 // Update — read-modify-write on StateTab[T] and Signal[T]
 
 type updatePage struct {


### PR DESCRIPTION
A batch of small, independent correctness fixes (each test-first, full `go test -race ./...` + `golangci-lint` clean locally), plus a README line-wrap.

### Fixes

- **`fix(encoding)`** — `float32` `Signal`/`StateTab` values were formatted at `bitSize 64`, so `reflect.Value.Float` widening leaked the float64 expansion (`float32(0.1)` → `0.10000000149011612`) into both the `data-signals` wire payload and the rendered DOM. Now branches on `reflect.Float32` and formats at `bitSize 32`. Tests: `TestStateTabText_rendersFloat32WithoutFloat64Noise`, `TestSignalEncode_float32WireValueHasNoFloat64Noise`.

- **`fix(ci)`** — the allocation-regression gate failed *open*: `|| true` swallowed the bench exit status and a missing/unparseable benchmark `WARN`+skipped the gate, so a renamed/broken bench left CI green with the only perf guard disabled. Now captures the bench status and treats "benchmark not found" / "unparseable allocs/op" as hard errors.

- **`fix(csp)`** — under `mw.CSP()` every server-pushed script (`Toast`/`Reload`/`ExecScript`/`Redirect`) was silently blocked, because the datastar-injected `<script>` carried no nonce. The page document's CSP nonce is now captured at render (a dedicated read-only field, never lazily minted) and threaded — HTML-escaped at the sink — into `sse.ExecuteScript`/`sse.Redirect`, reusing the *page* nonce the loaded document's CSP honors. First coverage of the interactive SSE path under CSP (`csp_push_test.go`).

- **`fix(sess)`** — `sess.Clear` accepted only `*via.Ctx`/`*http.Request`; a `*via.CtxR` (held by a View) fell through to a silent no-op. Added the missing `*via.CtxR` case mirroring `Get`, and corrected the godoc. Test: `TestClearSess_viaCtxRRemovesValue`.

- **`docs(readme)`** — wrap prose to 80 columns (matching `CONVENTIONS.md`) and tidy section headings.

Rebased onto current `main` (post-#57/#58); no overlap with the `via.sse.disconnect` reason-label work.