### PR TITLE
fix(sse): don't corrupt brotli streams with the raw handshake comment

### DIFF
--- a/sse.go
+++ b/sse.go
@@ -93,12 +93,21 @@ func runSSEStream(a *App, ctx *Ctx, w http.ResponseWriter, r *http.Request) {
 	// `:` per the SSE spec — Datastar (and any conformant client)
 	// silently ignores them, so this adds no event surface. Tests use
 	// it to replace the timing-based 20ms-sleep idiom.
-	setSSEWriteDeadline(w, a.cfg.sseWriteTimeout)
-	if _, err := io.WriteString(w, ": ready\n\n"); err != nil {
-		return
-	}
-	if fl, ok := w.(http.Flusher); ok {
-		fl.Flush()
+	//
+	// Only safe when the stream is NOT content-encoded: datastar routes
+	// its own writes through a compressing writer, but this raw write
+	// goes to the underlying ResponseWriter — uncompressed bytes in a
+	// Content-Encoding: br stream corrupt it for a real browser. The
+	// marker is an observability/test aid clients ignore, and the test
+	// client negotiates no encoding, so it still observes it.
+	if w.Header().Get("Content-Encoding") == "" {
+		setSSEWriteDeadline(w, a.cfg.sseWriteTimeout)
+		if _, err := io.WriteString(w, ": ready\n\n"); err != nil {
+			return
+		}
+		if fl, ok := w.(http.Flusher); ok {
+			fl.Flush()
+		}
 	}
 
 	var heartbeat <-chan time.Time

--- a/sse_brotli_test.go
+++ b/sse_brotli_test.go
@@ -1,0 +1,68 @@
+package via_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/go-via/via"
+	"github.com/go-via/via/h"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type brotliProbePage struct{}
+
+func (p *brotliProbePage) View(ctx *via.CtxR) h.H { return h.Div(h.Text("hi")) }
+
+var brotliTabRE = regexp.MustCompile(`&#34;via_tab&#34;:&#34;([^"&]+)&#34;`)
+
+// When the client negotiates brotli, datastar sets Content-Encoding: br and
+// routes writes through a compressing writer. Any RAW write to the underlying
+// ResponseWriter (e.g. the handshake comment) injects uncompressed bytes that
+// corrupt the stream for a real br browser. Assert the served stream carries
+// no raw bytes ahead of the compressed payload.
+func TestSSE_brotliHandshakeIsCompressionSafe(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	via.Mount[brotliProbePage](app, "/")
+	defer server.Close()
+
+	jar, _ := cookiejar.New(nil)
+	c := &http.Client{Jar: jar}
+	resp, err := c.Get(server.URL + "/")
+	require.NoError(t, err)
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	m := brotliTabRE.FindStringSubmatch(string(body))
+	require.Len(t, m, 2, "tab id in page")
+	tabID := m[1]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	sseURL := server.URL + "/_sse?datastar=" + url.QueryEscape(`{"via_tab":"`+tabID+`"}`)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, sseURL, nil)
+	req.Header.Set("Accept-Encoding", "br") // force brotli negotiation
+	sresp, err := (&http.Client{Jar: jar}).Do(req)
+	require.NoError(t, err)
+	defer sresp.Body.Close()
+
+	require.Equal(t, "br", sresp.Header.Get("Content-Encoding"),
+		"precondition: datastar must negotiate brotli for this client")
+
+	buf := make([]byte, 64)
+	n, _ := sresp.Body.Read(buf)
+	raw := string(buf[:n])
+	// A valid brotli stream never begins with this ASCII comment; if it does,
+	// a raw write bypassed the compressor and the browser's decode breaks.
+	assert.NotContains(t, raw, ": ready",
+		"raw ': ready' in a Content-Encoding: br stream corrupts real browsers")
+}


### PR DESCRIPTION
## Critical: live SSE is corrupted for any client that negotiates brotli

via configures datastar with brotli compression (`sse.go`). datastar sets `Content-Encoding: br` for any client advertising `br` (every modern browser's EventSource) and routes its writes through a compressing writer. But the `: ready\n\n` handshake comment is written **raw** to the underlying `ResponseWriter` — so a `Content-Encoding: br` response begins with uncompressed ASCII. The browser decodes the whole body as brotli, fails on the prefix, and the SSE stream is unusable → the live UI never updates.

Verified empirically: an SSE request with `Accept-Encoding: br` returns `Content-Encoding: br` whose first bytes are the literal `": ready\n\n"`. It went unnoticed because the test client (`vt`) negotiates no encoding (via offers only `br`, the client sends only `gzip`) so the raw write is harmless there.

## Fix

Gate the raw handshake marker on **no negotiated `Content-Encoding`**. It's an observability/test aid that conformant clients ignore; the no-encoding test client still receives it (so `vt.SSEReady` keeps working), while brotli clients now get a clean compressed stream.

Regression test `TestSSE_brotliHandshakeIsCompressionSafe` opens the stream with `Accept-Encoding: br` and asserts no raw `: ready` precedes the compressed payload. Full `go test -race ./...` green.