### PR TITLE
ci: run pull_request workflows only for PRs targeting main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,6 +9,7 @@ on:
   # Build (but don't deploy) on PRs that touch the docs, so a broken site
   # fails the PR rather than the post-merge deploy.
   pull_request:
+    branches: [main]
     paths:
       - "docs/**"
       - ".github/workflows/pages.yml"


### PR DESCRIPTION
Adds `branches: [main]` to the `pull_request` triggers in ci.yml and pages.yml so PRs between feature branches don't burn Actions runs. codeql.yml and dependency-review.yml already filter to main; push triggers were already main-only everywhere.