### PR TITLE
fix(docs): keep the nav tree expanded so nested pages are visible

### DIFF
--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -27,3 +27,15 @@ code, kbd, pre, samp, .highlight {
 .btn-primary:hover {
   color: #0b0b0f;
 }
+
+// Keep the nav tree statically expanded. By default just-the-docs only
+// reveals a section's children when that section is the active page, so
+// nested pages (e.g. Guides → Plugins) are invisible from anywhere else.
+// Show every child list, and drop the now-redundant collapse chevron.
+.nav-list .nav-list-item > .nav-list {
+  display: block;
+}
+
+.nav-list-expander {
+  display: none;
+}


### PR DESCRIPTION
**Plugins** (and every other nested page) was invisible from the docs home
page: just-the-docs only expands a section's children when that section is the
*active* page, so `Guides → Plugins` only showed once you were already inside
Guides.

Force all nested nav lists to `display: block` and hide the now-redundant
collapse chevron, so the full nav tree is discoverable from any page. Verified
with a local build/screenshot — Plugins now shows under Guides on the home
page.