### PR TITLE
docs(plugins): use the typed PicoTheme constant in the theme-switch snippet

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -40,7 +40,7 @@ signal references for inline expressions.
 
 ```go
 h.Button(h.Text("Blue"),
-    h.DataOnClick(picocss.ThemeRef()+" = 'blue'"))
+    h.DataOnClick("%s = %q", picocss.ThemeRef(), picocss.PicoThemeBlue))
 ```
 
 See `internal/examples/picocss` for client-side theme switching.


### PR DESCRIPTION
Swap the hand-built `ThemeRef()+" = 'blue'"` string for the printf-style `h.DataOnClick` with the typed `picocss.PicoThemeBlue` constant, matching the canonical pattern in `internal/examples/picocss`.

A full sweep of all 19 docs pages (one auditor per file, each finding verified) found no other places presenting a raw-string form where a typed helper/constant is the better showcase — the rest already use the typed API or intentionally teach the underlying primitive.

Verified the snippet compiles and renders `data-on:click="$_picoTheme = &quot;blue&quot;"`, equivalent to the original.