### PR TITLE
fix(runtime): disable context-TTL sweep when TTL ≤ SSE heartbeat

### DIFF
--- a/app.go
+++ b/app.go
@@ -328,12 +328,24 @@ func New(opts ...Option) *App {
 	a.rebuildChain()
 	a.handler = a.withSession()
 
-	if a.cfg.sessionTTL > 0 || a.cfg.contextTTL > 0 {
+	// A contextTTL no larger than the SSE heartbeat is unworkable: the
+	// sweep would reap a connected stream before the next heartbeat could
+	// refresh its lastAccess. Rather than let that kill live tabs, disable
+	// the context sweep entirely (no TTL) and warn. A short TTL only takes
+	// effect when the heartbeat is off (WithSSEHeartbeat(0)).
+	sweepContexts := a.cfg.contextTTL > 0
+	if sweepContexts && a.cfg.sseHeartbeat > 0 && a.cfg.contextTTL <= a.cfg.sseHeartbeat {
+		a.logWarn(nil, "via: contextTTL (%s) <= sseHeartbeat (%s); disabling the "+
+			"context-TTL sweep (no expiry) so live streams aren't reaped between heartbeats",
+			a.cfg.contextTTL, a.cfg.sseHeartbeat)
+		sweepContexts = false
+	}
+	if a.cfg.sessionTTL > 0 || sweepContexts {
 		a.stopSweep = make(chan struct{})
 		if a.cfg.sessionTTL > 0 {
 			go a.runSweep(a.cfg.sessionTTL/2, time.Millisecond, a.removeExpiredSessions)
 		}
-		if a.cfg.contextTTL > 0 {
+		if sweepContexts {
 			go a.runSweep(a.cfg.contextTTL/2, time.Second, a.removeExpiredContexts)
 		}
 	}

--- a/config.go
+++ b/config.go
@@ -71,10 +71,25 @@ func WithShutdownTimeout(d time.Duration) Option { return func(c *config) { c.sh
 // WithSessionTTL sets the per-session expiry. Default 30 minutes.
 func WithSessionTTL(d time.Duration) Option { return func(c *config) { c.sessionTTL = d } }
 
-// WithContextTTL sets the per-tab Ctx idle expiry. Default 15 minutes.
+// WithContextTTL sets the per-tab Ctx idle expiry. Default 15 minutes; a
+// value <= 0 disables the sweep (contexts never expire).
+//
+// A Ctx is "idle" by last activity, and the SSE heartbeat counts as
+// activity — so a connected stream is kept alive by heartbeat ticks and is
+// never swept as long as the TTL exceeds the heartbeat interval. Because a
+// TTL no larger than the heartbeat can't be kept alive that way, configuring
+// 0 < contextTTL <= [WithSSEHeartbeat] disables the context sweep entirely
+// (logged at startup) rather than risk reaping live streams between beats.
+// A short TTL therefore only takes effect with the heartbeat off.
 func WithContextTTL(d time.Duration) Option { return func(c *config) { c.contextTTL = d } }
 
-// WithSSEHeartbeat sets the SSE keep-alive interval.
+// WithSSEHeartbeat sets the SSE keep-alive interval. Default 25s; a value
+// <= 0 disables the heartbeat.
+//
+// The heartbeat doubles as the liveness signal for the context-TTL sweep:
+// each tick refreshes the Ctx's last-activity time, so a connected tab is
+// never expired while the heartbeat is running and the TTL exceeds it. See
+// [WithContextTTL] for what happens when the TTL is not larger than this.
 func WithSSEHeartbeat(d time.Duration) Option { return func(c *config) { c.sseHeartbeat = d } }
 
 // WithSSEWriteTimeout caps how long a single SSE drain may block on the

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -213,7 +213,10 @@ func TestContextSweep_disposesIdleTabAfterTTL(t *testing.T) {
 	sweepDisposed.Store(false)
 
 	var server *httptest.Server
-	app := via.New(via.WithTestServer(&server), via.WithContextTTL(40*time.Millisecond))
+	// Heartbeat off so the short TTL takes effect — a contextTTL <= the
+	// heartbeat disables the sweep (see WithContextTTL).
+	app := via.New(via.WithTestServer(&server),
+		via.WithContextTTL(40*time.Millisecond), via.WithSSEHeartbeat(0))
 	via.Mount[sweepDisposePage](app, "/")
 	defer server.Close()
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -169,15 +169,17 @@ func TestMetrics_SSEDisconnectReason_ttl(t *testing.T) {
 	t.Parallel()
 	// The idle-TTL sweep evicts a Ctx that has gone quiet and disposes
 	// it, waking the SSE drain loop on <-ctx.doneChan. The documented
-	// contract labels that exit "ttl". A short TTL keeps the test quick;
-	// the default 25s heartbeat never fires within the window, so the
-	// stream stays idle long enough to be swept.
+	// contract labels that exit "ttl". The heartbeat is disabled so the
+	// stream stays idle long enough to be swept; with the heartbeat on,
+	// contextTTL must exceed it (otherwise the sweep is disabled, see
+	// WithContextTTL) and a connected stream is never reaped.
 	m := &captureMetrics{}
 	var server *httptest.Server
 	app := via.New(
 		via.WithTestServer(&server),
 		via.WithMetrics(m),
 		via.WithContextTTL(40*time.Millisecond),
+		via.WithSSEHeartbeat(0),
 	)
 	via.Mount[metricsPage](app, "/")
 	defer server.Close()

--- a/sweep_test.go
+++ b/sweep_test.go
@@ -1,0 +1,53 @@
+package via_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-via/via"
+	"github.com/go-via/via/h"
+	"github.com/go-via/via/vt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type ttlGuardPage struct{}
+
+func (p *ttlGuardPage) Ping(ctx *via.Ctx) error { return nil }
+
+func (p *ttlGuardPage) View(ctx *via.CtxR) h.H { return h.Div() }
+
+func TestContextSweep_disabledWhenTTLNotAboveHeartbeat(t *testing.T) {
+	t.Parallel()
+
+	logger := &captureLogger{}
+	var server *httptest.Server
+	app := via.New(
+		via.WithTestServer(&server),
+		via.WithContextTTL(40*time.Millisecond),
+		via.WithSSEHeartbeat(80*time.Millisecond), // TTL <= heartbeat → sweep disabled
+		via.WithLogger(logger),
+	)
+	via.Mount[ttlGuardPage](app, "/")
+	defer server.Close()
+
+	warned := false
+	for _, r := range logger.snapshot() {
+		if r.level == via.LogWarn && strings.Contains(r.msg, "disabling the context-TTL sweep") {
+			warned = true
+		}
+	}
+	assert.True(t, warned, "a contextTTL <= sseHeartbeat misconfig must warn at startup")
+
+	tc := vt.NewClient(t, server, "/")
+	// Idle far past several would-be sweep ticks (interval = TTL/2 = 20ms). A
+	// TTL no larger than the heartbeat can't be kept alive by it, so the sweep
+	// is disabled rather than left to reap streams the heartbeat should hold.
+	time.Sleep(300 * time.Millisecond)
+
+	require.Equal(t, http.StatusOK, tc.Action("Ping").Fire(),
+		"contextTTL <= sseHeartbeat must disable the TTL sweep, so the Ctx is never reaped")
+}


### PR DESCRIPTION
## Problem

The context-TTL sweep keys off `lastAccess`, and the SSE heartbeat is the activity signal that refreshes it — so a connected stream is kept alive only while `contextTTL` is comfortably larger than the heartbeat. If `contextTTL <= sseHeartbeat`, the sweep can reap a live stream before the next heartbeat refreshes its `lastAccess`, killing the tab.

## Change

When `0 < contextTTL <= sseHeartbeat`, the context-TTL sweep is **not started** (contexts don't expire) and a startup warning is logged, rather than letting an unworkable TTL reap live streams between beats. A short TTL therefore only takes effect with the heartbeat disabled (`WithSSEHeartbeat(0)`).

- `app.go` — guard around the context-sweep goroutine + `logWarn` at startup.
- `config.go` — document the invariant on `WithContextTTL` and `WithSSEHeartbeat`.

## Tests

- `TestContextSweep_disabledWhenTTLNotAboveHeartbeat` — asserts the startup warning fires and the Ctx survives well past the TTL.
- Retargeted `TestMetrics_SSEDisconnectReason_ttl` and `TestContextSweep_disposesIdleTabAfterTTL` to `WithSSEHeartbeat(0)`, so they still exercise a real TTL sweep (and `reason=ttl`, from #58) under the new guard instead of relying on `TTL < heartbeat`.

## Verification

`go test -race ./...`, `gofmt`, `golangci-lint` (0 issues), and the allocation gate (render 169 / action 136, under the 180 / 149 floors) all clean.