### PR TITLE
docs: add just-the-docs layout to all pages

### DIFF
--- a/docs/actions-and-lifecycle.md
+++ b/docs/actions-and-lifecycle.md
@@ -1,5 +1,6 @@
 ---
 title: Actions & lifecycle
+layout: just-the-docs
 parent: Guides
 nav_order: 1
 ---

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,5 +1,6 @@
 ---
 title: Examples
+layout: just-the-docs
 nav_order: 3
 ---
 

--- a/docs/file-uploads.md
+++ b/docs/file-uploads.md
@@ -1,5 +1,6 @@
 ---
 title: File uploads
+layout: just-the-docs
 parent: Guides
 nav_order: 4
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,5 +1,6 @@
 ---
 title: Getting started
+layout: just-the-docs
 parent: Learn
 nav_order: 1
 ---

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,5 +1,6 @@
 ---
 title: Glossary
+layout: just-the-docs
 parent: Reference & ops
 nav_order: 5
 ---

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -1,5 +1,6 @@
 ---
 title: Guides
+layout: just-the-docs
 nav_order: 5
 has_children: true
 ---

--- a/docs/h-helpers.md
+++ b/docs/h-helpers.md
@@ -1,5 +1,6 @@
 ---
 title: h helpers reference
+layout: just-the-docs
 parent: Reference & ops
 nav_order: 3
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 ---
 title: Home
+layout: just-the-docs
 nav_order: 1
 ---
 

--- a/docs/learn.md
+++ b/docs/learn.md
@@ -1,5 +1,6 @@
 ---
 title: Learn
+layout: just-the-docs
 nav_order: 4
 has_children: true
 ---

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,5 +1,6 @@
 ---
 title: Plugins
+layout: just-the-docs
 parent: Guides
 nav_order: 5
 ---

--- a/docs/production.md
+++ b/docs/production.md
@@ -1,5 +1,6 @@
 ---
 title: Production & ops
+layout: just-the-docs
 parent: Reference & ops
 nav_order: 2
 ---

--- a/docs/reactive-state.md
+++ b/docs/reactive-state.md
@@ -1,5 +1,6 @@
 ---
 title: Reactive state
+layout: just-the-docs
 parent: Learn
 nav_order: 3
 ---

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,5 +1,6 @@
 ---
 title: Reference & ops
+layout: just-the-docs
 nav_order: 6
 has_children: true
 ---

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -1,5 +1,6 @@
 ---
 title: Rendering (h)
+layout: just-the-docs
 parent: Guides
 nav_order: 2
 ---

--- a/docs/routing-sessions-middleware.md
+++ b/docs/routing-sessions-middleware.md
@@ -1,5 +1,6 @@
 ---
 title: Routing, sessions & middleware
+layout: just-the-docs
 parent: Guides
 nav_order: 3
 ---

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,5 +1,6 @@
 ---
 title: Testing
+layout: just-the-docs
 parent: Reference & ops
 nav_order: 1
 ---

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting
+layout: just-the-docs
 parent: Reference & ops
 nav_order: 4
 ---

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,5 +1,6 @@
 ---
 title: "Tutorial: live chatroom"
+layout: just-the-docs
 parent: Learn
 nav_order: 2
 ---

--- a/docs/why-via.md
+++ b/docs/why-via.md
@@ -1,5 +1,6 @@
 ---
 title: Why Via
+layout: just-the-docs
 nav_order: 2
 ---
 


### PR DESCRIPTION
Fixes the GitHub Pages layout not being applied by adding explicit  frontmatter to all markdown pages.