### PR TITLE
docs(shape): drop godoc reference to a non-existent Ops[T]/To(v)

### DIFF
--- a/op_test.go
+++ b/op_test.go
@@ -14,9 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Op(ctx) returns a typed chain entry on every reactive kind. Generic
-// case exposes To(v); shape-specialized types (NumOps here) add their
-// typed verbs. Apply was removed — custom transforms go through Update.
+// Op(ctx) returns a typed chain entry on every reactive kind: each
+// shape-specialized type (NumOps here) adds its typed verbs, which route
+// through the handle's Update path. Apply was removed — custom transforms
+// go through Update.
 
 type opGenericPage struct {
 	Signal via.SignalNum[int]

--- a/shape_bool.go
+++ b/shape_bool.go
@@ -1,8 +1,7 @@
 package via
 
 // BoolOps is the chain returned by Op(ctx) on every Bool* reactive
-// type. Embeds Ops[bool] for the universal To(v); boolean verbs route
-// through the handle's Update path.
+// type; its boolean verbs route through the handle's Update path.
 type BoolOps struct {
 	ops[bool]
 }

--- a/shape_map.go
+++ b/shape_map.go
@@ -1,8 +1,7 @@
 package via
 
-// MapOps is the chain returned by Op(ctx) on every Map* reactive type.
-// Embeds Ops[map[K]V] for the universal To(v); map verbs route through
-// the handle's Update path.
+// MapOps is the chain returned by Op(ctx) on every Map* reactive type;
+// its map verbs route through the handle's Update path.
 type MapOps[K comparable, V any] struct {
 	ops[map[K]V]
 }

--- a/shape_num.go
+++ b/shape_num.go
@@ -10,9 +10,8 @@ type Number interface {
 		~float32 | ~float64
 }
 
-// NumOps is the chain returned by Op(ctx) on every Num* reactive type.
-// Embeds Ops[T] for the universal To(v); numeric verbs route through
-// the handle's Update path.
+// NumOps is the chain returned by Op(ctx) on every Num* reactive type;
+// its numeric verbs route through the handle's Update path.
 type NumOps[T Number] struct {
 	ops[T]
 }

--- a/shape_slice.go
+++ b/shape_slice.go
@@ -1,8 +1,7 @@
 package via
 
 // SliceOps is the chain returned by Op(ctx) on every Slice* reactive
-// type. Embeds Ops[[]T] for the universal To(v); slice verbs route
-// through the handle's Update path.
+// type; its slice verbs route through the handle's Update path.
 type SliceOps[T any] struct {
 	ops[[]T]
 }


### PR DESCRIPTION
`NumOps`, `BoolOps`, `SliceOps`, and `MapOps` godoc each claimed they "Embed `Ops[T]` for the universal `To(v)`". But **no exported `Ops[T]` type and no `To` method exist** — only the unexported `ops[T]` base, which carries just the `Update` closure and (per its own comment) "has no methods of its own". A user reading `go doc via.NumOps` was sent looking for an API that isn't there.

## Change

Reword the four docs to match the already-correct `StrOps` doc: the chain is returned by `Op(ctx)`, and its typed verbs route through the handle's `Update` path. Also fixed the same stale "exposes `To(v)`" claim in `op_test.go`.

Comment-only — no behavior change. `go build`, `go test`, `go vet`, `gofmt`, and `golangci-lint` (0 issues) all clean; `go doc` renders the corrected text.