### PR TITLE
chore: ignore extensionless build artifacts at the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,20 @@
-# If you prefer the allow list template instead of the deny list, see community template:
-# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+# Compiled example programs land at the repo root with no extension (e.g.
+# `chat` from `go build ./internal/examples/chat`). gitignore has no
+# "no-extension" glob, so: ignore every root-level entry, then re-include
+# directories, any file that HAS an extension, and LICENSE (the only
+# extensionless tracked file). Net effect — extensionless root files (build
+# artifacts) are ignored, everything else is tracked as normal.
 #
-# Binaries for programs and plugins
+# NB: this also ignores a new extensionless root file you DO want tracked
+# (e.g. Makefile, Dockerfile); add an explicit `!/Makefile` line for those.
+/*
+!/*/
+!/*.*
+!/LICENSE
+
+# Cross-platform binaries / plugins. Listed after the block above so they
+# re-assert the ignore for root files the blanket `!/*.*` would otherwise
+# un-ignore, and so they apply inside subdirectories too.
 *.exe
 *.exe~
 *.dll
@@ -17,9 +30,6 @@ coverage.*
 *.coverprofile
 profile.cov
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
-
 # Go workspace file
 go.work
 go.work.sum
@@ -27,26 +37,12 @@ go.work.sum
 # env file
 .env
 
-# Editor/IDE
-# .idea/
-# .vscode/
-
 # Via related
 .via
 
-#Agents
+# Agents
 .opencode
 .claude
 
 # Air artifacts
 *tmp/
-
-# Stray go-build outputs from example dirs
-/counter
-/countercomp
-/greeter
-/pathparams
-/picocss
-/sysmon
-/auth
-/todos


### PR DESCRIPTION
Compiled example programs (e.g. `chat` from `go build ./internal/examples/chat`) land at the repo root with **no extension**, and were one `git add -A` from entering history — a 15MB binary was sitting untracked at root. The hand-maintained per-name allowlist (`/counter`, `/auth`, …) had drifted and never covered `chat`.

## Change

`gitignore` has no "no-extension" glob, so the rule ignores every root-level entry, then re-includes directories, any file with an extension, and `LICENSE` (the only extensionless tracked file). Net effect: extensionless root files (build artifacts) are ignored, everything else is tracked as normal. The drifted per-name allowlist is removed (subsumed).

Caveat documented inline: a *wanted* extensionless root file (e.g. `Makefile`) is also ignored and needs an explicit `!/Makefile` line. Scope is root-only — a binary built inside `internal/examples/X/` isn't caught (same scope as the previous allowlist).

## Verification (`git check-ignore`)

- Ignored: `chat`, `counter`, `coverage.out`, `bin`, `server`, `go.work`, `.claude` ✓
- Tracked: `LICENSE`, `app.go`, `go.mod`, `.golangci.yml`, `.gitignore`, `ci-check.sh`, `datastar.js`, all source dirs ✓
- **Zero** tracked files become ignored.