### PR TITLE
docs: drop the redundant Via hero title on the home page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,11 +4,11 @@ layout: default
 nav_order: 1
 ---
 
-# Via
+# Reactive web apps in pure Go
 {: .fs-9 }
 
-Reactive web apps in pure Go. A composition is a struct. Reactive state is
-a typed field. Actions are methods. The compiler understands your UI.
+A composition is a struct. Reactive state is a typed field. Actions are
+methods. The compiler understands your UI.
 {: .fs-6 .fw-300 }
 
 [Get started](getting-started){: .btn .btn-primary .mr-2 }


### PR DESCRIPTION
The sidebar wordmark now carries the brand site-wide, so the home page's
`fs-9` **Via** heading was a redundant repeat. Promotes the tagline to the H1
("Reactive web apps in pure Go") — keeps one top-level heading for
SEO/search/a11y while the hero stops echoing the wordmark.