### PR TITLE
feat(docs): amber brand color scheme for the docs site

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -12,7 +12,7 @@ theme: just-the-docs
 url: https://go-via.github.io
 baseurl: /via
 
-color_scheme: dark
+color_scheme: amber
 search_enabled: true
 heading_anchors: true
 back_to_top: true

--- a/docs/_includes/head_custom.html
+++ b/docs/_includes/head_custom.html
@@ -9,3 +9,8 @@
 <meta name="twitter:title" content="{% if page.title %}{{ page.title }} · {% endif %}{{ site.title }}">
 <meta name="twitter:description" content="{{ page.description | default: site.description | strip_newlines }}">
 <meta name="twitter:image" content="{{ '/counter-scope.gif' | absolute_url }}">
+
+<!-- Fonts for the amber color scheme: Inter (body/headings), JetBrains Mono (code). -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600&display=swap">

--- a/docs/_sass/color_schemes/amber.scss
+++ b/docs/_sass/color_schemes/amber.scss
@@ -1,0 +1,29 @@
+// "amber" — Via's brand scheme: the logo's amber (#ffbf00) as the accent on
+// a deep neutral-dark base. Built on just-the-docs' `dark` scheme (which also
+// pulls in the one-dark code-highlight theme), then overriding the accent,
+// neutrals, and fonts. See docs/customization for the variable list.
+@import "./color_schemes/dark";
+
+// --- brand accent (was the default blue) ---
+$link-color: #ffbf00;
+$btn-primary-color: #ffbf00;
+
+// --- neutral-dark surfaces ---
+$body-background-color: #16181d;
+$sidebar-color: #1b1e24;
+$body-heading-color: #f2f4f8;
+$body-text-color: #c9ced8;
+$nav-child-link-color: #c9ced8;
+$base-button-color: #23272f;
+$code-background-color: #1b1e24;
+$table-background-color: #1b1e24;
+$search-background-color: #1b1e24;
+$search-result-preview-color: #8a91a0;
+$border-color: #2a2e37;
+$feedback-color: #14161a;
+
+// --- typography (loaded via docs/_includes/head_custom.html) ---
+$body-font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI",
+  Roboto, Helvetica, Arial, sans-serif;
+$mono-font-family: "JetBrains Mono", "SFMono-Regular", Menlo, Consolas,
+  "Liberation Mono", monospace;

--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -1,0 +1,21 @@
+// Appended after the theme, so these win regardless of how the font
+// variables cascade — a guaranteed apply for the amber scheme's typography,
+// plus a couple of brand accents the color variables don't reach.
+
+body {
+  font-family: $body-font-family;
+}
+
+h1, h2, h3, h4, h5, h6, .site-title {
+  font-family: $body-font-family;
+}
+
+code, kbd, pre, samp, .highlight {
+  font-family: $mono-font-family;
+}
+
+// Brand amber on the current nav item.
+.nav-list .nav-list-item .nav-list-link.active {
+  color: $link-color;
+  font-weight: 600;
+}


### PR DESCRIPTION
Restyles the GitHub Pages docs site (just-the-docs) with a custom **amber** scheme built on the brand color from `logo.svg` (`#ffbf00`).

## What

- New `docs/_sass/color_schemes/amber.scss` — `@import`s the `dark` scheme (per the just-the-docs custom-scheme convention, which also brings the one-dark code-highlight theme), then overrides: brand amber as the link/button/active-nav accent, a deep neutral-dark surface palette, and Inter / JetBrains Mono fonts.
- `docs/_sass/custom/custom.scss` — guaranteed font application + amber on the current nav item.
- `docs/_includes/head_custom.html` — loads Inter + JetBrains Mono (OG/Twitter cards preserved).
- `docs/_config.yml` — `color_scheme: dark` → `amber`.

## How it was chosen

Rendered four faithful design directions (amber-dark, amber-light, slate-dark, terminal) as screenshots and picked **Amber Dark** — on-brand, professional, broadest appeal.

The Pages workflow builds this PR (and fails it on a broken site), so a green check confirms the SCSS compiles. Visual preview matched the approved mockup.