### PR TITLE
ci: bump Go toolchain to 1.26.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
 
       - name: Setup Node

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
 
       - name: Initialize CodeQL

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/go-via/via
 
 go 1.24.0
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 require (
 	github.com/shirou/gopsutil/v4 v4.26.3


### PR DESCRIPTION
govulncheck now fails on the go1.26.3 standard library:

- GO-2026-5039 — net/textproto: arbitrary inputs included in errors without escaping (called via vt.Client.Reload → io.ReadAll → textproto.Reader.ReadMIMEHeader)
- GO-2026-5037 — crypto/x509: inefficient candidate hostname parsing

Both are fixed in go1.26.4. Bumps the toolchain in go.mod and the
go-version pin in the CI and CodeQL workflows.

Repo-wide failure (affects main); surfaced while CI-checking an
unrelated example PR.