### PR TITLE
fix(docs): dark label on the amber primary button

### DIFF
--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -19,3 +19,11 @@ code, kbd, pre, samp, .highlight {
   color: $link-color;
   font-weight: 600;
 }
+
+// Primary button ("Get started") sits on the bright amber fill. just-the-docs
+// defaults its label to white, which is near-illegible on amber — force the
+// ink color so the text reads (base + hover, since the mixin sets both).
+.btn-primary,
+.btn-primary:hover {
+  color: #0b0b0f;
+}


### PR DESCRIPTION
just-the-docs styles `.btn-primary` with **white** text, which is
near-illegible on the amber (`#ffbf00`) fill — the home page **Get started**
button looked low-contrast. Override the label to ink `#0b0b0f` (base + hover)
in `custom.scss`. Secondary buttons (amber-on-dark) are unaffected.

Verified with a local build/screenshot: dark label now reads cleanly on amber.