### PR TITLE
feat(sse): reconnect resilience — recover the tab instead of freezing

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -41,6 +41,11 @@ type Ctx struct {
 	// which is itself proof the tab is alive — the TTL sweep skips such a
 	// Ctx, so lastAccess governs only stream-less ctxs.
 	connected atomic.Int32
+	// everConnected latches once the first SSE stream opens. Unlike
+	// connected it never resets, so runSSEStream can tell a reconnect
+	// (resync the view — the client may have drifted during the gap)
+	// from the first connect (the page document already carries the view).
+	everConnected atomic.Bool
 
 	// lastSignals holds the most recent signals payload from an action
 	// POST so via.DecodeForm can read keys that aren't tracked by typed

--- a/docs/production.md
+++ b/docs/production.md
@@ -78,6 +78,8 @@ and emits structured events for ops dashboards:
 | `via.render.total` | counter | `route` |
 | `via.sse.connect` | counter | |
 | `via.sse.disconnect` | counter | |
+| `via.sse.resync` | counter | |
+| `via.sse.recover` | counter | `mode` |
 | `via.ctx.live` | gauge | |
 
 Adapt to Prometheus, OTel, or expvar by implementing three methods
@@ -100,16 +102,30 @@ existing patch queue + SSE drain — no extra wiring. Single-process only.
 ## Restart and tab survivability
 
 A live tab's state lives in memory on the server (the `*via.Ctx` and its
-session). It does **not** survive a process restart:
+session). It does **not** survive a process restart, but the *connection*
+recovers on its own:
 
-- After a deploy, every client's `via_tab` is unknown to the new process.
-  The next SSE reconnect 404s and the next action POST 404s.
-- Datastar retries the SSE connection forever, so a user watching a stale
-  tab sees it freeze rather than recover. Tell users to reload, or pair the
-  deploy with a sticky load balancer that drains long enough for tabs to
-  close naturally.
+- **Transient drop (server up, tab still known):** Datastar reconnects and
+  via re-ships the current view on the reconnect (counted as
+  `via.sse.resync`), so a client that drifted during the gap converges back
+  to server truth. Signals are not re-seeded — live client-side signal
+  state survives the blip. No user action needed.
+- **Stale tab (deploy/restart, or TTL-swept):** the reconnecting `via_tab`
+  is unknown to the process. via **re-bootstraps** the tab over the same
+  stream: it recovers the route from the tab id, rebuilds path/query params
+  from the `Referer`, runs `OnInit`/`OnConnect` on a fresh `*via.Ctx`, and
+  pushes the full view plus a fresh signal seed (including a new `via_tab`).
+  The user sees current — not stale — state without a reload; in-memory tab
+  state starts fresh (`via.sse.recover` with `mode=rebootstrap`).
+- **Unrecoverable (param route with no usable `Referer`, or the app is at
+  `WithMaxContexts` capacity):** via pushes an explicit
+  `window.location.reload()` so the tab recovers via a normal page load
+  instead of freezing (`via.sse.recover` with `mode=reload`).
+- A `via_tab` whose route prefix was never mounted is treated as forged and
+  still 404s — junk traffic can't mint contexts.
 - Sessions are also in-memory; logged-in users re-auth unless you back the
-  session store with something durable.
+  session store with something durable. `OnInit` runs again on every
+  re-bootstrap, so session-backed rehydration (below) applies there too.
 
 For session survivability, persist the `sess.Put`-stored payload (e.g. a JWT
 or opaque token) to a database keyed by the `via_session` cookie value, and

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -27,17 +27,21 @@ app := via.New(via.WithInsecureCookies())
 
 Never ship `WithInsecureCookies()` to production — it drops the `Secure` flag.
 
-## The tab freezes / actions 404 after a redeploy
+## The tab shows stale state / resets after a redeploy
 
-**Cause:** a tab's state lives in memory on the server. After a restart, the
-client's `via_tab` is unknown to the new process: the next SSE reconnect 404s
-and the next action POST 404s. Datastar retries the SSE forever, so the tab
-appears frozen rather than erroring.
+**Cause:** a tab's state lives in memory on the server and does not survive a
+restart. When the SSE stream reconnects with a `via_tab` the new process
+doesn't know, via re-bootstraps the tab in place: a fresh `*via.Ctx` is built
+from the route and the `Referer`'s path/query params, `OnInit` runs again, and
+the full view plus a new signal seed replace the stale UI. When the page
+request can't be reconstructed (a path-param route with no usable `Referer`),
+via pushes an explicit `window.location.reload()` instead. Either way the tab
+recovers without user action — but in-memory tab state starts over.
 
-**Fix:** tell users to reload after a deploy, or drain behind a sticky load
-balancer long enough for tabs to close. For session survival across restarts,
-persist the `sess.Put` payload to a durable store keyed by the `via_session`
-cookie and rehydrate in `OnInit`. See
+**Fix:** for state that must survive a deploy, persist the `sess.Put` payload
+to a durable store keyed by the `via_session` cookie and rehydrate in `OnInit`
+(which also runs on every re-bootstrap). Watch `via.sse.recover` to see how
+often clients hit this path. See
 [Production & ops](production#restart-and-tab-survivability).
 
 ## `on.Click(c.DoThing)` won't compile

--- a/docs/why-via.md
+++ b/docs/why-via.md
@@ -46,8 +46,9 @@ Read this before adopting. The non-goals are deliberate.
 - **Not a cluster runtime.** `StateApp[T]` and `Broadcast` are
   single-process. Horizontal scaling requires sticky sessions; App state is
   per-pod. There is no built-in fan-out across instances.
-- **Not offline-first.** Disconnect the SSE stream and the tab freezes until
-  reconnect — Via is for connected sessions, not PWAs.
+- **Not offline-first.** Disconnect the SSE stream and the tab is inert until
+  reconnect (the view resyncs automatically once the stream is back) — Via is
+  for connected sessions, not PWAs.
 - **Not a JavaScript replacement.** The browser still runs Datastar's Alien
   Signals graph. Via removes hand-written JS for the reactivity layer, not
   the runtime.

--- a/queue_order_test.go
+++ b/queue_order_test.go
@@ -1,0 +1,175 @@
+package via_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-via/via"
+	"github.com/go-via/via/h"
+	"github.com/go-via/via/vt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type queueOrderPage struct {
+	N via.StateTabNum[int]
+}
+
+func (p *queueOrderPage) Bump(ctx *via.Ctx) error {
+	return p.N.Update(ctx, func(n int) (int, error) { return n + 1, nil })
+}
+
+func (p *queueOrderPage) BumpAndOverride(ctx *via.Ctx) error {
+	if err := p.N.Update(ctx, func(n int) (int, error) { return n + 1, nil }); err != nil {
+		return err
+	}
+	ctx.Patch.Elements(h.Div(h.ID("n"), h.Text("OVERRIDE")))
+	return nil
+}
+
+func (p *queueOrderPage) View(ctx *via.CtxR) h.H {
+	return h.Div(h.ID("n"), p.N.Text(ctx))
+}
+
+// A tab whose SSE is down (hidden tab, transient drop) keeps acting via
+// POSTs; every flush re-renders the view into the patch queue. On
+// reconnect the drained frame must leave the client on the NEWEST
+// render — datastar applies same-id patches last-wins, so a stale
+// fragment surviving after the fresh one silently rewinds the UI
+// (observed live: tab stuck on the first of five increments).
+func TestReconnectAfterOfflineActionsShowsNewestState(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	via.Mount[queueOrderPage](app, "/q")
+	defer server.Close()
+
+	tc := vt.NewClient(t, server, "/q")
+	// Three state-mutating actions with no SSE stream open: each flush
+	// queues a fresh view render while nothing drains.
+	for i := 0; i < 3; i++ {
+		require.Equal(t, http.StatusOK, tc.Action("Bump").Fire())
+	}
+
+	frames, cancel := tc.SSE()
+	defer cancel()
+	body := vt.AwaitFrame(t, frames, 2*time.Second, ": ready")
+
+	assert.Contains(t, body, ">3<",
+		"reconnect drain must carry the newest render")
+	assert.NotContains(t, body, ">1<",
+		"stale renders must not survive in the drained frame — last-wins morph would rewind the UI to them")
+	assert.NotContains(t, body, ">2<",
+		"stale renders must not survive in the drained frame — last-wins morph would rewind the UI to them")
+}
+
+// A user-explicit Patch.Elements targeting an id the auto re-render also
+// ships must stay authoritative: datastar applies patches in document
+// order, so the explicit fragment has to come AFTER the auto render in
+// the wire frame.
+func TestExplicitElementPatchOverridesAutoRender(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	via.Mount[queueOrderPage](app, "/q")
+	defer server.Close()
+
+	tc := vt.NewClient(t, server, "/q")
+	frames, cancel := tc.SSEReady()
+	defer cancel()
+
+	require.Equal(t, http.StatusOK, tc.Action("BumpAndOverride").Fire())
+	body := vt.AwaitFrame(t, frames, 2*time.Second, "OVERRIDE")
+
+	auto := strings.Index(body, ">1<")
+	override := strings.Index(body, "OVERRIDE")
+	require.GreaterOrEqual(t, auto, 0, "auto render must be in the frame")
+	assert.Greater(t, override, auto,
+		"explicit patch must come after the auto render so last-wins keeps it authoritative")
+}
+
+// Explicit patches from separate offline actions are independent pushes
+// (often to different targets) — both must survive the reconnect drain,
+// in the order they were queued.
+func TestExplicitPatchesFromSeparateActionsAllSurviveReconnect(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	via.Mount[explicitQueuePage](app, "/e")
+	defer server.Close()
+
+	tc := vt.NewClient(t, server, "/e")
+	require.Equal(t, http.StatusOK, tc.Action("PushA").Fire())
+	require.Equal(t, http.StatusOK, tc.Action("PushB").Fire())
+
+	frames, cancel := tc.SSE()
+	defer cancel()
+	body := vt.AwaitFrame(t, frames, 2*time.Second, ": ready")
+
+	a := strings.Index(body, "PATCH-A")
+	b := strings.Index(body, "PATCH-B")
+	require.GreaterOrEqual(t, a, 0, "first explicit patch must survive")
+	require.GreaterOrEqual(t, b, 0, "second explicit patch must survive")
+	assert.Greater(t, b, a, "explicit patches must drain in queue order")
+}
+
+// A view that panics once N reaches the panic threshold. Used to prove a
+// later panicking re-render does not erase a previously queued good render.
+type panicRenderPage struct {
+	N via.StateTabNum[int]
+}
+
+func (p *panicRenderPage) Bump(ctx *via.Ctx) error {
+	return p.N.Update(ctx, func(n int) (int, error) { return n + 1, nil })
+}
+
+func (p *panicRenderPage) View(ctx *via.CtxR) h.H {
+	if p.N.Read(ctx) >= 2 {
+		panic("boom")
+	}
+	return h.Div(h.ID("n"), p.N.Text(ctx))
+}
+
+// A disconnected tab queues a good auto-render, then a later action's
+// re-render panics (yielding an empty fragment). The empty fragment must
+// NOT clobber the queued good render: on reconnect the client must still
+// receive the last good view, not an empty frame.
+func TestPanickingRenderDoesNotEraseQueuedGoodRender(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	via.Mount[panicRenderPage](app, "/p")
+	defer server.Close()
+
+	tc := vt.NewClient(t, server, "/p")
+	// N=1: good render queued. N=2: view panics, empty fragment — must not
+	// erase the queued ">1<".
+	require.Equal(t, http.StatusOK, tc.Action("Bump").Fire())
+	require.Equal(t, http.StatusOK, tc.Action("Bump").Fire())
+
+	frames, cancel := tc.SSE()
+	defer cancel()
+	body := vt.AwaitFrame(t, frames, 2*time.Second, ": ready")
+
+	assert.Contains(t, body, ">1<",
+		"a later panicking render must not erase the last good queued render")
+}
+
+type explicitQueuePage struct{}
+
+func (p *explicitQueuePage) PushA(ctx *via.Ctx) {
+	ctx.Patch.Elements(h.Div(h.ID("a"), h.Text("PATCH-A")))
+}
+
+func (p *explicitQueuePage) PushB(ctx *via.Ctx) {
+	ctx.Patch.Elements(h.Div(h.ID("b"), h.Text("PATCH-B")))
+}
+
+func (p *explicitQueuePage) View(ctx *via.CtxR) h.H { return h.Div(h.ID("root")) }

--- a/recover.go
+++ b/recover.go
@@ -1,0 +1,232 @@
+package via
+
+import (
+	"encoding/json"
+	"html"
+	"html/template"
+	"net/http"
+	"net/url"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"github.com/starfederation/datastar-go/datastar"
+)
+
+// This file implements SSE reconnect recovery: when a stream reconnects
+// with a via_tab the process no longer knows (TTL sweep, deploy/restart),
+// the old behavior was a 404 — which Datastar retries forever, freezing
+// the tab. Instead, a stale-but-plausible id re-bootstraps a fresh Ctx
+// over the same stream: the route is recovered from the tab id's prefix,
+// path/query params from the Referer, then OnInit runs and the full view
+// plus a fresh signal seed (including a new via_tab) replace the stale
+// state client-side. When the page request can't be reconstructed (a
+// param route with no usable Referer, or the app is at capacity), the
+// stream degrades to an explicit window.location.reload() — predictable
+// recovery, never a silent freeze.
+
+// sseBootstrap is the recovery payload runSSEStream ships before entering
+// its drain loop: the fresh signal seed and the full-view fragment that
+// replaces the stale tab container.
+type sseBootstrap struct {
+	signals  []byte // fresh seed: via_tab + app signals + Signal[T] slots
+	elements string // full view wrapped in the new ctx's container div
+	selector string // CSS selector addressing the stale container
+}
+
+// staleTabSuffixRE pins the random component of a recoverable tab id to
+// exactly what genSecureID emits (64 hex chars). Anything else is a forged
+// or garbage id and keeps the historical 404.
+var staleTabSuffixRE = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+// descriptorForStaleTab maps a stale tab id back to its mounted descriptor
+// via the route prefix genTabID baked in (`<route>_<64-hex>`). nil when the
+// id is malformed or names a route this process never mounted.
+func (a *App) descriptorForStaleTab(tabID string) *cmpDescriptor {
+	i := strings.LastIndexByte(tabID, '_')
+	if i <= 0 || !staleTabSuffixRE.MatchString(tabID[i+1:]) {
+		return nil
+	}
+	route := tabID[:i]
+	a.descsMu.RLock()
+	defer a.descsMu.RUnlock()
+	for _, d := range a.descs {
+		if d.route == route {
+			return d
+		}
+	}
+	return nil
+}
+
+// recoverSSE handles an SSE handshake whose via_tab is unknown. Runs the
+// descriptor's group middleware first — same posture as the page render
+// and the known-tab handshake — so a requireAuth-style guard vetoes the
+// re-bootstrap exactly as it would veto the page.
+func (a *App) recoverSSE(w http.ResponseWriter, r *http.Request, staleID string) {
+	d := a.descriptorForStaleTab(staleID)
+	if d == nil {
+		// Forged / garbage id: keep the historical 404 so junk traffic
+		// can't mint contexts.
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m := a.metricsOrNoop()
+		pageReq := a.recoveredPageRequest(r, d)
+		if pageReq == nil {
+			m.Counter("via.sse.recover", "mode", "reload")
+			a.streamReloadScript(w, r)
+			return
+		}
+		ctx, boot := a.rebootstrapCtx(d, w, r, pageReq, staleID)
+		if ctx == nil {
+			m.Counter("via.sse.recover", "mode", "reload")
+			a.streamReloadScript(w, r)
+			return
+		}
+		m.Counter("via.sse.recover", "mode", "rebootstrap")
+		runSSEStream(a, ctx, w, r, boot)
+	})
+	applyMiddleware(d.groupMW, handler).ServeHTTP(w, r)
+}
+
+// recoveredPageRequest reconstructs the page GET the original render was
+// born from, so path/query params decode into the fresh composition. The
+// page URL comes from the SSE request's Referer (same-origin fetches send
+// it); a paramless route falls back to its own literal pattern when no
+// Referer is available. Returns nil when the request can't be rebuilt —
+// the caller degrades to a reload.
+func (a *App) recoveredPageRequest(r *http.Request, d *cmpDescriptor) *http.Request {
+	var pagePath string
+	if ref := r.Referer(); ref != "" {
+		if u, err := url.Parse(ref); err == nil && u.Path != "" {
+			pagePath = u.Path
+			if u.RawQuery != "" {
+				pagePath += "?" + u.RawQuery
+			}
+		}
+	}
+	if pagePath == "" {
+		if strings.ContainsRune(d.route, '{') {
+			return nil // param values are unrecoverable without a Referer
+		}
+		pagePath = d.route
+	}
+
+	// Route the synthetic GET through a throwaway mux holding only this
+	// descriptor's pattern: ServeMux is the sole owner of pattern-matching
+	// semantics (and of populating PathValue), so reuse it rather than
+	// reimplementing wildcard matching. No match (a Referer from some
+	// other page) leaves matched nil → reload fallback.
+	synth, err := http.NewRequestWithContext(r.Context(), http.MethodGet, pagePath, nil)
+	if err != nil {
+		return nil
+	}
+	var matched *http.Request
+	mm := http.NewServeMux()
+	mm.HandleFunc("GET "+d.route, func(_ http.ResponseWriter, mr *http.Request) {
+		matched = mr
+	})
+	mm.ServeHTTP(noopResponseWriter{}, synth)
+	return matched
+}
+
+// rebootstrapCtx mirrors renderPage — fresh *C, params, OnInit, registry
+// insert — but renders for the SSE wire instead of a page document. The
+// fresh tab id is minted server-side and only ever travels down this
+// stream: accepting the client-supplied stale id as the new identity
+// would let a cross-origin GET register an attacker-known via_tab against
+// the victim's session, breaking the via_tab-as-CSRF-token model.
+func (a *App) rebootstrapCtx(d *cmpDescriptor, w http.ResponseWriter, r, pageReq *http.Request, staleID string) (*Ctx, *sseBootstrap) {
+	cmpVal := reflect.New(d.typ)
+	ctx := newCtx(d, cmpVal, genTabID(d.route))
+	ctx.app = a
+	ctx.session.Store(a.sessionFromRequest(r))
+	ctx.mu.Lock()
+	ctx.w = w
+	ctx.r = r
+	ctx.mu.Unlock()
+	ctx.captureCSPNonce(r)
+	// Same scoping as renderPage: writer/request live only for the
+	// synchronous bootstrap; goroutines launched from OnInit must not
+	// hold a dangling reference.
+	defer func() {
+		ctx.mu.Lock()
+		ctx.w = nil
+		ctx.r = nil
+		ctx.mu.Unlock()
+	}()
+
+	decodePathParams(cmpVal, pageReq, d)
+	decodeQueryParams(cmpVal, pageReq, d)
+
+	if ctx.initFn != nil {
+		func() {
+			defer recoverLog(ctx, "OnInit")
+			if err := ctx.initFn(ctx); err != nil {
+				a.logErr(ctx, "OnInit: %v", err)
+			}
+		}()
+	}
+
+	if !a.tryRegisterCtx(ctx, a.cfg.maxContexts) {
+		a.logWarn(nil, "max contexts reached (%d); rejecting SSE re-bootstrap", a.cfg.maxContexts)
+		return nil, nil
+	}
+
+	sigs, err := json.Marshal(a.initialSignals(ctx))
+	if err != nil {
+		// Same failure class as writePageDocument: a plugin app signal or
+		// Signal[T] init value that can't round-trip. Seed at least the
+		// fresh via_tab so actions recover even if the rest didn't encode.
+		a.logErr(ctx, "rebootstrapCtx: json.Marshal initial signals: %v", err)
+		sigs, _ = json.Marshal(map[string]string{tabSignalKey: ctx.id})
+	}
+
+	// The page document's beforeunload beacon closes over the OLD tab id
+	// (a no-op close after recovery), so the recovered ctx would only ever
+	// be reclaimed by the TTL sweep. Queue a replacement beacon for the
+	// fresh id; drainQueue ships it right after the bootstrap frames.
+	enqueueScript(ctx, "window.addEventListener('beforeunload',()=>{navigator.sendBeacon('/_sse/close','"+
+		template.JSEscapeString(ctx.id)+"');})")
+
+	return ctx, &sseBootstrap{
+		signals:  sigs,
+		elements: a.renderFragment(ctx),
+		selector: staleContainerSelector(staleID),
+	}
+}
+
+// staleContainerSelector addresses the old tab's container div. An
+// attribute selector (not #id) because routes — and therefore tab ids —
+// routinely contain `/`, which is invalid unescaped in an id selector.
+// The hex suffix is already validated; the route part is server-defined,
+// but escape quote/backslash anyway so the selector can't be broken out of.
+func staleContainerSelector(staleID string) string {
+	esc := strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(staleID)
+	return `[id="` + esc + `"]`
+}
+
+// streamReloadScript is the degraded recovery path: open the SSE stream
+// (a 200, so Datastar stops hammering the endpoint) and push an explicit
+// reload. The subsequent page GET re-bootstraps everything from scratch.
+func (a *App) streamReloadScript(w http.ResponseWriter, r *http.Request) {
+	sse := datastar.NewSSE(w, r,
+		datastar.WithCompression(datastar.WithBrotli(datastar.WithBrotliLevel(sseLevel))))
+	setSSEWriteDeadline(w, a.cfg.sseWriteTimeout)
+	var opts []datastar.ExecuteScriptOption
+	// No ctx on this path — thread the request's strict-CSP nonce (if a
+	// CSP middleware installed one) straight onto the injected <script>.
+	if n, ok := r.Context().Value(cspNonceKey{}).(string); ok && n != "" {
+		opts = append(opts, datastar.WithExecuteScriptAttributes(`nonce="`+html.EscapeString(n)+`"`))
+	}
+	_ = sse.ExecuteScript("window.location.reload()", opts...)
+}
+
+// noopResponseWriter absorbs the throwaway mux's output (the 404 it writes
+// on a non-matching synthetic request).
+type noopResponseWriter struct{}
+
+func (noopResponseWriter) Header() http.Header         { return http.Header{} }
+func (noopResponseWriter) Write(b []byte) (int, error) { return len(b), nil }
+func (noopResponseWriter) WriteHeader(int)             {}

--- a/render.go
+++ b/render.go
@@ -90,14 +90,18 @@ func (a *App) renderView(ctx *Ctx, w http.ResponseWriter) (body h.H, ok bool) {
 	return ctx.viewFn(ctx.readView()), true
 }
 
-func (a *App) writePageDocument(w http.ResponseWriter, ctx *Ctx, body h.H) {
+// initialSignals assembles the signal seed for a fresh ctx: via_tab,
+// every plugin-registered app signal, and every typed Signal[T] slot's
+// current value. Shared by the page document render and the SSE
+// re-bootstrap path (recoverSSE), which must seed the same set.
+func (a *App) initialSignals(ctx *Ctx) map[string]any {
 	a.appSignalsMu.RLock()
 	// Size hint: via_tab + every app signal + every typed signal slot.
 	// Map auto-grows beyond this if scope handles add more, but a
 	// correct hint avoids the rehash chain on the common path.
-	initialSigs := make(map[string]any, 1+len(a.appSignals)+len(ctx.desc.signalSlots))
-	initialSigs[tabSignalKey] = ctx.id
-	maps.Copy(initialSigs, a.appSignals)
+	sigs := make(map[string]any, 1+len(a.appSignals)+len(ctx.desc.signalSlots))
+	sigs[tabSignalKey] = ctx.id
+	maps.Copy(sigs, a.appSignals)
 	a.appSignalsMu.RUnlock()
 	for i, s := range ctx.desc.signalSlots {
 		if s.kind != kindSignal {
@@ -107,10 +111,13 @@ func (a *App) writePageDocument(w http.ResponseWriter, ctx *Ctx, body h.H) {
 		if err != nil {
 			continue
 		}
-		initialSigs[s.wireKey] = json.RawMessage(v)
+		sigs[s.wireKey] = json.RawMessage(v)
 	}
+	return sigs
+}
 
-	sigsJSON, err := json.Marshal(initialSigs)
+func (a *App) writePageDocument(w http.ResponseWriter, ctx *Ctx, body h.H) {
+	sigsJSON, err := json.Marshal(a.initialSignals(ctx))
 	if err != nil {
 		// A plugin pushed an unmarshalable value via RegisterAppSignal,
 		// or a typed Signal[T]'s init value can't round-trip. Log so

--- a/render.go
+++ b/render.go
@@ -196,18 +196,27 @@ func flushDirty(ctx *Ctx) {
 		// autoflush defer (would drop the action connection) and on the
 		// broadcast SyncNow goroutine (would crash the process — no defer
 		// stack to fall back on). renderFragment recovers and logs; a
-		// panic yields "", which prepends as a no-op and is dropped by the
-		// drain's elems != "" guard, so the broken fragment never ships
-		// while the signal flush below still proceeds.
+		// panic yields "" — see the empty-frag guard below.
 		frag := ctx.app.renderFragment(ctx)
-		ctx.queue.mu.Lock()
-		// Prepend the auto re-render so any user-explicit Patch.Elements
-		// patches already queued (e.g. from inside the action body) end
-		// up later in the wire frame. Datastar's morph applies patches
-		// in document order with last-write-wins per id, so this keeps
-		// the user's targeted override the authoritative one.
-		ctx.queue.elements = frag + ctx.queue.elements
-		ctx.queue.mu.Unlock()
+		if frag != "" {
+			ctx.queue.mu.Lock()
+			// Replace — never append — the auto re-render. Only the newest
+			// render is correct, and the drain emits it before the
+			// user-explicit elements queue, so a Patch.Elements override
+			// still lands later in the wire frame and stays authoritative
+			// under datastar's last-write-wins-per-id morph.
+			//
+			// Guarded on frag != "": a panicking render yields "", which
+			// must NOT clobber a previously queued GOOD render that hasn't
+			// drained yet (a disconnected tab accumulating renders — one
+			// later panic would otherwise erase the last good frame, and
+			// the drain's elems != "" guard means nothing ships, leaving
+			// the client with no fresh view at all). Replacing only on a
+			// non-empty render preserves the last good frame; the signal
+			// flush below still proceeds either way.
+			ctx.queue.autoElements = frag
+			ctx.queue.mu.Unlock()
+		}
 	}
 
 	if hasSignals {

--- a/runtime.go
+++ b/runtime.go
@@ -41,7 +41,18 @@ func putRenderBuf(b *bytes.Buffer) {
 // / flushDirty only set elements after rendering non-empty content, so
 // the implication holds in both directions.
 type patchQueue struct {
-	mu       sync.Mutex
+	mu sync.Mutex
+	// autoElements holds the view re-render queued by flushDirty. It is
+	// REPLACED (not appended) on every flush: between drains only the
+	// newest render matters, and accumulating them is actively harmful —
+	// the client applies same-id patches last-wins, so a stale fragment
+	// surviving after the fresh one in the drained frame would rewind
+	// the UI to the oldest queued render (seen live on a hidden tab
+	// catching up after several broadcasts).
+	autoElements string
+	// elements holds user-explicit Patch.Elements pushes, appended in
+	// call order. Drained AFTER autoElements so an explicit patch
+	// targeting an id the auto render also ships stays authoritative.
 	elements string
 	signals  map[string]any
 	scripts  strings.Builder

--- a/sse.go
+++ b/sse.go
@@ -210,7 +210,7 @@ func hasPending(q *patchQueue) bool {
 	}
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	return q.elements != "" || q.redirect != "" ||
+	return q.autoElements != "" || q.elements != "" || q.redirect != "" ||
 		len(q.signals) > 0 || q.scripts.Len() > 0
 }
 
@@ -218,10 +218,14 @@ func drainQueue(sse *datastar.ServerSentEventGenerator, ctx *Ctx, w http.Respons
 	setSSEWriteDeadline(w, writeTimeout)
 	q := ctx.queue
 	q.mu.Lock()
-	elems := q.elements
+	// Auto render first, explicit patches after: the morph applies
+	// same-id patches last-wins, so the user's targeted override beats
+	// the auto render of the same element.
+	elems := q.autoElements + q.elements
 	signals := q.signals
 	scripts := q.scripts.String()
 	redirect := q.redirect
+	q.autoElements = ""
 	q.elements = ""
 	q.signals = nil
 	q.scripts.Reset()

--- a/sse.go
+++ b/sse.go
@@ -38,7 +38,10 @@ func (a *App) handleSSE(w http.ResponseWriter, r *http.Request) {
 
 	ctx, ok := a.getCtx(tabID)
 	if !ok {
-		w.WriteHeader(http.StatusNotFound)
+		// Stale-but-plausible tab id (TTL sweep, process restart):
+		// re-bootstrap a fresh Ctx over this same stream instead of
+		// 404ing into Datastar's infinite retry (a frozen tab).
+		a.recoverSSE(w, r, tabID)
 		return
 	}
 	if sess := ctx.session.Load(); sess != nil && a.sessionFromRequest(r) != sess {
@@ -51,12 +54,12 @@ func (a *App) handleSSE(w http.ResponseWriter, r *http.Request) {
 	// descriptor's group middleware so a requireAuth-style guard can
 	// veto the SSE handshake before the stream goes hot.
 	stream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		runSSEStream(a, ctx, w, r)
+		runSSEStream(a, ctx, w, r, nil)
 	})
 	applyMiddleware(ctx.desc.groupMW, stream).ServeHTTP(w, r)
 }
 
-func runSSEStream(a *App, ctx *Ctx, w http.ResponseWriter, r *http.Request) {
+func runSSEStream(a *App, ctx *Ctx, w http.ResponseWriter, r *http.Request, boot *sseBootstrap) {
 	m := a.metricsOrNoop()
 	m.Counter("via.sse.connect")
 	// Default to "client": every exit path other than a server-side
@@ -87,6 +90,35 @@ func runSSEStream(a *App, ctx *Ctx, w http.ResponseWriter, r *http.Request) {
 
 	sse := datastar.NewSSE(w, r,
 		datastar.WithCompression(datastar.WithBrotli(datastar.WithBrotliLevel(sseLevel))))
+
+	// Latch-and-branch on connection history. A re-bootstrap (boot != nil)
+	// seeds the fresh tab wholesale: signals first (incl. the new via_tab,
+	// so data-* bindings in the incoming elements resolve), then the full
+	// view replacing the stale container. A plain reconnect re-ships only
+	// the view — never signals, which would clobber live client-side
+	// signal state — so a client that drifted while disconnected (e.g. a
+	// trimmed queue, a missed frame) converges back to server truth.
+	if reconnect := ctx.everConnected.Swap(true); boot != nil {
+		setSSEWriteDeadline(w, a.cfg.sseWriteTimeout)
+		if err := sse.PatchSignals(boot.signals); err != nil {
+			return
+		}
+		if boot.elements != "" {
+			if err := sse.PatchElements(boot.elements,
+				datastar.WithSelector(boot.selector),
+				datastar.WithMode(datastar.ElementPatchModeReplace)); err != nil {
+				return
+			}
+		}
+	} else if reconnect {
+		m.Counter("via.sse.resync")
+		if frag := a.renderFragment(ctx); frag != "" {
+			setSSEWriteDeadline(w, a.cfg.sseWriteTimeout)
+			if err := sse.PatchElements(frag); err != nil {
+				return
+			}
+		}
+	}
 
 	// Force-drain anything queued while the previous SSE was
 	// disconnected — patches accumulated during the gap have no wake

--- a/sse_recover_test.go
+++ b/sse_recover_test.go
@@ -1,0 +1,256 @@
+package via_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-via/via"
+	"github.com/go-via/via/h"
+	"github.com/go-via/via/vt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- pages ---
+
+type recoverPage struct {
+	N via.StateTabNum[int]
+	Q via.Signal[int]
+}
+
+func (p *recoverPage) OnInit(ctx *via.Ctx) error {
+	return p.N.Update(ctx, func(int) (int, error) { return 7, nil })
+}
+
+func (p *recoverPage) Bump(ctx *via.Ctx) error {
+	return p.N.Update(ctx, func(n int) (int, error) { return n + 1, nil })
+}
+
+func (p *recoverPage) View(ctx *via.CtxR) h.H {
+	return h.Div(h.ID("n"), p.N.Text(ctx))
+}
+
+type recoverParamPage struct {
+	Name string `path:"name"`
+}
+
+func (p *recoverParamPage) View(ctx *via.CtxR) h.H {
+	return h.Div(h.Textf("hello %s", p.Name))
+}
+
+// --- helpers ---
+
+// jarClient returns an http.Client with a cookie jar, so the session the
+// SSE handshake mints is carried by follow-up action POSTs (the recovered
+// ctx binds the handshake's session; a cookie-less action would 403).
+func jarClient(t *testing.T) *http.Client {
+	t.Helper()
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+	return &http.Client{Jar: jar, Transport: &http.Transport{}}
+}
+
+// openRawSSE opens GET /_sse with the given via_tab and optional Referer,
+// returning the response status, a frames channel (nil unless 200), and a
+// cancel func.
+func openRawSSE(t *testing.T, httpc *http.Client, serverURL, tabID, referer string) (int, <-chan string, func()) {
+	t.Helper()
+	ctx, cancelF := context.WithCancel(context.Background())
+	u := serverURL + "/_sse?datastar=" + url.QueryEscape(`{"via_tab":"`+tabID+`"}`)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	require.NoError(t, err)
+	if referer != "" {
+		req.Header.Set("Referer", referer)
+	}
+	resp, err := httpc.Do(req)
+	require.NoError(t, err)
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		cancelF()
+		return resp.StatusCode, nil, func() {}
+	}
+	out := make(chan string, 16)
+	go func() {
+		defer close(out)
+		defer resp.Body.Close()
+		buf := make([]byte, 4096)
+		for {
+			n, err := resp.Body.Read(buf)
+			if n > 0 {
+				out <- string(buf[:n])
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+	return resp.StatusCode, out, func() { cancelF(); resp.Body.Close() }
+}
+
+var staleSuffix = strings.Repeat("ab", 32) // 64 hex chars, valid shape, never issued
+
+var tabSignalRE = regexp.MustCompile(`"via_tab":"([^"]+)"`)
+
+// --- known-tab reconnect ---
+
+func TestSSE_reconnectResyncsViewElements(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	via.Mount[recoverPage](app, "/r")
+	defer server.Close()
+
+	tc := vt.NewClient(t, server, "/r")
+	frames, cancel := tc.SSEReady()
+	require.Equal(t, http.StatusOK, tc.Action("Bump").Fire())
+	vt.AwaitFrame(t, frames, 2*time.Second, ">8<")
+	cancel() // drop the stream; queue is fully drained
+
+	// Reconnect with no pending patches: the resync must re-ship the
+	// current view so a client that drifted during the gap is corrected.
+	// Raw SSE() (not SSEReady) — the resync frame precedes the ready
+	// marker, which SSEReady would consume along with everything before it.
+	frames2, cancel2 := tc.SSE()
+	defer cancel2()
+	body := vt.AwaitFrame(t, frames2, 2*time.Second, "datastar-patch-elements", ">8<")
+
+	// View-only resync: signals must NOT be re-seeded on a known-tab
+	// reconnect (would clobber live client-side signal state). The only
+	// signal traffic allowed here is the empty keepalive payload.
+	assert.NotContains(t, body, `"q"`, "reconnect resync must not re-seed signals")
+	assert.NotContains(t, body, "via_tab", "reconnect resync must not re-seed via_tab")
+}
+
+func TestSSE_firstConnectDoesNotResync(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	via.Mount[recoverPage](app, "/r")
+	defer server.Close()
+
+	tc := vt.NewClient(t, server, "/r")
+	frames, cancel := tc.SSEReady()
+	defer cancel()
+
+	// The page document already carries the full view; the first connect
+	// must not redundantly re-ship it.
+	select {
+	case f, ok := <-frames:
+		if ok {
+			assert.NotContains(t, f, "datastar-patch-elements",
+				"first connect must not re-render the view")
+		}
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+// --- unknown-tab re-bootstrap ---
+
+func TestSSE_unknownTabRebootstrapsFreshCtx(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	via.Mount[recoverPage](app, "/r")
+	defer server.Close()
+
+	httpc := jarClient(t)
+	stale := "/r_" + staleSuffix
+	status, frames, cancel := openRawSSE(t, httpc, server.URL, stale, server.URL+"/r")
+	defer cancel()
+	require.Equal(t, http.StatusOK, status,
+		"unknown via_tab on a mounted route must re-bootstrap, not 404")
+
+	// Bootstrap must seed a fresh via_tab signal and ship the full view
+	// (OnInit ran: N==7), replacing the stale container.
+	body := vt.AwaitFrame(t, frames, 2*time.Second,
+		"via_tab", "datastar-patch-elements", ">7<")
+	m := tabSignalRE.FindStringSubmatch(body)
+	require.Len(t, m, 2, "bootstrap must patch a via_tab signal")
+	newTab := m[1]
+	assert.NotEqual(t, stale, newTab, "re-bootstrap must mint a fresh tab id")
+	assert.True(t, strings.HasPrefix(newTab, "/r_"))
+	assert.Contains(t, body, stale,
+		"element patch must target the stale container id")
+
+	// The recovered tab is live: actions against the new id work and
+	// their patches arrive on this same stream.
+	fire := func() int {
+		resp, err := httpc.Post(server.URL+"/_action/Bump", "application/json",
+			strings.NewReader(`{"via_tab":"`+newTab+`"}`))
+		require.NoError(t, err)
+		resp.Body.Close()
+		return resp.StatusCode
+	}
+	require.Equal(t, http.StatusOK, fire())
+	vt.AwaitFrame(t, frames, 2*time.Second, ">8<")
+}
+
+func TestSSE_unknownTabRecoversPathParamsFromReferer(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	via.Mount[recoverParamPage](app, "/u/{name}")
+	defer server.Close()
+
+	stale := "/u/{name}_" + staleSuffix
+	status, frames, cancel := openRawSSE(t, jarClient(t), server.URL, stale, server.URL+"/u/alice")
+	defer cancel()
+	require.Equal(t, http.StatusOK, status)
+	vt.AwaitFrame(t, frames, 2*time.Second, "hello alice")
+}
+
+func TestSSE_unknownTabParamRouteWithoutRefererFallsBackToReload(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	via.Mount[recoverParamPage](app, "/u/{name}")
+	defer server.Close()
+
+	stale := "/u/{name}_" + staleSuffix
+	status, frames, cancel := openRawSSE(t, jarClient(t), server.URL, stale, "")
+	defer cancel()
+	require.Equal(t, http.StatusOK, status,
+		"unrecoverable params must degrade to an explicit reload, not 404")
+	vt.AwaitFrame(t, frames, 2*time.Second, "window.location.reload()")
+}
+
+func TestSSE_unknownTabUnmountedRoutePrefix404s(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	via.Mount[recoverPage](app, "/r")
+	defer server.Close()
+
+	status, _, cancel := openRawSSE(t, jarClient(t), server.URL, "/nope_"+staleSuffix, server.URL+"/nope")
+	defer cancel()
+	assert.Equal(t, http.StatusNotFound, status,
+		"a tab id whose route prefix was never mounted is forged — keep the 404")
+}
+
+func TestSSE_unknownTabMalformedID404s(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	via.Mount[recoverPage](app, "/r")
+	defer server.Close()
+
+	for _, id := range []string{"", "garbage", "/r_nothex", "/r_" + staleSuffix[:10]} {
+		status, _, cancel := openRawSSE(t, jarClient(t), server.URL, id, server.URL+"/r")
+		cancel()
+		assert.Equal(t, http.StatusNotFound, status, "id=%q", id)
+	}
+}


### PR DESCRIPTION
## Summary

Two changes, both verified live in a browser (Brave, multi-tab counterscope session) on top of the full test suite.

### 1. Reconnect recovery (closes #82)

- **Unknown `via_tab` on SSE reconnect** (TTL sweep, deploy/restart) no longer 404s into a frozen tab. The server re-bootstraps a fresh `Ctx` over the same stream: route recovered from the tab-id prefix, path/query params from the `Referer`, `OnInit`/`OnConnect` run, then a fresh signal seed (new `via_tab`) + full-view replace of the stale container.
- **Degraded path**: param route w/ no usable Referer, or app at `WithMaxContexts` capacity → explicit `window.location.reload()` push instead of a silent freeze.
- **Forged ids keep the 404** (route prefix must be mounted, suffix must be 64-hex) so junk traffic can't mint contexts. The fresh tab id is always minted server-side — accepting the client-supplied id would let a cross-origin GET register an attacker-known `via_tab` against the victim's session.
- **Known-tab reconnects** now re-ship the current view (elements only; signals untouched so live client-side signal state survives), converging drifted clients back to server truth.
- New metrics: `via.sse.resync`, `via.sse.recover{mode=rebootstrap|reload}`. Docs updated (`production.md`, `troubleshooting.md`, `why-via.md`).

### 2. Patch-queue stale-render inversion (found while verifying #82)

`flushDirty` prepended every auto re-render to the queue. A disconnected tab (datastar closes SSE on hidden tabs) accumulates fragments newest-first, and the client's last-wins-per-id morph applied the **oldest** — a refocused tab visibly rewound (caught live: tab showed the 1st of 5 increments). The auto-render now lives in its own queue slot, replaced per flush; user-explicit `Patch.Elements` still drain after it and stay authoritative. A panicking view's empty fragment no longer erases the last good queued frame.

## Tests

- `sse_recover_test.go`: re-bootstrap (static + param routes), reload fallback, forged-id 404s, known-tab view-only resync, first-connect no-op
- `queue_order_test.go`: newest-render-wins on reconnect drain, explicit-patch authority, multi-action explicit accumulation, panic-erase guard
- Full suite, `ci-check.sh` alloc gates, `golangci-lint`: green

## Known follow-ups (out of scope, discovered during live verification)

- Bundled datastar never retries a *cleanly closed* SSE stream (graceful SIGTERM deploy still freezes; needs a client-side re-arm on `datastar-fetch` finished/retries-failed) and caps retries at 10 — the "retries forever" doc claim was corrected here.
- SSE handshake 403 (session mismatch, e.g. session TTL swept under a live tab) also freezes permanently; candidate fix is re-bootstrapping on mismatch as well.

Closes #82