### PR TITLE
refactor(examples,docs): use typed ops where they fit

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,9 +42,7 @@ type Counter struct {
 }
 
 func (c *Counter) Inc(ctx *via.Ctx) {
-    _ = c.Hits.Update(ctx, func(n int) (int, error) {
-        return n + c.Step.Read(ctx), nil
-    })
+    c.Hits.Op(ctx).Add(c.Step.Read(ctx))
 }
 
 func (c *Counter) View(ctx *via.CtxR) h.H {

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -79,8 +79,8 @@ func (r *Room) Send(ctx *via.Ctx) {
     if name == "" {
         name = "Anon"
     }
+    r.Log.Op(ctx).Append(Message{From: name, Body: body})
     _ = r.Log.Update(ctx, func(log []Message) ([]Message, error) {
-        log = append(log, Message{From: name, Body: body})
         if len(log) > 50 { // keep a recent window so the room can't grow forever
             log = log[len(log)-50:]
         }
@@ -90,9 +90,10 @@ func (r *Room) Send(ctx *via.Ctx) {
 }
 ```
 
-`Update` appends under a per-key mutex — concurrent senders can't lose
+`Op(ctx).Append` appends under a per-key mutex — concurrent senders can't lose
 messages — then Via diffs the View and ships the new `<p>` to every subscribed
-tab over SSE. Writing `Draft` back to `""` clears the sender's input.
+tab over SSE. The trailing `Update` trims the log to a recent window. Writing
+`Draft` back to `""` clears the sender's input.
 
 ## 4. Run it
 

--- a/internal/examples/chat/main.go
+++ b/internal/examples/chat/main.go
@@ -46,8 +46,8 @@ func (r *Room) Send(ctx *via.Ctx) {
 	if name == "" {
 		name = "Anon"
 	}
+	r.Log.Op(ctx).Append(Message{From: name, Body: body})
 	_ = r.Log.Update(ctx, func(log []Message) ([]Message, error) {
-		log = append(log, Message{From: name, Body: body})
 		if len(log) > recentWindow {
 			log = log[len(log)-recentWindow:]
 		}

--- a/internal/examples/counter/main.go
+++ b/internal/examples/counter/main.go
@@ -22,7 +22,7 @@ type Counter struct {
 // fail meaningfully — Update / Set don't surface errors.
 
 func (c *Counter) Inc(ctx *via.Ctx) {
-	_ = c.Hits.Update(ctx, func(n int) (int, error) { return n + c.Step.Read(ctx), nil })
+	c.Hits.Op(ctx).Add(c.Step.Read(ctx))
 }
 
 func (c *Counter) Reset(ctx *via.Ctx) {

--- a/internal/examples/countercomp/main.go
+++ b/internal/examples/countercomp/main.go
@@ -19,7 +19,7 @@ type CounterCard struct {
 }
 
 func (c *CounterCard) Inc(ctx *via.Ctx) {
-	_ = c.Count.Update(ctx, func(n int) (int, error) { return n + c.Step.Read(ctx), nil })
+	c.Count.Op(ctx).Add(c.Step.Read(ctx))
 }
 
 // View takes the click attribute as a parameter so the parent can decide

--- a/internal/examples/feed/main.go
+++ b/internal/examples/feed/main.go
@@ -25,7 +25,7 @@ type Feed struct {
 }
 
 func (p *Feed) Toggle(ctx *via.Ctx) {
-	_ = p.Running.Update(ctx, func(b bool) (bool, error) { return !b, nil })
+	p.Running.Op(ctx).Toggle()
 }
 
 func (p *Feed) Clear(ctx *via.Ctx) {

--- a/internal/examples/pathparams/main.go
+++ b/internal/examples/pathparams/main.go
@@ -29,7 +29,7 @@ func (c *CounterPage) OnInit(ctx *via.Ctx) error {
 }
 
 func (c *CounterPage) Increment(ctx *via.Ctx) error {
-	_ = c.Count.Update(ctx, func(n int) (int, error) { return n + c.Step.Read(ctx), nil })
+	c.Count.Op(ctx).Add(c.Step.Read(ctx))
 	return nil
 }
 

--- a/internal/examples/picocss/main.go
+++ b/internal/examples/picocss/main.go
@@ -32,13 +32,13 @@ type Page struct {
 
 func (p *Page) Inc(ctx *via.Ctx) {
 	if p.Visible.Read(ctx) < len(allFeatures) {
-		_ = p.Visible.Update(ctx, func(n int) (int, error) { return n + 1, nil })
+		p.Visible.Op(ctx).Inc()
 	}
 }
 
 func (p *Page) Dec(ctx *via.Ctx) {
 	if p.Visible.Read(ctx) > 1 {
-		_ = p.Visible.Update(ctx, func(n int) (int, error) { return n - 1, nil })
+		p.Visible.Op(ctx).Dec()
 	}
 }
 

--- a/internal/examples/todos/main.go
+++ b/internal/examples/todos/main.go
@@ -33,9 +33,7 @@ func (t *Todos) Add(ctx *via.Ctx) error {
 	if text == "" {
 		return nil
 	}
-	_ = t.Items.Update(ctx, func(items []Item) ([]Item, error) {
-		return append(items, Item{Text: text}), nil
-	})
+	t.Items.Op(ctx).Append(Item{Text: text})
 	t.Draft.Write(ctx, "")
 	return nil
 }
@@ -54,15 +52,7 @@ func (t *Todos) Toggle(ctx *via.Ctx) error {
 }
 
 func (t *Todos) Clear(ctx *via.Ctx) error {
-	_ = t.Items.Update(ctx, func(items []Item) ([]Item, error) {
-		live := make([]Item, 0, len(items))
-		for _, it := range items {
-			if !it.Done {
-				live = append(live, it)
-			}
-		}
-		return live, nil
-	})
+	t.Items.Op(ctx).Filter(func(it Item) bool { return !it.Done })
 	return nil
 }
 


### PR DESCRIPTION
Replaces verbose `Update(ctx, func(cur)(T,error){...})` mutations with Via's
typed op-chain verbs wherever a single op expresses the intent — across the
examples and the docs that mirror them.

**Converted**
- `counter`/`pathparams`/`countercomp`: `Count.Op(ctx).Add(step)`
- `picocss`: `Visible.Op(ctx).Inc()` / `.Dec()`
- `feed`: `Running.Op(ctx).Toggle()`
- `todos`: `Items.Op(ctx).Append(item)`; `Clear` → `.Filter(!Done)`
- `chat` (+ `docs/tutorial`): `Log.Op(ctx).Append(msg)`, with the sliding-window
  trim kept as a small `Update` (no "keep last N" op)
- `docs/getting-started`: `Hits.Op(ctx).Add(step)`

**Left as `Update`** where no single op fits: `feed.Points` (append+window),
`todos.Toggle` (mutate one by index), `upload.Last` (`StateSess` set, no `Write`).
`reactive-state.md` keeps `Update` in passages that document the method itself.

Build, full test suite, `go vet`, golangci-lint, and the allocation gates all
pass (`ci-check.sh` SUCCESS).