### PR TITLE
fix(sse): coalesce an action's patches into one SSE frame

### DIFF
--- a/action.go
+++ b/action.go
@@ -166,6 +166,15 @@ func runAction(a *App, ctx *Ctx, slotIdx int, slot *actionSlot,
 	ctx.actionMu.Lock()
 	defer ctx.actionMu.Unlock()
 
+	// Hold queue wakes for the whole handler so the auto re-render and any
+	// explicit Patch pushes drain as one frame at action end, auto render
+	// before explicit (last-wins keeps the override authoritative).
+	// Registered before the flush defer below so it runs AFTER it (LIFO):
+	// the flush populates the queue, then the release fires the single
+	// wake. Resilient to a panic in the flush defer.
+	ctx.queue.holdNotify()
+	defer ctx.queue.releaseNotify()
+
 	ctx.mu.Lock()
 	ctx.w = w
 	ctx.r = r

--- a/queue_order_test.go
+++ b/queue_order_test.go
@@ -84,13 +84,20 @@ func TestExplicitElementPatchOverridesAutoRender(t *testing.T) {
 	defer cancel()
 
 	require.Equal(t, http.StatusOK, tc.Action("BumpAndOverride").Fire())
-	body := vt.AwaitFrame(t, frames, 2*time.Second, "OVERRIDE")
+	body := vt.AwaitFrame(t, frames, 2*time.Second, ">1<", "OVERRIDE")
 
 	auto := strings.Index(body, ">1<")
 	override := strings.Index(body, "OVERRIDE")
 	require.GreaterOrEqual(t, auto, 0, "auto render must be in the frame")
 	assert.Greater(t, override, auto,
 		"explicit patch must come after the auto render so last-wins keeps it authoritative")
+	// One action's patches must drain as ONE element-patch event. If the
+	// mid-action Patch.Elements notify triggers an early drain, the
+	// override ships in its own frame BEFORE the end-of-action auto render
+	// — two events, with the auto render last, silently rewinding the UI
+	// off the override under datastar's last-wins-per-id morph.
+	assert.Equal(t, 1, strings.Count(body, "datastar-patch-elements"),
+		"an action's auto render and explicit patch must ship in a single element-patch event")
 }
 
 // Explicit patches from separate offline actions are independent pushes
@@ -172,4 +179,55 @@ func (p *explicitQueuePage) PushB(ctx *via.Ctx) {
 	ctx.Patch.Elements(h.Div(h.ID("b"), h.Text("PATCH-B")))
 }
 
+func (p *explicitQueuePage) PushSilent(ctx *via.Ctx) {
+	ctx.SyncOff()
+	ctx.Patch.Elements(h.Div(h.ID("a"), h.Text("PATCH-A")))
+}
+
 func (p *explicitQueuePage) View(ctx *via.CtxR) h.H { return h.Div(h.ID("root")) }
+
+// An action that pushes an explicit patch but mutates no State queues no
+// auto render, so the end-of-action flush renders nothing. The explicit
+// push is then the only thing that can wake the SSE goroutine on a live
+// stream — if an action that holds wakes until it returns fails to
+// release that wake when there's no render, the push never reaches the
+// tab.
+func TestExplicitOnlyActionStillReachesLiveStream(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	via.Mount[explicitQueuePage](app, "/e")
+	defer server.Close()
+
+	tc := vt.NewClient(t, server, "/e")
+	frames, cancel := tc.SSEReady()
+	defer cancel()
+
+	require.Equal(t, http.StatusOK, tc.Action("PushA").Fire())
+	body := vt.AwaitFrame(t, frames, 2*time.Second, "PATCH-A")
+	assert.Equal(t, 1, strings.Count(body, "datastar-patch-elements"),
+		"the explicit push must drain in one element-patch event")
+}
+
+// SyncOff suppresses the dirty-bit re-render but NOT explicit Patch.Elements
+// pushes (so a recovery toast still reaches the user on a silent action).
+// The silent branch skips flushDirty entirely, so the held explicit-push
+// wake must still be released at action end or the push is lost.
+func TestSilentActionStillShipsExplicitPatch(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	via.Mount[explicitQueuePage](app, "/e")
+	defer server.Close()
+
+	tc := vt.NewClient(t, server, "/e")
+	frames, cancel := tc.SSEReady()
+	defer cancel()
+
+	require.Equal(t, http.StatusOK, tc.Action("PushSilent").Fire())
+	body := vt.AwaitFrame(t, frames, 2*time.Second, "PATCH-A")
+	assert.Contains(t, body, "PATCH-A",
+		"explicit pushes survive SyncOff even though the auto render is suppressed")
+}

--- a/runtime.go
+++ b/runtime.go
@@ -58,19 +58,71 @@ type patchQueue struct {
 	scripts  strings.Builder
 	redirect string
 	wake     chan struct{}
+	// hold defers wakes while an action handler runs so all of the
+	// action's patches — the auto re-render and any explicit Patch pushes
+	// — drain in a SINGLE frame at action end. Without it a mid-action
+	// Patch.Elements notify can wake the SSE goroutine and drain the
+	// explicit push BEFORE the end-of-action flush queues the auto render,
+	// splitting one action across two frames with the auto render last,
+	// which rewinds the UI off the override under last-wins morphing.
+	// pending records that a wake arrived while held, so releaseNotify
+	// fires exactly one wake to drain the coalesced frame.
+	hold    bool
+	pending bool
 }
 
 func newPatchQueue() *patchQueue {
 	return &patchQueue{wake: make(chan struct{}, 1)}
 }
 
+// notify wakes the SSE drain loop, unless wakes are currently held (see
+// holdNotify) in which case it records a pending wake to fire on release.
+// Acquires q.mu — callers must NOT hold q.mu when calling it.
 func (q *patchQueue) notify() {
 	if q == nil {
 		return
 	}
+	q.mu.Lock()
+	if q.hold {
+		q.pending = true
+		q.mu.Unlock()
+		return
+	}
+	q.mu.Unlock()
+	q.signal()
+}
+
+func (q *patchQueue) signal() {
 	select {
 	case q.wake <- struct{}{}:
 	default:
+	}
+}
+
+// holdNotify starts deferring wakes; pair with releaseNotify. Used to make
+// an action handler's patches atomic in a single SSE frame.
+func (q *patchQueue) holdNotify() {
+	if q == nil {
+		return
+	}
+	q.mu.Lock()
+	q.hold = true
+	q.mu.Unlock()
+}
+
+// releaseNotify stops deferring wakes and fires one wake if any notify
+// arrived while held, draining the action's coalesced patches.
+func (q *patchQueue) releaseNotify() {
+	if q == nil {
+		return
+	}
+	q.mu.Lock()
+	q.hold = false
+	fire := q.pending
+	q.pending = false
+	q.mu.Unlock()
+	if fire {
+		q.signal()
 	}
 }
 
@@ -182,10 +234,13 @@ func genTabID(route string) string {
 func enqueueScript(ctx *Ctx, s string) {
 	q := ctx.queue
 	q.mu.Lock()
-	defer q.mu.Unlock()
 	q.scripts.WriteString("try{")
 	q.scripts.WriteString(s)
 	q.scripts.WriteString("}catch(e){console.error(e)};")
+	q.mu.Unlock()
+	// notify acquires q.mu, so it must run after the unlock above — every
+	// other call site already enqueues under the lock then notifies after
+	// releasing it.
 	q.notify()
 }
 


### PR DESCRIPTION
## Problem

`TestExplicitElementPatchOverridesAutoRender` flaked ~35% under `-race` (it's what forced job re-runs on #88/#89).

Root cause is a real ordering bug, not just a test issue: an action's explicit `Patch.Elements`/`Patch.Signals`/`ExecScript` call `notify()` mid-handler, which can wake the SSE drain loop and ship the explicit push in its own frame **before** the end-of-action flush queues the auto re-render. Under datastar's last-wins-per-id morph, the later auto render then **rewinds the UI off the override** — the exact failure mode the queue design comments warn about.

## Fix

Hold queue wakes for the duration of an action (`holdNotify`/`releaseNotify` on `patchQueue`, wired into `runAction`) so every patch a handler produces drains in a **single frame** at action end, auto render before explicit. `releaseNotify` is deferred so it fires after the flush populates the queue, and runs on every exit path (normal/error/panic/SyncOff).

`enqueueScript` now unlocks `q.mu` before `notify()` — `notify()` acquires `q.mu` now, so the old notify-under-lock self-deadlocked (caught in testing).

## Tests

- Strengthened the flaky test to assert single-frame atomicity (exactly one `datastar-patch-elements` event) plus the existing order assertion.
- Added `TestExplicitOnlyActionStillReachesLiveStream` and `TestSilentActionStillShipsExplicitPatch` — the paths where the end-of-action flush renders nothing, so the held wake must still be released or the push is lost.

Verified: previously-flaky test **0 failures / 300 runs** under `-race` (was ~35%); full suite `go test -race -count=3 ./...` green.