### PR TITLE
fix(test): stop sharing http.DefaultTransport across parallel tests

### DIFF
--- a/action_test.go
+++ b/action_test.go
@@ -56,7 +56,7 @@ func TestAction_unknownMethodReturns404(t *testing.T) {
 	via.Mount[counterPage](app, "/")
 	defer server.Close()
 
-	resp, err := http.Post(server.URL+"/_action/Nope", "application/json", strings.NewReader(`{}`))
+	resp, err := server.Client().Post(server.URL+"/_action/Nope", "application/json", strings.NewReader(`{}`))
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)

--- a/app_test.go
+++ b/app_test.go
@@ -22,7 +22,7 @@ func TestApp_servesDatastarJS(t *testing.T) {
 	via.New(via.WithTestServer(&server))
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/_datastar.js")
+	resp, err := server.Client().Get(server.URL + "/_datastar.js")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -38,7 +38,7 @@ func TestApp_routes404ForUnknownPath(t *testing.T) {
 	})
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/unknown-path")
+	resp, err := server.Client().Get(server.URL + "/unknown-path")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
@@ -57,13 +57,13 @@ func TestApp_handlesMultipleRoutes(t *testing.T) {
 	})
 	defer server.Close()
 
-	resp1, err := http.Get(server.URL + "/first")
+	resp1, err := server.Client().Get(server.URL + "/first")
 	require.NoError(t, err)
 	buf1, _ := io.ReadAll(resp1.Body)
 	resp1.Body.Close()
 	assert.Contains(t, string(buf1), "first")
 
-	resp2, err := http.Get(server.URL + "/second")
+	resp2, err := server.Client().Get(server.URL + "/second")
 	require.NoError(t, err)
 	buf2, _ := io.ReadAll(resp2.Body)
 	resp2.Body.Close()
@@ -82,10 +82,10 @@ func TestApp_builtinEndpointsReject404OnUnknownTab(t *testing.T) {
 		do   func() (*http.Response, error)
 	}{
 		{"GET /_sse", func() (*http.Response, error) {
-			return http.Get(server.URL + "/_sse")
+			return server.Client().Get(server.URL + "/_sse")
 		}},
 		{"POST /_action/Inc", func() (*http.Response, error) {
-			return http.Post(server.URL+"/_action/Inc", "text/plain", nil)
+			return server.Client().Post(server.URL+"/_action/Inc", "text/plain", nil)
 		}},
 	}
 	for _, c := range cases {
@@ -118,7 +118,7 @@ func TestApp_Handle_routesCustomPath(t *testing.T) {
 	app.Handle("/raw", customHandler{})
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/raw")
+	resp, err := server.Client().Get(server.URL + "/raw")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
@@ -189,7 +189,7 @@ func TestUse_concurrentBootCallsKeepAllMiddlewareInChain(t *testing.T) {
 		w.Write([]byte("ok"))
 	})
 
-	resp, err := http.Get(server.URL + "/ping")
+	resp, err := server.Client().Get(server.URL + "/ping")
 	require.NoError(t, err)
 	resp.Body.Close()
 

--- a/composition_test.go
+++ b/composition_test.go
@@ -39,7 +39,7 @@ func TestMount_renders404OnUnknownRoute(t *testing.T) {
 	via.Mount[simpleCounter](app, "/counter")
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/unknown")
+	resp, err := server.Client().Get(server.URL + "/unknown")
 	defer func() { _ = resp.Body.Close() }()
 	if err != nil {
 		t.Fatal(err)

--- a/config_test.go
+++ b/config_test.go
@@ -81,14 +81,14 @@ func TestMaxContexts_rejectsBeyondCap(t *testing.T) {
 	defer server.Close()
 
 	for range 2 {
-		resp, err := http.Get(server.URL + "/")
+		resp, err := server.Client().Get(server.URL + "/")
 		require.NoError(t, err)
 		resp.Body.Close()
 		assert.Equal(t, http.StatusOK, resp.StatusCode,
 			"first %d requests should fit under the cap", 2)
 	}
 
-	resp, err := http.Get(server.URL + "/")
+	resp, err := server.Client().Get(server.URL + "/")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode,
@@ -104,7 +104,7 @@ func TestMaxContexts_zeroDisablesTheCap(t *testing.T) {
 	defer server.Close()
 
 	for range 5 {
-		resp, err := http.Get(server.URL + "/")
+		resp, err := server.Client().Get(server.URL + "/")
 		require.NoError(t, err)
 		resp.Body.Close()
 		assert.Equal(t, http.StatusOK, resp.StatusCode,

--- a/csp_test.go
+++ b/csp_test.go
@@ -41,7 +41,7 @@ func TestStrictCSP_setsHeaderAndMatchesViewNonce(t *testing.T) {
 	via.Mount[strictCSPPage](app, "/")
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/")
+	resp, err := server.Client().Get(server.URL + "/")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -73,7 +73,7 @@ func TestStrictCSP_extraDirectivesAppended(t *testing.T) {
 	via.Mount[strictCSPPage](app, "/")
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/")
+	resp, err := server.Client().Get(server.URL + "/")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	csp := resp.Header.Get("Content-Security-Policy")
@@ -95,7 +95,7 @@ func TestCSPNonce_middlewareThreadedNonceReachesView(t *testing.T) {
 	via.Mount[cspEchoPage](app, "/")
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/")
+	resp, err := server.Client().Get(server.URL + "/")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Contains(t, resp.Header.Get("Content-Security-Policy"), "nonce-"+nonce)
@@ -140,7 +140,7 @@ func TestCSPNonce_renderedValueIsBase64URLFormatted(t *testing.T) {
 	via.Mount[cspEchoPage](app, "/")
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/")
+	resp, err := server.Client().Get(server.URL + "/")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	body := readAll(t, resp.Body)
@@ -174,7 +174,7 @@ func TestCSPNonce_isStableAcrossCallsInSameRequest(t *testing.T) {
 	via.Mount[cspTwoNoncePage](app, "/")
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/")
+	resp, err := server.Client().Get(server.URL + "/")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	body := readAll(t, resp.Body)
@@ -195,7 +195,7 @@ func TestCSPNonce_differsAcrossRequests(t *testing.T) {
 	defer server.Close()
 
 	get := func() string {
-		resp, err := http.Get(server.URL + "/")
+		resp, err := server.Client().Get(server.URL + "/")
 		require.NoError(t, err)
 		defer resp.Body.Close()
 		body := readAll(t, resp.Body)

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -40,7 +40,7 @@ func TestCookie_readsValueFromRequest(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", server.URL+"/", nil)
 	req.AddCookie(&http.Cookie{Name: "flavor", Value: "mint"})
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := server.Client().Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 

--- a/ctxr_test.go
+++ b/ctxr_test.go
@@ -60,7 +60,7 @@ func TestCtxR_ExposesIDAndCookieReadsToView(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", server.URL+"/", nil)
 	req.AddCookie(&http.Cookie{Name: "flavor", Value: "mint"})
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := server.Client().Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -73,7 +73,7 @@ func TestCtxR_ExposesIDAndCookieReadsToView(t *testing.T) {
 	body2 := func() string {
 		req, _ := http.NewRequest("GET", server.URL+"/", nil)
 		req.AddCookie(&http.Cookie{Name: "flavor", Value: "mint"})
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := server.Client().Do(req)
 		require.NoError(t, err)
 		defer resp.Body.Close()
 		buf := make([]byte, 0, 1<<14)

--- a/group_test.go
+++ b/group_test.go
@@ -27,7 +27,7 @@ func TestGroup_prefixesRoutes(t *testing.T) {
 	})
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/api/users")
+	resp, err := server.Client().Get(server.URL + "/api/users")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -50,7 +50,7 @@ func TestGroup_middlewareAppliesToHandlerFunc(t *testing.T) {
 	})
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/api/users")
+	resp, err := server.Client().Get(server.URL + "/api/users")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, "yes", resp.Header.Get("X-Group"),
@@ -71,7 +71,7 @@ func TestGroup_middlewareCanShortCircuit(t *testing.T) {
 	})
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/admin/secret")
+	resp, err := server.Client().Get(server.URL + "/admin/secret")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -98,7 +98,7 @@ func TestGroup_middlewareAppliesToMountedComposition(t *testing.T) {
 	via.Mount[groupedComp](group, "/dashboard")
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/admin/dashboard")
+	resp, err := server.Client().Get(server.URL + "/admin/dashboard")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, "wrapped", resp.Header.Get("X-Group"),
@@ -124,7 +124,7 @@ func TestGroup_pathParamsUnderGroupPrefix(t *testing.T) {
 	via.Mount[tenantPage](api, "/users/{id}")
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/api/acme/users/42")
+	resp, err := server.Client().Get(server.URL + "/api/acme/users/42")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -153,7 +153,7 @@ func TestGroup_routes404WithoutPrefix(t *testing.T) {
 	})
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/users")
+	resp, err := server.Client().Get(server.URL + "/users")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
@@ -168,7 +168,7 @@ func TestGroup_Handle_registersCustomHandler(t *testing.T) {
 	group.Handle("/widgets", customHandler{})
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/api/widgets")
+	resp, err := server.Client().Get(server.URL + "/api/widgets")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	buf, _ := io.ReadAll(resp.Body)
@@ -187,14 +187,14 @@ func TestGroup_handleFuncRegistersExplicitMethod(t *testing.T) {
 	})
 	defer server.Close()
 
-	resp, err := http.Post(server.URL+"/api/widgets", "application/json", http.NoBody)
+	resp, err := server.Client().Post(server.URL+"/api/widgets", "application/json", http.NoBody)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	buf, _ := io.ReadAll(resp.Body)
 	assert.Contains(t, string(buf), "created")
 
 	// GET to the same path must miss — POST registration shouldn't leak.
-	getResp, err := http.Get(server.URL + "/api/widgets")
+	getResp, err := server.Client().Get(server.URL + "/api/widgets")
 	require.NoError(t, err)
 	defer getResp.Body.Close()
 	assert.Equal(t, http.StatusMethodNotAllowed, getResp.StatusCode)

--- a/info_test.go
+++ b/info_test.go
@@ -1,7 +1,6 @@
 package via_test
 
 import (
-	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -26,7 +25,7 @@ func TestLiveTabs_reflectsRegisteredCount(t *testing.T) {
 	assert.Equal(t, 0, app.LiveTabs(), "starts at zero")
 
 	for i := 1; i <= 3; i++ {
-		resp, err := http.Get(server.URL + "/")
+		resp, err := server.Client().Get(server.URL + "/")
 		require.NoError(t, err)
 		resp.Body.Close()
 		assert.Equal(t, i, app.LiveTabs(),

--- a/integration_test.go
+++ b/integration_test.go
@@ -49,7 +49,7 @@ func TestIntegration_fullProductionStack(t *testing.T) {
 	via.Mount[kitchenSinkPage](app, "/page")
 
 	// Page render with query param.
-	resp, err := http.Get(server.URL + "/page?q=hello")
+	resp, err := server.Client().Get(server.URL + "/page?q=hello")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)

--- a/log_test.go
+++ b/log_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"log"
 	"log/slog"
-	"net/http"
 	"net/http/httptest"
 	"slices"
 	"strings"
@@ -103,7 +102,7 @@ func TestLogLevel_warnDefault_noNoiseOnHealthyRequest(t *testing.T) {
 	via.Mount[accessLogPage](app, "/")
 
 	for range 5 {
-		resp, err := http.Get(server.URL + "/")
+		resp, err := server.Client().Get(server.URL + "/")
 		require.NoError(t, err)
 		resp.Body.Close()
 	}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -24,7 +24,7 @@ func TestMiddleware_addsHeaderToResponse(t *testing.T) {
 	})
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/test")
+	resp, err := server.Client().Get(server.URL + "/test")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, "applied", resp.Header.Get("X-Middleware"))
@@ -43,7 +43,7 @@ func TestMiddleware_shortCircuits(t *testing.T) {
 	})
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/test")
+	resp, err := server.Client().Get(server.URL + "/test")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
@@ -67,7 +67,7 @@ func TestMiddleware_runsMultiple(t *testing.T) {
 	})
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/test")
+	resp, err := server.Client().Get(server.URL + "/test")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, "one", resp.Header.Get("X-First"))

--- a/mw/mw_test.go
+++ b/mw/mw_test.go
@@ -23,7 +23,7 @@ func TestHSTS_defaultHeaderHasOneYearAndSubdomains(t *testing.T) {
 	app.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {})
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/")
+	resp, err := server.Client().Get(server.URL + "/")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -44,7 +44,7 @@ func TestHSTS_optionsCustomiseHeader(t *testing.T) {
 	app.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {})
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/")
+	resp, err := server.Client().Get(server.URL + "/")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	got := resp.Header.Get("Strict-Transport-Security")
@@ -67,7 +67,7 @@ func TestRedirectHTTPS_passesHTTPSThroughViaXForwardedProto(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", server.URL+"/", nil)
 	req.Header.Set("X-Forwarded-Proto", "https")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := server.Client().Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode,
@@ -206,7 +206,7 @@ func TestAccessLog_statusWriterForwardsFlush(t *testing.T) {
 	})
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/stream")
+	resp, err := server.Client().Get(server.URL + "/stream")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	buf := make([]byte, 256)
@@ -225,7 +225,7 @@ func TestAccessLog_includesRequestIDWhenPresent(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", server.URL+"/", nil)
 	req.Header.Set("X-Request-ID", "trace-7")
-	resp, _ := http.DefaultClient.Do(req)
+	resp, _ := server.Client().Do(req)
 	resp.Body.Close()
 
 	found := false
@@ -245,7 +245,7 @@ func TestAccessLog_emitsOneRecordPerRequest(t *testing.T) {
 	via.Mount[accessLogPage](app, "/")
 
 	for range 3 {
-		resp, err := http.Get(server.URL + "/")
+		resp, err := server.Client().Get(server.URL + "/")
 		require.NoError(t, err)
 		resp.Body.Close()
 	}
@@ -338,7 +338,7 @@ func TestRecover_panicAfterPartialWriteKeepsServerAlive(t *testing.T) {
 	})
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/half")
+	resp, err := server.Client().Get(server.URL + "/half")
 	require.NoError(t, err)
 	body := readAll(t, resp.Body)
 	resp.Body.Close()
@@ -346,7 +346,7 @@ func TestRecover_panicAfterPartialWriteKeepsServerAlive(t *testing.T) {
 		"headers already flushed → Recover cannot rewrite to 500")
 	assert.Contains(t, body, "partial")
 
-	resp2, err := http.Get(server.URL + "/ok")
+	resp2, err := server.Client().Get(server.URL + "/ok")
 	require.NoError(t, err)
 	body2 := readAll(t, resp2.Body)
 	resp2.Body.Close()
@@ -367,14 +367,14 @@ func TestRecover_panicReturns500AndKeepsServerAlive(t *testing.T) {
 		_, _ = w.Write([]byte("ok"))
 	})
 
-	resp, err := http.Get(server.URL + "/boom")
+	resp, err := server.Client().Get(server.URL + "/boom")
 	require.NoError(t, err)
 	resp.Body.Close()
 	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode,
 		"panicking handler should produce 500")
 
 	// Subsequent requests still work.
-	resp2, err := http.Get(server.URL + "/ok")
+	resp2, err := server.Client().Get(server.URL + "/ok")
 	require.NoError(t, err)
 	resp2.Body.Close()
 	assert.Equal(t, http.StatusOK, resp2.StatusCode,
@@ -426,7 +426,7 @@ func TestRequestID_generatesWhenAbsent(t *testing.T) {
 	via.Mount[ridProbePage](app, "/")
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/")
+	resp, err := server.Client().Get(server.URL + "/")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -446,7 +446,7 @@ func TestRequestID_passesThroughInboundHeader(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", server.URL+"/", nil)
 	req.Header.Set("X-Request-ID", "my-trace-123")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := server.Client().Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, "my-trace-123", resp.Header.Get("X-Request-ID"),
@@ -468,13 +468,13 @@ func TestDefaults_installsRecoverRequestIDAndAccessLog(t *testing.T) {
 	})
 
 	// Recover survives the panic.
-	resp, err := http.Get(server.URL + "/boom")
+	resp, err := server.Client().Get(server.URL + "/boom")
 	require.NoError(t, err)
 	resp.Body.Close()
 	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 
 	// RequestID stamps a header.
-	resp2, err := http.Get(server.URL + "/ok")
+	resp2, err := server.Client().Get(server.URL + "/ok")
 	require.NoError(t, err)
 	resp2.Body.Close()
 	assert.NotEmpty(t, resp2.Header.Get("X-Request-ID"))

--- a/on/on_test.go
+++ b/on/on_test.go
@@ -3,7 +3,6 @@ package on_test
 import (
 	"bytes"
 	"io"
-	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -369,7 +368,7 @@ func TestKey_panicsOnAnonymousFunction(t *testing.T) {
 
 func getBody(t *testing.T, server *httptest.Server, path string) string {
 	t.Helper()
-	resp, err := http.Get(server.URL + path)
+	resp, err := server.Client().Get(server.URL + path)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	buf, _ := io.ReadAll(resp.Body)

--- a/render_test.go
+++ b/render_test.go
@@ -32,7 +32,7 @@ func TestWritePageDocument_marshalFailureStillRenders(t *testing.T) {
 	via.Mount[unmarshalablePage](app, "/")
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/")
+	resp, err := server.Client().Get(server.URL + "/")
 	require.NoError(t, err)
 	body := readAll(t, resp.Body)
 	resp.Body.Close()
@@ -54,7 +54,7 @@ func TestView_panicReachesTheConfiguredLoggerNotBareStderr(t *testing.T) {
 	app, server, logger := newLoggedApp(t, via.LogError)
 	via.Mount[panicViewPage](app, "/")
 
-	resp, err := http.Get(server.URL + "/")
+	resp, err := server.Client().Get(server.URL + "/")
 	require.NoError(t, err)
 	resp.Body.Close()
 
@@ -78,7 +78,7 @@ func TestView_panicProducesControlled500NotADroppedConnection(t *testing.T) {
 	app, server, _ := newLoggedApp(t, via.LogError)
 	via.Mount[panicViewPage](app, "/")
 
-	resp, err := http.Get(server.URL + "/")
+	resp, err := server.Client().Get(server.URL + "/")
 	require.NoError(t, err,
 		"View panic must yield an HTTP response, not a dropped connection")
 	body := readAll(t, resp.Body)

--- a/server_test.go
+++ b/server_test.go
@@ -93,7 +93,7 @@ func TestWithNotFound_servesCustomHandlerOnUnknownRoute(t *testing.T) {
 	via.Mount[introspectPage](app, "/known")
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/no-such-thing")
+	resp, err := server.Client().Get(server.URL + "/no-such-thing")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -115,7 +115,7 @@ func TestWithNotFound_doesNotInterceptKnownRoutes(t *testing.T) {
 	via.Mount[introspectPage](app, "/known")
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/known")
+	resp, err := server.Client().Get(server.URL + "/known")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -206,14 +206,14 @@ func TestHandleStatic_servesFromFS(t *testing.T) {
 	app.HandleStatic("/static/", fsys)
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/static/app.css")
+	resp, err := server.Client().Get(server.URL + "/static/app.css")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Contains(t, string(body), "amber")
 
-	resp2, err := http.Get(server.URL + "/static/sub/inner.txt")
+	resp2, err := server.Client().Get(server.URL + "/static/sub/inner.txt")
 	require.NoError(t, err)
 	defer resp2.Body.Close()
 	body2, _ := io.ReadAll(resp2.Body)
@@ -233,7 +233,7 @@ func TestHandleStatic_notFoundFallsThrough(t *testing.T) {
 	app.HandleStatic("/assets/", fsys)
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/assets/missing.txt")
+	resp, err := server.Client().Get(server.URL + "/assets/missing.txt")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)

--- a/sess_test.go
+++ b/sess_test.go
@@ -25,7 +25,7 @@ func TestSession_cookieIsSetWithSecureDefaults(t *testing.T) {
 	})
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/test")
+	resp, err := server.Client().Get(server.URL + "/test")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -50,7 +50,7 @@ func TestSession_insecureCookiesDisablesSecureFlag(t *testing.T) {
 	})
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/test")
+	resp, err := server.Client().Get(server.URL + "/test")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -95,7 +95,7 @@ func TestSession_secureFlagWhenWithSecureCookiesEnabled(t *testing.T) {
 	})
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/test")
+	resp, err := server.Client().Get(server.URL + "/test")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 

--- a/signal_test.go
+++ b/signal_test.go
@@ -94,7 +94,7 @@ func TestSignal_keyDefaultsToLowercasedFieldName(t *testing.T) {
 
 func getBody(t *testing.T, server *httptest.Server, path string) string {
 	t.Helper()
-	resp, err := http.Get(server.URL + path)
+	resp, err := server.Client().Get(server.URL + path)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	buf, _ := io.ReadAll(resp.Body)

--- a/sse_test.go
+++ b/sse_test.go
@@ -30,7 +30,7 @@ func TestHandleSSEClose_oversizedBodyReturns413(t *testing.T) {
 	via.Mount[sseEmptyPage](app, "/")
 	defer server.Close()
 
-	resp, err := http.Post(
+	resp, err := server.Client().Post(
 		server.URL+"/_sse/close",
 		"text/plain",
 		bytes.NewReader(bytes.Repeat([]byte("x"), 1024)),
@@ -48,7 +48,7 @@ func TestHandleSSEClose_unknownTabIsNoOp200(t *testing.T) {
 	via.Mount[sseEmptyPage](app, "/")
 	defer server.Close()
 
-	resp, err := http.Post(
+	resp, err := server.Client().Post(
 		server.URL+"/_sse/close",
 		"text/plain",
 		strings.NewReader("does-not-exist"),

--- a/stream_test.go
+++ b/stream_test.go
@@ -48,7 +48,7 @@ func TestStream_callbackPanicDoesNotCrashServer(t *testing.T) {
 	// If recoverLog didn't catch the panic, the server goroutine would
 	// be dead and the follow-up GET would fail. Surviving the request
 	// is the assertion.
-	resp, err := http.Get(server.URL + "/")
+	resp, err := server.Client().Get(server.URL + "/")
 	require.NoError(t, err)
 	resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)


### PR DESCRIPTION
## Summary
`httptest.Server.Close` calls `http.DefaultTransport.CloseIdleConnections()` as cleanup. All test files use `t.Parallel()` + `http.Get`/`http.Post`/`http.DefaultClient` (shared DefaultTransport), so one test's server teardown can sever an idle connection another test is about to reuse — the `transport connection broken: CloseIdleConnections called` flake that failed CI on main (mw HSTS test).

Mechanical fix across 20 test files: every request now goes through its own `server.Client()`, whose transport no other test can touch. `vt` already used dedicated transports and is untouched.

## Testing
- `go vet ./...` clean
- `go test -count=3 -parallel 16 ./...` — zero failures across 3 stress runs