### PR TITLE
feat(examples): redesign counterscope UI with Via branding

### DIFF
--- a/internal/examples/counterscope/main.go
+++ b/internal/examples/counterscope/main.go
@@ -24,15 +24,50 @@ type Page struct {
 func (p *Page) IncLocal(ctx *via.Ctx)  { p.Local.Op(ctx).Inc() }
 func (p *Page) IncShared(ctx *via.Ctx) { p.Shared.Op(ctx).Inc() }
 
-const bigNum = "font-size:6rem;font-weight:700;text-align:center;margin:0;line-height:1;font-variant-numeric:tabular-nums"
+// Brand palette from docs/assets/branding (amber bolt on ink).
+const (
+	amber = "#ffbf00"
+	ink   = "#1b1e24"
+	cream = "#efece4"
+)
 
-const viaLogo = `<svg width="20" height="44" viewBox="30 -8 144 336" aria-hidden="true" style="vertical-align:middle"><path d="M 142,0 L 92,130 L 168,130 L 58,320 L 116,190 L 38,190 Z" fill="none" stroke="currentColor" stroke-width="10" stroke-linecap="square" stroke-linejoin="miter" stroke-miterlimit="10"/></svg>`
+const bigNum = "font-size:7rem;font-weight:700;text-align:center;margin:0;" +
+	"line-height:1;font-variant-numeric:tabular-nums;letter-spacing:-0.02em"
+
+// boltLogo is the Via bolt mark (docs/assets/branding/bolt-amber.svg).
+const boltLogo = `<svg width="26" height="28" viewBox="30 38 146 154" aria-hidden="true" style="vertical-align:middle"><path fill="` + amber + `" d="M 109,45 L 119,45 L 92,97 L 168,97 L 100,185 L 91,185 L 116,142 L 38,142 Z"/></svg>`
 
 func brand() h.H {
-	return h.A(h.Href("/"), h.Style("display:inline-flex;align-items:center;gap:0.5rem;text-decoration:none;color:inherit"),
-		h.Raw(viaLogo),
-		h.Strong(h.Style("font-size:1.15rem;letter-spacing:0.02em"), h.Text("Via")),
-		h.Small(h.Style("opacity:0.55;margin-left:0.25rem"), h.Text("hypermedia")),
+	return h.A(h.Href("/"),
+		h.Style("display:inline-flex;align-items:center;gap:0.6rem;text-decoration:none;color:inherit"),
+		h.Raw(boltLogo),
+		h.Strong(h.Style("font-size:1.3rem;letter-spacing:0.04em;font-weight:700"), h.Text("via")),
+		h.Small(h.Style("opacity:0.55;margin-left:0.25rem;letter-spacing:0.08em;text-transform:uppercase;font-size:0.7rem"),
+			h.Text("counter scope")),
+	)
+}
+
+func badge(label string) h.H {
+	return h.Small(
+		h.Style("display:inline-block;padding:0.15rem 0.6rem;border-radius:999px;"+
+			"font-size:0.7rem;font-weight:600;letter-spacing:0.1em;text-transform:uppercase;"+
+			"background:"+amber+";color:"+ink),
+		h.Text(label),
+	)
+}
+
+func counterCard(title, scope, hint string, value h.H, btn h.H) h.H {
+	return h.Article(
+		h.Style("border-top:3px solid "+amber+";display:flex;flex-direction:column;gap:1rem"),
+		h.HGroup(
+			h.Div(h.Style("display:flex;align-items:center;justify-content:space-between"),
+				h.H4(h.Style("margin:0"), h.Text(title)),
+				badge(scope),
+			),
+			h.P(h.Small(h.Style("opacity:0.7"), h.Text(hint))),
+		),
+		h.P(h.Style(bigNum), value),
+		h.Footer(h.Style("margin-top:auto"), btn),
 	)
 }
 
@@ -41,33 +76,29 @@ func (p *Page) View(ctx *via.CtxR) h.H {
 		h.Header(h.Class("container"),
 			h.Nav(
 				h.Ul(h.Li(brand())),
-				h.Ul(h.Li(h.Small(h.Text("Counter Scope — tab vs app state")))),
+				h.Ul(h.Li(h.Small(h.Style("opacity:0.6"), h.Text("tab vs app state, live over SSE")))),
 			),
 		),
 		h.Main(h.Class("container"),
+			h.P(h.Style("text-align:center;max-width:38rem;margin:0 auto 2rem"),
+				h.Small(h.Text("Open this page in two windows side by side. "+
+					"Local counts per tab; Shared syncs everywhere, instantly."))),
 			h.Div(h.Class("grid"),
-				h.Article(
-					h.HGroup(
-						h.H4(h.Text("Local")),
-						h.P(h.Small(h.Text("Per-tab — StateTab[int]"))),
-					),
-					h.P(h.Style(bigNum), p.Local.Text(ctx)),
-					h.Footer(h.Button(h.Style("width:100%"), h.Text("+1"), on.Click(p.IncLocal))),
+				counterCard("Local", "this tab", "StateTab[int] — independent per browser tab",
+					h.Span(h.Style("color:"+cream), p.Local.Text(ctx)),
+					h.Button(h.Class("outline"), h.Style("width:100%"), h.Text("+1"), on.Click(p.IncLocal)),
 				),
-				h.Article(
-					h.HGroup(
-						h.H4(h.Text("Shared")),
-						h.P(h.Small(h.Text("Across all tabs — StateApp[int]"))),
-					),
-					h.P(h.Style(bigNum), p.Shared.Text(ctx)),
-					h.Footer(h.Button(h.Style("width:100%"), h.Text("+1"), on.Click(p.IncShared))),
+				counterCard("Shared", "all tabs", "StateApp[int] — one value across every session",
+					h.Span(h.Style("color:"+amber), p.Shared.Text(ctx)),
+					h.Button(h.Style("width:100%"), h.Text("+1"), on.Click(p.IncShared)),
 				),
 			),
 		),
 		h.Footer(h.Class("container"),
 			h.Hr(),
-			h.P(h.Style("text-align:center;margin:0"),
-				h.Small(h.Text("Made with ❤️ Via Hypermedia")),
+			h.P(h.Style("text-align:center;margin:0;display:flex;align-items:center;justify-content:center;gap:0.4rem"),
+				h.Raw(`<svg width="14" height="15" viewBox="30 38 146 154" aria-hidden="true"><path fill="`+amber+`" d="M 109,45 L 119,45 L 92,97 L 168,97 L 100,185 L 91,185 L 116,142 L 38,142 Z"/></svg>`),
+				h.Small(h.Text("Made with Via Hypermedia — go-via/via")),
 			),
 		),
 	)
@@ -75,7 +106,7 @@ func (p *Page) View(ctx *via.CtxR) h.H {
 
 func main() {
 	app := via.New(
-		via.WithTitle("Counter Scope"),
+		via.WithTitle("Via — Counter Scope"),
 		via.WithPlugins(picocss.Plugin(picocss.WithThemes([]picocss.PicoTheme{picocss.PicoThemeAmber}))),
 	)
 	via.Mount[Page](app, "/")


### PR DESCRIPTION
Redesigns the counterscope example UI using the official brand assets:

- Amber bolt mark + lowercase wordmark from `docs/assets/branding`
- Brand palette constants (amber `#ffbf00`, ink `#1b1e24`, cream `#efece4`)
- Counter cards with amber top border and scope badges (this tab / all tabs)
- Larger tabular numerals — Local in cream, Shared in amber
- Outline button for Local, solid primary for Shared
- Intro copy explaining the two-window demo

Pure styling change to the example's View; no behavior change. Verified
live in Chrome: both counters increment over SSE.