### PR TITLE
refactor!: remove `any` from the public API where it erased type safety

### DIFF
--- a/broadcast.go
+++ b/broadcast.go
@@ -22,10 +22,24 @@ func (a *App) Broadcast(script string) int {
 	return len(ctxs)
 }
 
+// BroadcastSignal pushes one typed signal value to every currently-live
+// tab via its Signal[T] handle — the typed counterpart of
+// [App.BroadcastSignals] for signals bound at Mount. Returns the tab
+// count; nil sig is a no-op.
+func BroadcastSignal[T any](a *App, sig *Signal[T], value T) int {
+	if a == nil || sig == nil {
+		return 0
+	}
+	return a.BroadcastSignals(map[string]any{sig.Key(): value})
+}
+
 // BroadcastSignals pushes a signal patch to every currently-live tab.
 // Useful for site-wide announcements that drive a banner via a
 // client-only signal (e.g. "$_systemNotice = 'planned maintenance'")
 // without rendering each composition. Returns the tab count.
+//
+// This is the untyped escape hatch for dynamic / client-only signal
+// keys; when a *Signal[T] handle exists, prefer [BroadcastSignal].
 func (a *App) BroadcastSignals(values map[string]any) int {
 	if len(values) == 0 {
 		return 0

--- a/docs/h-helpers.md
+++ b/docs/h-helpers.md
@@ -27,7 +27,9 @@ symbol's contract.
   the winning branch is constructed.
 - `h.Maybe(v, fn)` — render `fn(v)` only when v ≠ zero(T) (T must be
   `comparable`).
-- `h.Switch(value, h.Case(...), h.Default(...))` — tab-style equality.
+- `h.Switch(value, h.Case(...), h.Default[K](...))` — tab-style
+  equality; `value` and every `Case` key share one comparable type `K`.
+  `Default` needs the type spelled out (nothing to infer it from).
 - `h.IfStr(cond, s)` — `s` if cond, `""` otherwise; pairs with
   `h.Class` and `h.Styles`.
 

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -44,7 +44,7 @@ h.Each(items, func(it Item) h.H { return h.Li(h.T(it.Name)) })
 h.EachIndexed(items, func(i int, it Item) h.H { ... })
 h.If(loggedIn, h.Span(h.T("Welcome")))
 h.IfElse(ok, yesNode, noNode)
-h.Switch(key, cases, defaultNode)
+h.Switch(key, h.Case(k1, n1), h.Default[K](fallback))
 h.Fragment(nodeA, nodeB)   // group nodes without a wrapper element
 ```
 

--- a/h/group.go
+++ b/h/group.go
@@ -177,30 +177,36 @@ func EachSeq2[K, V any](seq iter.Seq2[K, V], fn func(K, V) H) H {
 
 // SwitchCase pairs a key with the node to render when [Switch]'s value
 // matches the key. Build with [Case] / [Default].
-type SwitchCase struct {
-	key       any
+type SwitchCase[K comparable] struct {
+	key       K
 	node      H
 	isDefault bool
 }
 
 // Case returns a [SwitchCase] that fires when [Switch]'s value equals
 // key.
-func Case(key any, node H) SwitchCase { return SwitchCase{key: key, node: node} }
+func Case[K comparable](key K, node H) SwitchCase[K] {
+	return SwitchCase[K]{key: key, node: node}
+}
 
 // Default returns a [SwitchCase] that fires when no other case matches.
 // At most one Default per Switch is honoured (the first one wins).
-func Default(node H) SwitchCase { return SwitchCase{node: node, isDefault: true} }
+//
+// K cannot be inferred from the argument, so it is spelled explicitly
+// at the call site: h.Default[Status](unknownView).
+func Default[K comparable](node H) SwitchCase[K] {
+	return SwitchCase[K]{node: node, isDefault: true}
+}
 
 // Switch renders the first matching [SwitchCase] and nothing else.
 //
-// Comparison is `==`, so both value and every [Case] key must be of a
-// comparable type. Passing a slice, map, or function (or a key that
-// contains one) will panic at render time with the standard "comparing
-// uncomparable type" runtime error — Go's interface-equality semantics,
-// not something h can soften. For tab-style branching on a non-
-// comparable value, project it to a comparable key first (e.g. a tag
-// string or enum) and Switch on that.
-func Switch(value any, cases ...SwitchCase) H {
+// value and every [Case] key share the comparable type K, so a
+// mismatched case is a compile error. Note Go's comparable admits
+// interface and comparable-struct types whose comparison can still
+// panic at runtime if a value carries a non-comparable dynamic type —
+// for tab-style branching on such a value, project it to a simple key
+// first (e.g. a tag string or enum) and Switch on that.
+func Switch[K comparable](value K, cases ...SwitchCase[K]) H {
 	var fallback H
 	for _, c := range cases {
 		if c.isDefault {

--- a/h/h_test.go
+++ b/h/h_test.go
@@ -199,7 +199,7 @@ func TestSwitch_rendersMatchingCase(t *testing.T) {
 	got := render(t, h.Div(h.Switch("settings",
 		h.Case("overview", h.P(h.Text("o"))),
 		h.Case("settings", h.P(h.Text("s"))),
-		h.Default(h.P(h.Text("d"))),
+		h.Default[string](h.P(h.Text("d"))),
 	)))
 	assert.Equal(t, "<div><p>s</p></div>", got)
 }
@@ -208,7 +208,7 @@ func TestSwitch_fallsBackToDefault(t *testing.T) {
 	t.Parallel()
 	got := render(t, h.Div(h.Switch("missing",
 		h.Case("a", h.P(h.Text("a"))),
-		h.Default(h.P(h.Text("d"))),
+		h.Default[string](h.P(h.Text("d"))),
 	)))
 	assert.Equal(t, "<div><p>d</p></div>", got)
 }

--- a/handler.go
+++ b/handler.go
@@ -1,0 +1,12 @@
+package via
+
+// Action constrains the bound-method shapes the via/on helpers accept:
+// func(*Ctx) error, or func(*Ctx) when nothing in the body can fail.
+// It is a type-parameter constraint (a union), so passing anything else
+// to on.Click and friends is a compile error rather than a runtime
+// panic. The value must still be a bound method value (e.g. c.Inc) —
+// closures and top-level functions satisfy the type but have no method
+// name to route to, and panic at first render.
+type Action interface {
+	func(*Ctx) | func(*Ctx) error
+}

--- a/internal/examples/todos/main.go
+++ b/internal/examples/todos/main.go
@@ -141,7 +141,7 @@ func (t *Todos) View(ctx *via.CtxR) h.H {
 
 // filterButton renders one of the three filter pills. Active pill is
 // styled with the standard button look; others get the outline class.
-func filterButton(name, current string, action any) h.H {
+func filterButton(name, current string, action func(*via.Ctx)) h.H {
 	return h.Button(
 		h.Class(h.IfStr(name != current, "outline secondary")),
 		h.Text(strings.ToUpper(name[:1])+name[1:]),

--- a/internal/sessbridge/sessbridge.go
+++ b/internal/sessbridge/sessbridge.go
@@ -1,0 +1,19 @@
+// Package sessbridge lets the via/sess package reach the unexported
+// session KV methods on via.Session without via exporting an untyped
+// Load/Store/Delete surface. via sets the function vars at init; sess
+// is the only consumer. The `any` here is internal plumbing — the
+// public typed API lives in via/sess.
+//
+// A plain function-var bridge (rather than an interface) is used because
+// via cannot import this package's types from sess's point of view
+// without creating a via ↔ sessbridge type cycle.
+package sessbridge
+
+var (
+	// Load reads the value stored under key on a *via.Session.
+	Load func(s any, key string) (any, bool)
+	// Store writes value under key on a *via.Session.
+	Store func(s any, key string, value any)
+	// Delete removes the value under key on a *via.Session.
+	Delete func(s any, key string)
+)

--- a/on/on.go
+++ b/on/on.go
@@ -42,33 +42,33 @@ var eventAttrCache = map[string]string{
 }
 
 // Click binds a click handler.
-func Click(fn any, opts ...spec.Option) h.H { return event("click", fn, opts...) }
+func Click[F via.Action](fn F, opts ...spec.Option) h.H { return event("click", fn, opts...) }
 
 // Change binds a change handler (e.g. <select>, <input type=checkbox>).
-func Change(fn any, opts ...spec.Option) h.H { return event("change", fn, opts...) }
+func Change[F via.Action](fn F, opts ...spec.Option) h.H { return event("change", fn, opts...) }
 
 // Input binds an input handler.
-func Input(fn any, opts ...spec.Option) h.H { return event("input", fn, opts...) }
+func Input[F via.Action](fn F, opts ...spec.Option) h.H { return event("input", fn, opts...) }
 
 // Submit binds a form submit handler.
-func Submit(fn any, opts ...spec.Option) h.H { return event("submit", fn, opts...) }
+func Submit[F via.Action](fn F, opts ...spec.Option) h.H { return event("submit", fn, opts...) }
 
 // Focus binds a focus handler.
-func Focus(fn any, opts ...spec.Option) h.H { return event("focus", fn, opts...) }
+func Focus[F via.Action](fn F, opts ...spec.Option) h.H { return event("focus", fn, opts...) }
 
 // Blur binds a blur handler.
-func Blur(fn any, opts ...spec.Option) h.H { return event("blur", fn, opts...) }
+func Blur[F via.Action](fn F, opts ...spec.Option) h.H { return event("blur", fn, opts...) }
 
 // DblClick binds a double-click handler.
-func DblClick(fn any, opts ...spec.Option) h.H { return event("dblclick", fn, opts...) }
+func DblClick[F via.Action](fn F, opts ...spec.Option) h.H { return event("dblclick", fn, opts...) }
 
 // MouseEnter binds a mouseenter handler (does not bubble).
-func MouseEnter(fn any, opts ...spec.Option) h.H {
+func MouseEnter[F via.Action](fn F, opts ...spec.Option) h.H {
 	return event("mouseenter", fn, opts...)
 }
 
 // MouseLeave binds a mouseleave handler (does not bubble).
-func MouseLeave(fn any, opts ...spec.Option) h.H {
+func MouseLeave[F via.Action](fn F, opts ...spec.Option) h.H {
 	return event("mouseleave", fn, opts...)
 }
 
@@ -77,7 +77,7 @@ func MouseLeave(fn any, opts ...spec.Option) h.H {
 // appears in the DOM:
 //
 //	h.Div(on.Load(p.RefreshChart))
-func Load(fn any, opts ...spec.Option) h.H { return event("load", fn, opts...) }
+func Load[F via.Action](fn F, opts ...spec.Option) h.H { return event("load", fn, opts...) }
 
 // Event is the escape hatch for any DOM event not covered by a named
 // helper above. Pass the event name as it would appear after `on:`
@@ -90,13 +90,13 @@ func Load(fn any, opts ...spec.Option) h.H { return event("load", fn, opts...) }
 // user input or per-request data would grow the cache unboundedly. The
 // cache is sized correctly when call sites are static — tens to
 // hundreds of bindings for any real app.
-func Event(name string, fn any, opts ...spec.Option) h.H {
+func Event[F via.Action](name string, fn F, opts ...spec.Option) h.H {
 	return event(name, fn, opts...)
 }
 
 // Key binds a keydown handler that fires only when the named key matches.
 // "Enter", "Escape", "ArrowUp", … (W3C key codes).
-func Key(key string, fn any, opts ...spec.Option) h.H {
+func Key[F via.Action](key string, fn F, opts ...spec.Option) h.H {
 	spec := &spec.Trigger{
 		Event:     "keydown",
 		Method:    fn,

--- a/on/on_test.go
+++ b/on/on_test.go
@@ -286,7 +286,9 @@ func TestClick_panicMessageNamesNil(t *testing.T) {
 		assert.Contains(t, msg, "got nil",
 			"panic should specifically call out nil rather than a generic 'closure/top-level/nil' clause")
 	}()
-	on.Click(nil)
+	// Bare on.Click(nil) no longer compiles (F can't be inferred); a
+	// typed nil func value is the remaining way to smuggle nil in.
+	on.Click[func(*via.Ctx)](nil)
 }
 
 func topLevelClickHandler(ctx *via.Ctx) error { return nil }
@@ -336,21 +338,6 @@ func TestClick_panicMessageNamesTopLevelFunctionWhoseNameStartsWithFunc(t *testi
 		assert.NotContains(t, msg, "got a closure")
 	}()
 	on.Click(functionalTopLevelHandler)
-}
-
-func TestClick_panicMessageNamesNonFunctionValue(t *testing.T) {
-	t.Parallel()
-	// `on.Click(42)` is a programming error distinct from nil — the
-	// panic must not lie about what was passed.
-	defer func() {
-		rec := recover()
-		require.NotNil(t, rec)
-		msg, ok := rec.(string)
-		require.True(t, ok)
-		assert.NotContains(t, msg, "got nil",
-			"a non-function value must not be reported as nil")
-	}()
-	on.Click(42)
 }
 
 func TestKey_panicMessageNamesClosure(t *testing.T) {

--- a/sess.go
+++ b/sess.go
@@ -4,7 +4,17 @@ import (
 	"net/http"
 	"sync/atomic"
 	"time"
+
+	"github.com/go-via/via/internal/sessbridge"
 )
+
+// Wire the sess package's access path to the unexported KV methods.
+// See internal/sessbridge for why this is a function-var bridge.
+func init() {
+	sessbridge.Load = func(s any, key string) (any, bool) { return s.(*Session).load(key) }
+	sessbridge.Store = func(s any, key string, value any) { s.(*Session).store(key, value) }
+	sessbridge.Delete = func(s any, key string) { s.(*Session).delete(key) }
+}
 
 // sessionCookieName is the name of the HTTP cookie via uses to identify
 // a browser session across requests. Centralized here so set/read/delete
@@ -21,32 +31,34 @@ type session struct {
 // expires per [WithSessionTTL].
 //
 // A Session obtained via [Ctx.Session] marks the page dirty + fans out
-// to subscribed tabs on Store; one obtained via [RequestSession] (in a
+// to subscribed tabs on writes; one obtained via [RequestSession] (in a
 // middleware, before a Ctx exists) is cookie-only and does not trigger
 // re-render.
 //
-// Typed access lives in the via/sess subpackage — most code reaches
-// for sess.Get[T] / sess.Put[T] / sess.Clear[T] rather than this type
-// directly.
+// All value access is typed and lives in the via/sess subpackage —
+// sess.Get[T] / sess.Put[T] / sess.Clear[T]. Session itself only
+// exposes [Session.Rotate].
 type Session struct {
 	data *session
 	ctx  *Ctx
 	app  *App
 }
 
-// Load reads the value stored under key, or nil/false if absent or if
-// the Session is detached (no underlying session record).
-func (s *Session) Load(key string) (any, bool) {
+// load reads the value stored under key, or nil/false if absent or if
+// the Session is detached (no underlying session record). Unexported:
+// the only sanctioned access path is the typed via/sess package, which
+// reaches these through internal/sessbridge.
+func (s *Session) load(key string) (any, bool) {
 	if s == nil || s.data == nil {
 		return nil, false
 	}
 	return s.data.data.Load(key)
 }
 
-// Store writes value under key. When the Session is bound to a Ctx,
+// store writes value under key. When the Session is bound to a Ctx,
 // also marks the page dirty so the view re-renders and fans the write
 // out to every other live tab on the same session subscribed to key.
-func (s *Session) Store(key string, value any) {
+func (s *Session) store(key string, value any) {
 	if s == nil || s.data == nil {
 		return
 	}
@@ -59,9 +71,9 @@ func (s *Session) Store(key string, value any) {
 	}
 }
 
-// Delete removes the value stored under key. When the Session is bound
+// delete removes the value stored under key. When the Session is bound
 // to a Ctx, also marks the page dirty so the view re-renders.
-func (s *Session) Delete(key string) {
+func (s *Session) delete(key string) {
 	if s == nil || s.data == nil {
 		return
 	}
@@ -113,7 +125,7 @@ func (s *Session) Rotate() string {
 }
 
 // RequestSession returns the [Session] cookie-resolved off r, or a
-// detached Session (Load/Store no-op) if the request carries no via
+// detached Session (reads/writes no-op) if the request carries no via
 // session yet. Use this from middleware that needs to read or write
 // session state before any composition is rendered.
 //

--- a/sess/sess.go
+++ b/sess/sess.go
@@ -32,7 +32,30 @@ import (
 	"sync"
 
 	"github.com/go-via/via"
+	"github.com/go-via/via/internal/sessbridge"
 )
+
+// Source constrains where a session can be resolved from: a *via.Ctx
+// (actions / handlers), a *via.CtxR (reads during a render), or an
+// *http.Request (middleware, before any composition is rendered).
+type Source interface {
+	*via.Ctx | *via.CtxR | *http.Request
+}
+
+// session resolves src to its *via.Session. The type switch is
+// exhaustive over [Source]; the constraint guarantees no other type can
+// reach the default branch.
+func session[S Source](src S) *via.Session {
+	switch v := any(src).(type) {
+	case *via.Ctx:
+		return v.Session()
+	case *via.CtxR:
+		return v.Session()
+	case *http.Request:
+		return via.RequestSession(v)
+	}
+	return nil
+}
 
 // Put stores a typed value in the session bound to ctx, keyed by the
 // type name. Use it to attach "the logged-in user" or any struct that
@@ -44,28 +67,17 @@ func Put[T any](ctx *via.Ctx, v T) {
 	if ctx == nil {
 		return
 	}
-	ctx.Session().Store(typeKey[T](), v)
+	sessbridge.Store(ctx.Session(), typeKey[T](), v)
 }
 
 // Get reads the typed value stored with [Put], returning the zero
-// value of T and false if nothing matches. src may be a *via.Ctx, a
-// *via.CtxR (for reads during a render), or an *http.Request — the last
-// form lets middleware check the session before any composition is
-// rendered.
-func Get[T any](src any) (T, bool) {
+// value of T and false if nothing matches. src may be any [Source]: a
+// *via.Ctx, a *via.CtxR (for reads during a render), or an
+// *http.Request — the last form lets middleware check the session
+// before any composition is rendered.
+func Get[T any, S Source](src S) (T, bool) {
 	var zero T
-	var s *via.Session
-	switch v := src.(type) {
-	case *via.Ctx:
-		s = v.Session()
-	case *via.CtxR:
-		s = v.Session()
-	case *http.Request:
-		s = via.RequestSession(v)
-	default:
-		return zero, false
-	}
-	raw, ok := s.Load(typeKey[T]())
+	raw, ok := sessbridge.Load(session(src), typeKey[T]())
 	if !ok {
 		return zero, false
 	}
@@ -73,19 +85,11 @@ func Get[T any](src any) (T, bool) {
 	return t, ok
 }
 
-// Clear removes the value stored under T's key from the session. src may
-// be a *via.Ctx, a *via.CtxR, or an *http.Request — the same kinds [Get]
-// accepts, so a value read during a render can be cleared from the same
-// render.
-func Clear[T any](src any) {
-	switch v := src.(type) {
-	case *via.Ctx:
-		v.Session().Delete(typeKey[T]())
-	case *via.CtxR:
-		v.Session().Delete(typeKey[T]())
-	case *http.Request:
-		via.RequestSession(v).Delete(typeKey[T]())
-	}
+// Clear removes the value stored under T's key from the session. src
+// may be any [Source] — the same kinds [Get] accepts, so a value read
+// during a render can be cleared from the same render.
+func Clear[T any, S Source](src S) {
+	sessbridge.Delete(session(src), typeKey[T]())
 }
 
 // Rotate issues a fresh session id, copies the current session's data


### PR DESCRIPTION
## Summary

- **sess**: `Get`/`Clear` now take a `Source` union constraint (`*via.Ctx | *via.CtxR | *http.Request`) — call sites unchanged, wrong types are compile errors instead of a silent `false`.
- **on**: all 12 helpers generic over new `via.Action` (`func(*Ctx) | func(*Ctx) error`); `on.Click(42)`/`on.Click(nil)` no longer compile. Bound-method check remains runtime.
- **h**: `Switch`/`Case` generic over `K comparable`; mismatched case keys are compile errors. `h.Default[K](node)` needs an explicit type argument (nothing to infer from).
- **Session**: raw `Load`/`Store`/`Delete` KV unexported; `via/sess` is the only access path, wired through `internal/sessbridge`. Public surface is now just `Rotate`.
- Adds typed `via.BroadcastSignal[T](app, sig, value)`; string-keyed `BroadcastSignals`/`Patch.Signal(s)`/`RegisterAppSignal` stay as the documented escape hatch for dynamic/client-only signal keys.
- Out of scope by design: printf-style `...any`, `Logger.Log` kv pairs, echarts JSON `map[string]any`.

## Breaking
- `Session.Load/Store/Delete` removed from public API
- `h.Default` requires explicit type argument
- `on.*`/`sess.Get`/`sess.Clear`/`h.Switch` reject previously-compiling wrong-typed arguments

## Testing
- `go build ./...`, `go vet ./...`, `go test ./...` all green; gofmt clean