### PR TITLE
feat(maplibre): MapLibre GL plugin — interactive maps driven from Go

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -74,3 +74,64 @@ func (p *Page) Refresh(ctx *via.Ctx) error {
 
 See `internal/examples/sysmon` for a live system monitor streaming into
 ECharts.
+
+### maplibre
+
+`maplibre.Plugin()` integrates [MapLibre GL JS](https://maplibre.org) —
+interactive vector maps whose camera, markers, and data layers are all driven
+from Go and pushed over SSE. Hold a `*maplibre.Map`, build it in `OnInit`,
+mount it in `View`, then move it from actions or a `via.Stream` ticker:
+
+```go
+type Page struct {
+    Map *maplibre.Map
+}
+
+func (p *Page) OnInit(ctx *via.Ctx) error {
+    if p.Map == nil {
+        p.Map = maplibre.NewMap(
+            maplibre.WithCenter(-122.42, 37.77), // [lng, lat], longitude first
+            maplibre.WithZoom(11),
+            maplibre.WithNavigationControl(),
+        )
+    }
+    return nil
+}
+
+func (p *Page) View(ctx *via.CtxR) h.H { return p.Map.Mount() }
+
+func (p *Page) GoToTokyo(ctx *via.Ctx) { p.Map.FlyTo(ctx, 139.69, 35.69, 10) }
+```
+
+Coordinates are `[lng, lat]` — longitude first — everywhere: `WithCenter`,
+`FlyTo`, `AddMarker`, and all GeoJSON. This is the inverse of the lat/lng most
+map UIs print, and the single most common MapLibre mistake.
+
+The runtime surface, all delivered over SSE:
+
+- Camera — `FlyTo` (curved flight), `EaseTo`, `JumpTo`, `SetCenter`,
+  `SetZoom`, `SetPitch`, `SetBearing`, and `FitBounds(w, s, e, n)`.
+- Markers — `AddMarker(ctx, id, lng, lat, opts…)` places a keyed pin;
+  `MoveMarker` repositions it live (vehicle tracking), `RemoveMarker` /
+  `ClearMarkers` tear down. Options: `Color`, `Draggable`, `Scale`,
+  `PopupText` (XSS-safe, for user content), `PopupHTML` (trusted markup only).
+- Data — declare sources/layers with `WithGeoJSONSource` + `WithLayer`, or
+  add them at runtime with `AddGeoJSONSource` / `AddLayer`; push live data
+  with `SetGeoJSON(ctx, sourceID, fc)`. Build GeoJSON with `Point`,
+  `LineString`, `Polygon`, `Feature`, `FeatureCollection`; build layers with
+  `CircleLayer` / `LineLayer` / `FillLayer` / `SymbolLayer`.
+- Lifecycle — `SetStyle`, `Resize`, `Dispose`, and the `Call(ctx, method,
+  args…)` escape hatch for any Map method the typed API misses.
+
+{: .warning }
+The default style is MapLibre's no-key demo style, meant for demos and CI,
+not a production SLA. Supply your own with `WithStyle(url)` (e.g. a MapTiler
+or Stadia style) for real use. Pin a v5 release — v6 is ESM-only and drops the
+`maplibregl` global the `<script>` include relies on.
+
+Self-host or harden with `WithSource` / `WithStylesheet` (offline, air-gapped),
+or `WithCSPBuild()` to use the inline-worker bundle under a strict `worker-src`
+policy.
+
+See `internal/examples/maps` for a server-driven world map: city buttons fly
+the camera and a drone marker glides along a route, live, over SSE.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -90,7 +90,7 @@ type Page struct {
 func (p *Page) OnInit(ctx *via.Ctx) error {
     if p.Map == nil {
         p.Map = maplibre.NewMap(
-            maplibre.WithCenter(-122.42, 37.77), // [lng, lat], longitude first
+            maplibre.WithCenter(maplibre.At(-122.42, 37.77)), // At(lng, lat)
             maplibre.WithZoom(11),
             maplibre.WithNavigationControl(),
         )
@@ -100,21 +100,26 @@ func (p *Page) OnInit(ctx *via.Ctx) error {
 
 func (p *Page) View(ctx *via.CtxR) h.H { return p.Map.Mount() }
 
-func (p *Page) GoToTokyo(ctx *via.Ctx) { p.Map.FlyTo(ctx, 139.69, 35.69, 10) }
+func (p *Page) GoToTokyo(ctx *via.Ctx) { p.Map.FlyTo(ctx, maplibre.At(139.69, 35.69), 10) }
 ```
 
-Coordinates are `[lng, lat]` — longitude first — everywhere: `WithCenter`,
-`FlyTo`, `AddMarker`, and all GeoJSON. This is the inverse of the lat/lng most
-map UIs print, and the single most common MapLibre mistake.
+Coordinates are `[lng, lat]` — longitude first — the inverse of the lat/lng most
+map UIs print, and the single most common MapLibre mistake. The camera, marker,
+and center APIs take a typed `LngLat` whose named fields defuse the swap: build
+it with `maplibre.LngLat{Lng: …, Lat: …}` (order-independent) or the
+`maplibre.At(lng, lat)` shorthand; box APIs take a `Bounds{West, South, East,
+North}`. GeoJSON geometry (`Point`, `LineString`, `Polygon`) stays as raw
+`[lng, lat]` arrays.
 
 The runtime surface, all delivered over SSE:
 
-- Camera — `FlyTo` (curved flight), `EaseTo`, `JumpTo`, `SetCenter`,
-  `SetZoom`, `SetPitch`, `SetBearing`, and `FitBounds(w, s, e, n)`.
-- Markers — `AddMarker(ctx, id, lng, lat, opts…)` places a keyed pin;
-  `MoveMarker` repositions it live (vehicle tracking), `RemoveMarker` /
-  `ClearMarkers` tear down. Options: `Color`, `Draggable`, `Scale`,
-  `PopupText` (XSS-safe, for user content), `PopupHTML` (trusted markup only).
+- Camera — `FlyTo` (curved flight), `EaseTo`, `JumpTo`, `SetCenter` (all take a
+  `LngLat`), `SetZoom`, `SetPitch`, `SetBearing`, and `FitBounds(ctx, Bounds)`.
+- Markers — `AddMarker(ctx, id, At(lng, lat), opts…)` places a keyed pin;
+  `WithMarker` declares a static one at construction; `MoveMarker` repositions
+  it live (vehicle tracking), `RemoveMarker` / `ClearMarkers` tear down. Options:
+  `Color`, `Draggable`, `Scale`, `PopupText` (XSS-safe, for user content),
+  `PopupHTML` (an `h.H` body — `h.T` escapes, `h.Raw` is trusted markup only).
 - Data — declare sources/layers with `WithGeoJSONSource` + `WithLayer`, or
   add them at runtime with `AddGeoJSONSource` / `AddLayer`; push live data
   with `SetGeoJSON(ctx, sourceID, fc)`. Build GeoJSON with `Point`,

--- a/internal/examples/maps/main.go
+++ b/internal/examples/maps/main.go
@@ -11,6 +11,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"sync"
 	"time"
@@ -49,14 +50,15 @@ type Page struct {
 	mu     sync.Mutex
 	leg    int     // index of the current route segment start
 	t      float64 // 0..1 progress along the current segment
+	pins   int     // count of user-dropped pins, for unique marker ids
 	ticker *via.Ticker
 }
 
 func (p *Page) OnInit(ctx *via.Ctx) error {
 	if p.Map == nil {
-		p.Map = maplibre.NewMap(
+		opts := []maplibre.MapOption{
 			maplibre.WithElementID("map"),
-			maplibre.WithCenter(10, 30),
+			maplibre.WithCenter(maplibre.At(10, 30)),
 			maplibre.WithZoom(1.4),
 			maplibre.WithNavigationControl(),
 			maplibre.WithScaleControl(maplibre.BottomLeft),
@@ -70,28 +72,60 @@ func (p *Page) OnInit(ctx *via.Ctx) error {
 				maplibre.Layout("line-cap", "round"),
 				maplibre.Layout("line-join", "round"),
 			)),
-		)
+			// A clickable "zone" polygon: a filled GeoJSON feature carrying an
+			// id property. OnFeatureClick reports which zone was clicked.
+			maplibre.WithGeoJSONSource("zones", maplibre.FeatureCollection(
+				maplibre.Feature(
+					maplibre.Polygon([][][]float64{{{20, 0}, {60, 0}, {60, 30}, {20, 30}, {20, 0}}}),
+					map[string]any{"id": "zone-alpha", "name": "Operations zone Alpha"},
+				),
+			), maplibre.GenerateFeatureIDs()),
+			maplibre.WithLayer(maplibre.FillLayer("zones", "zones",
+				// Data-driven fill: amber while hovered, indigo otherwise.
+				maplibre.Paint("fill-color", maplibre.WhenHovered("#ffcc00", "#5856d6")),
+				maplibre.Paint("fill-opacity", 0.45),
+			)),
+			// Hover-to-highlight, entirely client-side (feature-state).
+			maplibre.WithFeatureHover("zones"),
+			// Click-to-place: a tap on the basemap round-trips into Go, which
+			// drops a pin there — the inbound half of the map's interactivity.
+			maplibre.OnClick(p.DropPin),
+			// Marker gestures also round-trip: clicking a pin flies to it,
+			// dragging one reports where it landed.
+			maplibre.OnMarkerClick(p.FocusMarker),
+			maplibre.OnMarkerDragEnd(p.PinMoved),
+			// Clicking a rendered data-layer feature reports which one (by id).
+			maplibre.OnFeatureClick("zones", p.ZoneClicked),
+			// Escape hatch: right-click (contextmenu) reports the location +
+			// live zoom — any MapLibre event can drive Go this way.
+			maplibre.OnMapEvent("contextmenu", p.RightClicked),
+		}
+		// The cities are fixed pins — declare them at construction with
+		// WithMarker, so they render on first paint with no OnConnect work.
+		for _, c := range cities {
+			opts = append(opts, maplibre.WithMarker(c.name, maplibre.At(c.lng, c.lat), maplibre.PopupText(c.name)))
+		}
+		p.Map = maplibre.NewMap(opts...)
 	}
 	return nil
 }
 
 func (p *Page) OnConnect(ctx *via.Ctx) error {
-	for _, c := range cities {
-		p.Map.AddMarker(ctx, c.name, c.lng, c.lat, maplibre.PopupText(c.name))
-	}
-	p.Map.AddMarker(ctx, "drone", route[0][0], route[0][1],
+	// Only the drone is dynamic (a ticker moves it), so it's the one marker
+	// added at connect time rather than declared with WithMarker.
+	p.Map.AddMarker(ctx, "drone", maplibre.At(route[0][0], route[0][1]),
 		maplibre.Color("#ff3b30"), maplibre.PopupText("Drone"))
 
 	p.ticker = via.Stream(ctx, 80*time.Millisecond, func(ctx *via.Ctx, _ time.Time) {
 		lng, lat := p.advance()
-		p.Map.MoveMarker(ctx, "drone", lng, lat)
+		p.Map.MoveMarker(ctx, "drone", maplibre.At(lng, lat))
 	})
 	return nil
 }
 
-// advance steps the drone along the route, ping-ponging at the ends, and
-// returns its new [lng, lat]. Guarded so a click and a tick can't race the
-// leg/progress fields.
+// advance steps the drone along the route, looping back to the first leg after
+// the last, and returns its new [lng, lat]. Guarded so a click and a tick can't
+// race the leg/progress fields.
 func (p *Page) advance() (float64, float64) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -124,7 +158,54 @@ func (p *Page) FlyToCity(ctx *via.Ctx) {
 		return
 	}
 	c := cities[idx]
-	p.Map.FlyTo(ctx, c.lng, c.lat, c.zoom)
+	p.Map.FlyTo(ctx, maplibre.At(c.lng, c.lat), c.zoom)
+}
+
+// DropPin places a green marker wherever the user clicked the basemap. The
+// clicked [lng, lat] rides back in on the MapEvent — no client JavaScript.
+func (p *Page) DropPin(ctx *via.Ctx) {
+	e := p.Map.Event(ctx)
+	p.mu.Lock()
+	p.pins++
+	n := p.pins
+	p.mu.Unlock()
+	p.Map.AddMarker(ctx, fmt.Sprintf("pin-%d", n), e.LngLat(),
+		maplibre.Color("#34c759"),
+		maplibre.Draggable(),
+		// e.Zoom is the live camera at click time — carried on every gesture.
+		maplibre.PopupText(fmt.Sprintf("Pin %d — %.4f, %.4f @ z%.1f", n, e.Lat, e.Lng, e.Zoom)))
+}
+
+// FocusMarker flies the camera to whichever marker the user clicked. The
+// clicked marker's id and position ride back in on the MapEvent.
+func (p *Page) FocusMarker(ctx *via.Ctx) {
+	e := p.Map.Event(ctx)
+	p.Map.FlyTo(ctx, e.LngLat(), 6)
+	ctx.Toast(fmt.Sprintf("Selected %s", e.MarkerID))
+}
+
+// PinMoved reports where a dragged marker was dropped — drag-to-reposition,
+// driven entirely from Go.
+func (p *Page) PinMoved(ctx *via.Ctx) {
+	e := p.Map.Event(ctx)
+	ctx.Toast(fmt.Sprintf("%s moved to %.4f, %.4f", e.MarkerID, e.Lat, e.Lng))
+}
+
+// ZoneClicked opens a popup ("dialog") at the clicked feature, showing details
+// the server looked up by the feature's id — the server-authoritative
+// selection pattern, surfaced as an on-map dialog.
+func (p *Page) ZoneClicked(ctx *via.Ctx) {
+	e := p.Map.Event(ctx)
+	p.Map.ShowPopup(ctx, "zone-info", e.LngLat(),
+		fmt.Sprintf("Zone %s — click the map to dismiss", e.FeatureID),
+		maplibre.PopupMaxWidth("220px"))
+}
+
+// RightClicked handles a contextmenu (right-click) via the OnMapEvent escape
+// hatch, reporting where and at what zoom.
+func (p *Page) RightClicked(ctx *via.Ctx) {
+	e := p.Map.Event(ctx)
+	ctx.Toast(fmt.Sprintf("Right-clicked %.3f, %.3f @ z%.1f", e.Lat, e.Lng, e.Zoom))
 }
 
 func (p *Page) View(ctx *via.CtxR) h.H {
@@ -137,7 +218,7 @@ func (p *Page) View(ctx *via.CtxR) h.H {
 		h.Main(h.Class("container"),
 			h.HGroup(
 				h.H2(h.T("Via × MapLibre")),
-				h.P(h.T("The camera, markers, and the moving drone are all driven from Go over SSE.")),
+				h.P(h.T("The camera, markers, and the moving drone are all driven from Go over SSE. Click anywhere on the map to drop a pin — the click round-trips through Go.")),
 			),
 			h.Div(append([]h.H{h.Class("grid")}, buttons...)...),
 			h.P(

--- a/internal/examples/maps/main.go
+++ b/internal/examples/maps/main.go
@@ -1,0 +1,164 @@
+// Maps is a server-driven world map: the camera, the markers, and a moving
+// marker are all controlled from Go and pushed to the browser over SSE — no
+// client JavaScript. City buttons fly the camera (FlyTo); a "drone" marker
+// glides along a route, stepped by a server-side ticker (MoveMarker); the
+// route line is a GeoJSON layer. Each tab runs its own ticker, so the motion
+// is per-connection — this shows Go driving the map, not cross-tab fan-out
+// (for that pattern, see the chat example's app-scoped state).
+//
+//	go run ./internal/examples/maps
+//	open http://localhost:3000
+package main
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/go-via/via"
+	"github.com/go-via/via/h"
+	"github.com/go-via/via/on"
+	"github.com/go-via/via/plugins/maplibre"
+	"github.com/go-via/via/plugins/picocss"
+)
+
+type city struct {
+	name     string
+	lng, lat float64
+	zoom     float64
+}
+
+var cities = []city{
+	{"San Francisco", -122.42, 37.77, 9},
+	{"New York", -74.0, 40.71, 9},
+	{"London", -0.12, 51.5, 9},
+	{"Tokyo", 139.69, 35.69, 9},
+	{"Sydney", 151.21, -33.87, 9},
+}
+
+// route is the great-circle-ish path the drone walks, as [lng, lat] pairs.
+var route = [][]float64{
+	{-122.42, 37.77}, {-74.0, 40.71}, {-0.12, 51.5}, {139.69, 35.69}, {151.21, -33.87},
+}
+
+type Page struct {
+	Map     *maplibre.Map
+	Running via.SignalBool     `via:"running,init=true"`
+	CityIdx via.SignalNum[int] `via:"cityIdx"` // which city a button click targets
+
+	mu     sync.Mutex
+	leg    int     // index of the current route segment start
+	t      float64 // 0..1 progress along the current segment
+	ticker *via.Ticker
+}
+
+func (p *Page) OnInit(ctx *via.Ctx) error {
+	if p.Map == nil {
+		p.Map = maplibre.NewMap(
+			maplibre.WithElementID("map"),
+			maplibre.WithCenter(10, 30),
+			maplibre.WithZoom(1.4),
+			maplibre.WithNavigationControl(),
+			maplibre.WithScaleControl(maplibre.BottomLeft),
+			// The route line is drawn from a GeoJSON source declared up front.
+			maplibre.WithGeoJSONSource("route", maplibre.FeatureCollection(
+				maplibre.Feature(maplibre.LineString(route), nil),
+			)),
+			maplibre.WithLayer(maplibre.LineLayer("route", "route",
+				maplibre.Paint("line-color", "#ff9500"),
+				maplibre.Paint("line-width", 2),
+				maplibre.Layout("line-cap", "round"),
+				maplibre.Layout("line-join", "round"),
+			)),
+		)
+	}
+	return nil
+}
+
+func (p *Page) OnConnect(ctx *via.Ctx) error {
+	for _, c := range cities {
+		p.Map.AddMarker(ctx, c.name, c.lng, c.lat, maplibre.PopupText(c.name))
+	}
+	p.Map.AddMarker(ctx, "drone", route[0][0], route[0][1],
+		maplibre.Color("#ff3b30"), maplibre.PopupText("Drone"))
+
+	p.ticker = via.Stream(ctx, 80*time.Millisecond, func(ctx *via.Ctx, _ time.Time) {
+		lng, lat := p.advance()
+		p.Map.MoveMarker(ctx, "drone", lng, lat)
+	})
+	return nil
+}
+
+// advance steps the drone along the route, ping-ponging at the ends, and
+// returns its new [lng, lat]. Guarded so a click and a tick can't race the
+// leg/progress fields.
+func (p *Page) advance() (float64, float64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.t += 0.02
+	if p.t >= 1 {
+		p.t = 0
+		p.leg = (p.leg + 1) % (len(route) - 1)
+	}
+	a, b := route[p.leg], route[p.leg+1]
+	return a[0] + (b[0]-a[0])*p.t, a[1] + (b[1]-a[1])*p.t
+}
+
+func (p *Page) ToggleRunning(ctx *via.Ctx) {
+	v := !p.Running.Read(ctx)
+	p.Running.Write(ctx, v)
+	if v {
+		p.ticker.Resume()
+	} else {
+		p.ticker.Pause()
+	}
+}
+
+// FlyToCity flies the camera to the city the clicked button selected via the
+// cityIdx signal. on.Click takes a bound method, not a per-city closure, so
+// the target rides in on a signal the button sets before the action fires.
+func (p *Page) FlyToCity(ctx *via.Ctx) {
+	idx := p.CityIdx.Read(ctx)
+	if idx < 0 || idx >= len(cities) {
+		return
+	}
+	c := cities[idx]
+	p.Map.FlyTo(ctx, c.lng, c.lat, c.zoom)
+}
+
+func (p *Page) View(ctx *via.CtxR) h.H {
+	buttons := make([]h.H, len(cities))
+	for i, c := range cities {
+		buttons[i] = h.Button(h.Class("outline"), h.T(c.name),
+			on.Click(p.FlyToCity, on.SetSignal(&p.CityIdx.Signal, i)))
+	}
+	return h.Body(
+		h.Main(h.Class("container"),
+			h.HGroup(
+				h.H2(h.T("Via × MapLibre")),
+				h.P(h.T("The camera, markers, and the moving drone are all driven from Go over SSE.")),
+			),
+			h.Div(append([]h.H{h.Class("grid")}, buttons...)...),
+			h.P(
+				h.Button(
+					h.Data("text", "$running?'Pause drone':'Resume drone'"),
+					on.Click(p.ToggleRunning),
+				),
+			),
+			p.Map.Mount(),
+		),
+	)
+}
+
+func main() {
+	app := via.New(
+		via.WithTitle("Via × MapLibre"),
+		via.WithPlugins(
+			picocss.Plugin(picocss.WithDarkMode()),
+			maplibre.Plugin(),
+		),
+	)
+	via.Mount[Page](app, "/")
+	_ = http.ListenAndServe(":3000", app)
+}

--- a/internal/examples/maps/main_test.go
+++ b/internal/examples/maps/main_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-via/via"
+	"github.com/go-via/via/plugins/maplibre"
+	"github.com/go-via/via/vt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The page must render without panicking: on.Click takes a bound method, so a
+// per-city closure would panic at render time and 500 the page. This is the
+// regression guard for that whole class of mistake.
+func TestMaps_pageRendersWithMapAndPluginAssets(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithPlugins(maplibre.Plugin()), via.WithTestServer(&server))
+	via.Mount[Page](app, "/")
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	html := string(body)
+
+	assert.Contains(t, html, "maplibre-gl.js", "the MapLibre script must be injected")
+	assert.Contains(t, html, "maplibre-gl.css", "the required CSS must be injected")
+	assert.Contains(t, html, "new maplibregl.Map(", "the map must initialize on the page")
+	assert.Contains(t, html, ".addLayer(", "the route layer must be declared at load")
+}
+
+func TestMaps_flyToCityPushesCameraOverSSE(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithPlugins(maplibre.Plugin()), via.WithTestServer(&server))
+	via.Mount[Page](app, "/")
+	defer server.Close()
+
+	tc := vt.NewClient(t, server, "/")
+	frames, cancel := tc.SSEReady()
+	defer cancel()
+
+	// cityIdx 3 is Tokyo; the button sets the signal, the action reads it.
+	require.Equal(t, http.StatusOK, tc.Action("FlyToCity").WithSignal("cityIdx", 3).Fire())
+	vt.AwaitFrame(t, frames, 2*time.Second, "flyTo", "139.69")
+}

--- a/internal/examples/maps/main_test.go
+++ b/internal/examples/maps/main_test.go
@@ -54,3 +54,79 @@ func TestMaps_flyToCityPushesCameraOverSSE(t *testing.T) {
 	require.Equal(t, http.StatusOK, tc.Action("FlyToCity").WithSignal("cityIdx", 3).Fire())
 	vt.AwaitFrame(t, frames, 2*time.Second, "flyTo", "139.69")
 }
+
+// A basemap click must round-trip the clicked lng/lat into Go and drop a
+// marker there — the inbound-event half of the map's interactivity.
+func TestMaps_clickDropsPinAtClickedCoordinates(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithPlugins(maplibre.Plugin()), via.WithTestServer(&server))
+	via.Mount[Page](app, "/")
+	defer server.Close()
+
+	tc := vt.NewClient(t, server, "/")
+	frames, cancel := tc.SSEReady()
+	defer cancel()
+
+	require.Equal(t, http.StatusOK,
+		tc.Action("DropPin").WithSignal("viaMapLng", 2.35).WithSignal("viaMapLat", 48.85).Fire())
+	vt.AwaitFrame(t, frames, 2*time.Second, "setLngLat", "2.35", "48.85")
+}
+
+// Clicking a marker must fly the camera to that marker's posted position —
+// proving the marker's id + coordinates round-trip into the Go handler.
+func TestMaps_markerClickFliesToTheClickedMarker(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithPlugins(maplibre.Plugin()), via.WithTestServer(&server))
+	via.Mount[Page](app, "/")
+	defer server.Close()
+
+	tc := vt.NewClient(t, server, "/")
+	frames, cancel := tc.SSEReady()
+	defer cancel()
+
+	require.Equal(t, http.StatusOK, tc.Action("FocusMarker").
+		WithSignal("viaMapId", "New York").WithSignal("viaMapLng", -74.0).WithSignal("viaMapLat", 40.71).Fire())
+	vt.AwaitFrame(t, frames, 2*time.Second, "flyTo", "-74", "40.71")
+}
+
+// Clicking a data-layer feature must surface its id to the Go handler, which
+// toasts it — proving the feature selection round-trips.
+func TestMaps_featureClickReportsTheClickedZone(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithPlugins(maplibre.Plugin()), via.WithTestServer(&server))
+	via.Mount[Page](app, "/")
+	defer server.Close()
+
+	tc := vt.NewClient(t, server, "/")
+	frames, cancel := tc.SSEReady()
+	defer cancel()
+
+	require.Equal(t, http.StatusOK,
+		tc.Action("ZoneClicked").WithSignal("viaMapFeatureId", "zone-alpha").Fire())
+	vt.AwaitFrame(t, frames, 2*time.Second, "zone-alpha")
+}
+
+// A right-click (contextmenu), wired via the OnMapEvent escape hatch, must
+// round-trip the location and live zoom into the Go handler.
+func TestMaps_rightClickReportsLocationAndZoom(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	app := via.New(via.WithPlugins(maplibre.Plugin()), via.WithTestServer(&server))
+	via.Mount[Page](app, "/")
+	defer server.Close()
+
+	tc := vt.NewClient(t, server, "/")
+	frames, cancel := tc.SSEReady()
+	defer cancel()
+
+	require.Equal(t, http.StatusOK, tc.Action("RightClicked").
+		WithSignal("viaMapLng", 8.55).WithSignal("viaMapLat", 47.37).WithSignal("viaMapZoom", 5.0).Fire())
+	vt.AwaitFrame(t, frames, 2*time.Second, "Right-clicked", "47.370", "8.550")
+}

--- a/plugins/maplibre/camera.go
+++ b/plugins/maplibre/camera.go
@@ -1,0 +1,59 @@
+package maplibre
+
+import (
+	"fmt"
+
+	"github.com/go-via/via"
+)
+
+// FlyTo animates a curved, zoom-then-pan flight to (lng, lat) at zoom — the
+// "navigate the user somewhere" gesture. Server-driven: call it from an
+// action and the camera flies on every connected tab. Coordinates are
+// [lng, lat] (longitude first).
+func (m *Map) FlyTo(ctx *via.Ctx, lng, lat, zoom float64) {
+	m.camera(ctx, "flyTo", lng, lat, zoom)
+}
+
+// EaseTo moves the camera to (lng, lat) at zoom with a straight eased
+// transition — cheaper and less theatrical than [Map.FlyTo] for small hops.
+func (m *Map) EaseTo(ctx *via.Ctx, lng, lat, zoom float64) {
+	m.camera(ctx, "easeTo", lng, lat, zoom)
+}
+
+// JumpTo snaps the camera to (lng, lat) at zoom with no animation.
+func (m *Map) JumpTo(ctx *via.Ctx, lng, lat, zoom float64) {
+	m.camera(ctx, "jumpTo", lng, lat, zoom)
+}
+
+func (m *Map) camera(ctx *via.Ctx, method string, lng, lat, zoom float64) {
+	ctx.ExecScript(fmt.Sprintf("%s?.%s(%s)", m.mapRef(), method,
+		mustJSON(map[string]any{"center": []float64{lng, lat}, "zoom": zoom})))
+}
+
+// SetCenter recenters on (lng, lat) without changing zoom, instantly.
+func (m *Map) SetCenter(ctx *via.Ctx, lng, lat float64) {
+	ctx.ExecScript(fmt.Sprintf("%s?.setCenter(%s)", m.mapRef(), mustJSON([]float64{lng, lat})))
+}
+
+// SetZoom sets the zoom level instantly.
+func (m *Map) SetZoom(ctx *via.Ctx, zoom float64) {
+	ctx.ExecScript(fmt.Sprintf("%s?.setZoom(%g)", m.mapRef(), zoom))
+}
+
+// SetPitch tilts the camera to deg degrees (0 = straight down).
+func (m *Map) SetPitch(ctx *via.Ctx, deg float64) {
+	ctx.ExecScript(fmt.Sprintf("%s?.setPitch(%g)", m.mapRef(), deg))
+}
+
+// SetBearing rotates the map to deg degrees clockwise from north.
+func (m *Map) SetBearing(ctx *via.Ctx, deg float64) {
+	ctx.ExecScript(fmt.Sprintf("%s?.setBearing(%g)", m.mapRef(), deg))
+}
+
+// FitBounds frames the box (west, south, east, north) in view, zooming and
+// centering to fit. Use it to frame a route, a set of markers, or a region
+// without computing the center/zoom yourself.
+func (m *Map) FitBounds(ctx *via.Ctx, west, south, east, north float64) {
+	bounds := [][]float64{{west, south}, {east, north}}
+	ctx.ExecScript(fmt.Sprintf("%s?.fitBounds(%s,{padding:40})", m.mapRef(), mustJSON(bounds)))
+}

--- a/plugins/maplibre/camera.go
+++ b/plugins/maplibre/camera.go
@@ -6,54 +6,53 @@ import (
 	"github.com/go-via/via"
 )
 
-// FlyTo animates a curved, zoom-then-pan flight to (lng, lat) at zoom — the
-// "navigate the user somewhere" gesture. Server-driven: call it from an
-// action and the camera flies on every connected tab. Coordinates are
-// [lng, lat] (longitude first).
-func (m *Map) FlyTo(ctx *via.Ctx, lng, lat, zoom float64) {
-	m.camera(ctx, "flyTo", lng, lat, zoom)
+// FlyTo animates a curved, zoom-then-pan flight to at, at the given zoom — the
+// "navigate the user somewhere" gesture. Server-driven: call it from an action
+// and the camera flies on every connected tab.
+func (m *Map) FlyTo(ctx *via.Ctx, at LngLat, zoom float64) {
+	m.camera(ctx, "flyTo", at, zoom)
 }
 
-// EaseTo moves the camera to (lng, lat) at zoom with a straight eased
+// EaseTo moves the camera to at, at the given zoom, with a straight eased
 // transition — cheaper and less theatrical than [Map.FlyTo] for small hops.
-func (m *Map) EaseTo(ctx *via.Ctx, lng, lat, zoom float64) {
-	m.camera(ctx, "easeTo", lng, lat, zoom)
+func (m *Map) EaseTo(ctx *via.Ctx, at LngLat, zoom float64) {
+	m.camera(ctx, "easeTo", at, zoom)
 }
 
-// JumpTo snaps the camera to (lng, lat) at zoom with no animation.
-func (m *Map) JumpTo(ctx *via.Ctx, lng, lat, zoom float64) {
-	m.camera(ctx, "jumpTo", lng, lat, zoom)
+// JumpTo snaps the camera to at, at the given zoom, with no animation.
+func (m *Map) JumpTo(ctx *via.Ctx, at LngLat, zoom float64) {
+	m.camera(ctx, "jumpTo", at, zoom)
 }
 
-func (m *Map) camera(ctx *via.Ctx, method string, lng, lat, zoom float64) {
+func (m *Map) camera(ctx *via.Ctx, method string, at LngLat, zoom float64) {
 	ctx.ExecScript(fmt.Sprintf("%s?.%s(%s)", m.mapRef(), method,
-		mustJSON(map[string]any{"center": []float64{lng, lat}, "zoom": zoom})))
+		mustJSON(map[string]any{"center": at.pair(), "zoom": zoom})))
 }
 
-// SetCenter recenters on (lng, lat) without changing zoom, instantly.
-func (m *Map) SetCenter(ctx *via.Ctx, lng, lat float64) {
-	ctx.ExecScript(fmt.Sprintf("%s?.setCenter(%s)", m.mapRef(), mustJSON([]float64{lng, lat})))
+// SetCenter recenters on at without changing zoom, instantly.
+func (m *Map) SetCenter(ctx *via.Ctx, at LngLat) {
+	ctx.ExecScript(fmt.Sprintf("%s?.setCenter(%s)", m.mapRef(), mustJSON(at.pair())))
 }
 
 // SetZoom sets the zoom level instantly.
 func (m *Map) SetZoom(ctx *via.Ctx, zoom float64) {
-	ctx.ExecScript(fmt.Sprintf("%s?.setZoom(%g)", m.mapRef(), zoom))
+	ctx.ExecScript(fmt.Sprintf("%s?.setZoom(%s)", m.mapRef(), mustJSON(zoom)))
 }
 
 // SetPitch tilts the camera to deg degrees (0 = straight down).
 func (m *Map) SetPitch(ctx *via.Ctx, deg float64) {
-	ctx.ExecScript(fmt.Sprintf("%s?.setPitch(%g)", m.mapRef(), deg))
+	ctx.ExecScript(fmt.Sprintf("%s?.setPitch(%s)", m.mapRef(), mustJSON(deg)))
 }
 
 // SetBearing rotates the map to deg degrees clockwise from north.
 func (m *Map) SetBearing(ctx *via.Ctx, deg float64) {
-	ctx.ExecScript(fmt.Sprintf("%s?.setBearing(%g)", m.mapRef(), deg))
+	ctx.ExecScript(fmt.Sprintf("%s?.setBearing(%s)", m.mapRef(), mustJSON(deg)))
 }
 
-// FitBounds frames the box (west, south, east, north) in view, zooming and
-// centering to fit. Use it to frame a route, a set of markers, or a region
-// without computing the center/zoom yourself.
-func (m *Map) FitBounds(ctx *via.Ctx, west, south, east, north float64) {
-	bounds := [][]float64{{west, south}, {east, north}}
+// FitBounds frames b in view, zooming and centering to fit. Use it to frame a
+// route, a set of markers, or a region without computing the center/zoom
+// yourself.
+func (m *Map) FitBounds(ctx *via.Ctx, b Bounds) {
+	bounds := [][]float64{b.sw(), b.ne()}
 	ctx.ExecScript(fmt.Sprintf("%s?.fitBounds(%s,{padding:40})", m.mapRef(), mustJSON(bounds)))
 }

--- a/plugins/maplibre/camera_test.go
+++ b/plugins/maplibre/camera_test.go
@@ -1,0 +1,45 @@
+package maplibre_test
+
+import "testing"
+
+func TestMapAPI_FlyTo_emitsCurvedFlightWithLngLatCenter(t *testing.T) {
+	t.Parallel()
+	fireMapAction(t, "FlyTo", "flyTo", `"center":[-122.42,37.77]`, `"zoom":12`)
+}
+
+func TestMapAPI_EaseTo_emitsEasedMove(t *testing.T) {
+	t.Parallel()
+	fireMapAction(t, "EaseTo", "easeTo", `"center":[2.35,48.85]`)
+}
+
+func TestMapAPI_JumpTo_emitsInstantMove(t *testing.T) {
+	t.Parallel()
+	fireMapAction(t, "JumpTo", "jumpTo", `"center":[139.69,35.69]`)
+}
+
+func TestMapAPI_SetCenter_emitsLngLatArray(t *testing.T) {
+	t.Parallel()
+	fireMapAction(t, "SetCenter", "setCenter([-0.12,51.5])")
+}
+
+func TestMapAPI_SetZoom_emitsZoomCall(t *testing.T) {
+	t.Parallel()
+	fireMapAction(t, "SetZoom", "setZoom(7)")
+}
+
+func TestMapAPI_SetPitch_emitsPitchCall(t *testing.T) {
+	t.Parallel()
+	fireMapAction(t, "SetPitch", "setPitch(60)")
+}
+
+func TestMapAPI_SetBearing_emitsBearingCall(t *testing.T) {
+	t.Parallel()
+	fireMapAction(t, "SetBearing", "setBearing(90)")
+}
+
+func TestMapAPI_FitBounds_emitsSouthWestNorthEastBoxWithPadding(t *testing.T) {
+	t.Parallel()
+	// Assert the padding too: a bounds-only needle would still pass if the
+	// padding were dropped, silently fitting flush to the viewport edges.
+	fireMapAction(t, "FitBounds", "fitBounds([[-10,40],[5,55]],{padding:40})")
+}

--- a/plugins/maplibre/coords.go
+++ b/plugins/maplibre/coords.go
@@ -1,0 +1,35 @@
+package maplibre
+
+// LngLat is a geographic point. Its named fields defuse the classic MapLibre
+// foot-gun — coordinates are [lng, lat] (longitude first), the inverse of the
+// lat/lng most humans say — so the camera, marker, and center APIs take this
+// instead of a bare (lng, lat) pair. Construct it with keyed fields in any
+// order for self-documenting safety, or with the [At] shorthand:
+//
+//	maplibre.LngLat{Lat: 51.5, Lng: -0.12} // order-independent, unswappable
+//	maplibre.At(-0.12, 51.5)               // terse: longitude first
+type LngLat struct {
+	Lng float64
+	Lat float64
+}
+
+// At builds a [LngLat] from a longitude and latitude (longitude FIRST). Prefer
+// the keyed LngLat{Lng:…, Lat:…} literal when you want the order checked at the
+// call site; At is the terse form for when you're sure of the order.
+func At(lng, lat float64) LngLat { return LngLat{Lng: lng, Lat: lat} }
+
+// pair returns the [lng, lat] slice MapLibre expects.
+func (p LngLat) pair() []float64 { return []float64{p.Lng, p.Lat} }
+
+// Bounds is a geographic box. Named edges defuse the west/south/east/north
+// ordering foot-gun for [Map.FitBounds] and [WithMaxBounds].
+type Bounds struct {
+	West  float64
+	South float64
+	East  float64
+	North float64
+}
+
+// sw / ne return the corner pairs MapLibre expects ([[sw],[ne]]).
+func (b Bounds) sw() []float64 { return []float64{b.West, b.South} }
+func (b Bounds) ne() []float64 { return []float64{b.East, b.North} }

--- a/plugins/maplibre/coords_test.go
+++ b/plugins/maplibre/coords_test.go
@@ -1,0 +1,25 @@
+package maplibre_test
+
+import (
+	"testing"
+
+	"github.com/go-via/via/plugins/maplibre"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAt_ordersLongitudeFirst(t *testing.T) {
+	t.Parallel()
+	// At's whole job is to pin the [lng, lat] order, so the foot-gun lives in
+	// exactly one documented place instead of every call site.
+	p := maplibre.At(-0.12, 51.5)
+	assert.Equal(t, -0.12, p.Lng, "first arg is longitude")
+	assert.Equal(t, 51.5, p.Lat, "second arg is latitude")
+}
+
+func TestLngLat_keyedLiteralIsOrderIndependent(t *testing.T) {
+	t.Parallel()
+	// The safe form: written lat-first by a human who thinks lat/lng, still
+	// correct because the fields are named.
+	p := maplibre.LngLat{Lat: 51.5, Lng: -0.12}
+	assert.Equal(t, maplibre.At(-0.12, 51.5), p)
+}

--- a/plugins/maplibre/data.go
+++ b/plugins/maplibre/data.go
@@ -1,0 +1,201 @@
+package maplibre
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-via/via"
+)
+
+// GeoJSON builders. All coordinates are [lng, lat] (longitude first) per
+// RFC 7946 — the same order MapLibre uses everywhere.
+
+// Point returns a GeoJSON Point geometry at (lng, lat).
+func Point(lng, lat float64) map[string]any {
+	return map[string]any{"type": "Point", "coordinates": []float64{lng, lat}}
+}
+
+// LineString returns a GeoJSON LineString geometry through coords, each an
+// [lng, lat] pair.
+func LineString(coords [][]float64) map[string]any {
+	return map[string]any{"type": "LineString", "coordinates": coords}
+}
+
+// Polygon returns a GeoJSON Polygon geometry from rings — the first ring is
+// the outer boundary, any others are holes. Each ring is a closed loop of
+// [lng, lat] pairs (first == last).
+func Polygon(rings [][][]float64) map[string]any {
+	return map[string]any{"type": "Polygon", "coordinates": rings}
+}
+
+// Feature wraps a geometry (e.g. from [Point]) with properties, which layer
+// paint expressions can read via ["get","key"]. A nil props is fine.
+func Feature(geometry, props map[string]any) map[string]any {
+	if props == nil {
+		props = map[string]any{}
+	}
+	return map[string]any{"type": "Feature", "geometry": geometry, "properties": props}
+}
+
+// PointFeature is sugar for a [Feature] wrapping a [Point] — the common case
+// of a labelled pin or data point.
+func PointFeature(lng, lat float64, props map[string]any) map[string]any {
+	return Feature(Point(lng, lat), props)
+}
+
+// FeatureCollection bundles features into the top-level object a GeoJSON
+// source expects. Call with no args for an empty collection (a source to fill
+// later via [Map.SetGeoJSON]).
+func FeatureCollection(features ...map[string]any) map[string]any {
+	if features == nil {
+		features = []map[string]any{}
+	}
+	return map[string]any{"type": "FeatureCollection", "features": features}
+}
+
+// LayerOption configures a layer spec from the typed layer builders.
+type LayerOption func(map[string]any)
+
+// Paint sets a paint property (e.g. "circle-color", "line-width"). Paint
+// properties control appearance and can be data-driven expressions.
+func Paint(key string, value any) LayerOption {
+	return func(spec map[string]any) { nestedSet(spec, "paint", key, value) }
+}
+
+// Layout sets a layout property (e.g. "line-cap", "visibility", "text-field").
+// Layout properties affect how features are placed and laid out.
+func Layout(key string, value any) LayerOption {
+	return func(spec map[string]any) { nestedSet(spec, "layout", key, value) }
+}
+
+// Filter restricts the layer to features matching a MapLibre filter
+// expression, e.g. []any{"==", []any{"get", "kind"}, "park"}.
+func Filter(expr []any) LayerOption {
+	return func(spec map[string]any) { spec["filter"] = expr }
+}
+
+func nestedSet(spec map[string]any, group, key string, value any) {
+	g, ok := spec[group].(map[string]any)
+	if !ok {
+		g = map[string]any{}
+		spec[group] = g
+	}
+	g[key] = value
+}
+
+func layer(kind, id, source string, opts []LayerOption) map[string]any {
+	spec := map[string]any{"id": id, "type": kind, "source": source}
+	for _, o := range opts {
+		o(spec)
+	}
+	return spec
+}
+
+// CircleLayer renders a source's points as circles. Style with Paint, e.g.
+// Paint("circle-radius", 6), Paint("circle-color", "#e55").
+func CircleLayer(id, source string, opts ...LayerOption) map[string]any {
+	return layer("circle", id, source, opts)
+}
+
+// LineLayer renders a source's lines. Style with Paint("line-color", …),
+// Paint("line-width", …).
+func LineLayer(id, source string, opts ...LayerOption) map[string]any {
+	return layer("line", id, source, opts)
+}
+
+// FillLayer renders a source's polygons. Style with Paint("fill-color", …),
+// Paint("fill-opacity", …).
+func FillLayer(id, source string, opts ...LayerOption) map[string]any {
+	return layer("fill", id, source, opts)
+}
+
+// SymbolLayer renders a source as icons and/or text labels. Configure via
+// Layout, e.g. Layout("text-field", []any{"get", "name"}).
+func SymbolLayer(id, source string, opts ...LayerOption) map[string]any {
+	return layer("symbol", id, source, opts)
+}
+
+// SetGeoJSON replaces the data of the GeoJSON source named id — the primary
+// way to push live data (markers-as-layer, routes, choropleths) to every
+// connected tab. The source must already exist (declared via
+// [WithGeoJSONSource] or added with [Map.AddGeoJSONSource]); if it doesn't,
+// the call is a safe no-op. Returns an error only if data can't be
+// marshalled.
+func (m *Map) SetGeoJSON(ctx *via.Ctx, id string, data map[string]any) error {
+	jdata, err := marshal(data)
+	if err != nil {
+		return err
+	}
+	m.execReady(ctx, fmt.Sprintf("var _s=_m.getSource(%s);if(_s)_s.setData(%s)", mustJSON(id), jdata))
+	return nil
+}
+
+// AddGeoJSONSource adds a GeoJSON source at runtime (the [WithGeoJSONSource]
+// equivalent for sources created after first paint). A no-op if a source with
+// that id already exists. Returns an error only on marshal failure.
+func (m *Map) AddGeoJSONSource(ctx *via.Ctx, id string, data map[string]any) error {
+	jsource, err := marshal(geoJSONSource(data))
+	if err != nil {
+		return err
+	}
+	m.execReady(ctx, fmt.Sprintf("if(!_m.getSource(%s))_m.addSource(%s,%s)", mustJSON(id), mustJSON(id), jsource))
+	return nil
+}
+
+// AddLayer adds a layer at runtime. Build spec with [CircleLayer] etc. A no-op
+// if a layer with that id already exists. Returns an error only on marshal
+// failure.
+func (m *Map) AddLayer(ctx *via.Ctx, spec map[string]any) error {
+	jspec, err := marshal(spec)
+	if err != nil {
+		return err
+	}
+	id, _ := spec["id"].(string)
+	m.execReady(ctx, fmt.Sprintf("if(!_m.getLayer(%s))_m.addLayer(%s)", mustJSON(id), jspec))
+	return nil
+}
+
+// SetPaintProperty updates one paint property of a layer at runtime (e.g.
+// recolor a choropleth, fade a layer). Returns an error only if value can't
+// be marshalled.
+func (m *Map) SetPaintProperty(ctx *via.Ctx, layerID, property string, value any) error {
+	jval, err := marshal(value)
+	if err != nil {
+		return err
+	}
+	m.execReady(ctx, fmt.Sprintf("_m.setPaintProperty(%s,%s,%s)", mustJSON(layerID), mustJSON(property), jval))
+	return nil
+}
+
+// SetLayerVisibility shows or hides a layer without removing it.
+func (m *Map) SetLayerVisibility(ctx *via.Ctx, layerID string, visible bool) {
+	v := "none"
+	if visible {
+		v = "visible"
+	}
+	m.execReady(ctx, fmt.Sprintf("_m.setLayoutProperty(%s,'visibility',%s)", mustJSON(layerID), mustJSON(v)))
+}
+
+// RemoveLayer removes a layer, leaving its source in place.
+func (m *Map) RemoveLayer(ctx *via.Ctx, layerID string) {
+	m.execReady(ctx, fmt.Sprintf("if(_m.getLayer(%s))_m.removeLayer(%s)", mustJSON(layerID), mustJSON(layerID)))
+}
+
+// RemoveLayerAndSource removes a layer and then its source, in that order —
+// MapLibre throws if a source is removed while a layer still references it.
+func (m *Map) RemoveLayerAndSource(ctx *via.Ctx, layerID, sourceID string) {
+	m.execReady(ctx, fmt.Sprintf(
+		"if(_m.getLayer(%s))_m.removeLayer(%s);if(_m.getSource(%s))_m.removeSource(%s)",
+		mustJSON(layerID), mustJSON(layerID), mustJSON(sourceID), mustJSON(sourceID)))
+}
+
+// marshal is the runtime counterpart to mustJSON: it returns the error rather
+// than panicking, because the value may originate from user data at action
+// time.
+func marshal(v any) (string, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", fmt.Errorf("maplibre: marshal: %v", err)
+	}
+	return string(b), nil
+}

--- a/plugins/maplibre/data_test.go
+++ b/plugins/maplibre/data_test.go
@@ -1,0 +1,136 @@
+package maplibre_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/go-via/via/plugins/maplibre"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func jsonOf(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+func TestPoint_emitsLngLatGeometry(t *testing.T) {
+	t.Parallel()
+	assert.JSONEq(t, `{"type":"Point","coordinates":[-122.4,37.8]}`,
+		jsonOf(t, maplibre.Point(-122.4, 37.8)))
+}
+
+func TestLineString_emitsCoordinateArray(t *testing.T) {
+	t.Parallel()
+	got := maplibre.LineString([][]float64{{0, 0}, {1, 1}})
+	assert.JSONEq(t, `{"type":"LineString","coordinates":[[0,0],[1,1]]}`, jsonOf(t, got))
+}
+
+func TestPointFeature_wrapsGeometryWithProperties(t *testing.T) {
+	t.Parallel()
+	got := maplibre.PointFeature(1, 2, map[string]any{"name": "x"})
+	assert.JSONEq(t,
+		`{"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":{"name":"x"}}`,
+		jsonOf(t, got))
+}
+
+func TestFeature_defaultsNilPropertiesToEmptyObject(t *testing.T) {
+	t.Parallel()
+	got := maplibre.Feature(maplibre.Point(0, 0), nil)
+	assert.Contains(t, jsonOf(t, got), `"properties":{}`,
+		"a nil props must serialize as {} so the Feature stays valid GeoJSON")
+}
+
+func TestFeatureCollection_wrapsFeatures(t *testing.T) {
+	t.Parallel()
+	got := maplibre.FeatureCollection(maplibre.PointFeature(1, 2, nil))
+	assert.Contains(t, jsonOf(t, got), `"type":"FeatureCollection"`)
+	assert.Contains(t, jsonOf(t, got), `"features":[`)
+}
+
+func TestFeatureCollection_emptyIsNonNullFeaturesArray(t *testing.T) {
+	t.Parallel()
+	assert.Contains(t, jsonOf(t, maplibre.FeatureCollection()), `"features":[]`,
+		"an empty collection must emit [] not null, so setData has a valid value")
+}
+
+func TestCircleLayer_setsTypeSourceAndNestedPaint(t *testing.T) {
+	t.Parallel()
+	got := maplibre.CircleLayer("dots", "pts",
+		maplibre.Paint("circle-radius", 6), maplibre.Paint("circle-color", "#e55"))
+	js := jsonOf(t, got)
+	assert.Contains(t, js, `"type":"circle"`)
+	assert.Contains(t, js, `"source":"pts"`)
+	assert.Contains(t, js, `"circle-radius":6`)
+	assert.Contains(t, js, `"circle-color":"#e55"`)
+}
+
+func TestSymbolLayer_putsTextFieldUnderLayout(t *testing.T) {
+	t.Parallel()
+	got := maplibre.SymbolLayer("labels", "pts",
+		maplibre.Layout("text-field", []any{"get", "name"}))
+	assert.Contains(t, jsonOf(t, got), `"layout":{"text-field":["get","name"]}`)
+}
+
+func TestMapAPI_SetGeoJSON_setsSourceDataGuardedByStyleReady(t *testing.T) {
+	t.Parallel()
+	fireMapAction(t, "SetGeoJSON",
+		"__viaMapReady", `getSource("pts")`, ".setData(", `"FeatureCollection"`)
+}
+
+func TestMapAPI_AddGeoJSONSource_addsGeojsonTypedSourceIdempotently(t *testing.T) {
+	t.Parallel()
+	// The if(!getSource) guard makes a re-add a no-op rather than throwing on
+	// a duplicate source id — so a reconnect can safely re-run it.
+	fireMapAction(t, "AddSource", `if(!_m.getSource("pts"))`, ".addSource(", `"type":"geojson"`)
+}
+
+func TestMapAPI_AddLayer_addsLayerGuardedByExistence(t *testing.T) {
+	t.Parallel()
+	fireMapAction(t, "AddCircleLayer", ".addLayer(", `"type":"circle"`, "getLayer")
+}
+
+func TestMapAPI_SetPaintProperty_emitsPaintUpdate(t *testing.T) {
+	t.Parallel()
+	fireMapAction(t, "SetPaint", `setPaintProperty("dots","circle-color","#00f")`)
+}
+
+func TestMapAPI_SetLayerVisibility_togglesVisibility(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		action string
+		needle string
+	}{
+		{"show", "ShowLayer", "'visibility',\"visible\""},
+		{"hide", "HideLayer", "'visibility',\"none\""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fireMapAction(t, tt.action, "setLayoutProperty", tt.needle)
+		})
+	}
+}
+
+func TestMapAPI_RemoveLayerAndSource_removesLayerBeforeSource(t *testing.T) {
+	t.Parallel()
+	// removeSource throws if a layer still references it, so order matters.
+	frame := fireMapAction(t, "RemoveLayerSource", "removeLayer", "removeSource")
+	assert.Less(t, strings.Index(frame, "removeLayer"), strings.Index(frame, "removeSource"),
+		"removeLayer must be emitted before removeSource")
+}
+
+func TestMapAPI_SetPaintProperty_returnsErrorOnUnmarshallableValue(t *testing.T) {
+	t.Parallel()
+	// A channel can't be JSON-encoded: the method returns the marshal error
+	// (no broken script is emitted), which the default handler surfaces as a
+	// toast carrying the package-prefixed message.
+	frame := fireMapAction(t, "SetPaintBad", "maplibre: marshal")
+	assert.NotContains(t, frame, "setPaintProperty",
+		"a marshal failure must abort before emitting the paint script")
+}

--- a/plugins/maplibre/data_test.go
+++ b/plugins/maplibre/data_test.go
@@ -57,6 +57,36 @@ func TestFeatureCollection_emptyIsNonNullFeaturesArray(t *testing.T) {
 		"an empty collection must emit [] not null, so setData has a valid value")
 }
 
+func TestWithGeoJSONSource_GenerateFeatureIDs_emitsGenerateId(t *testing.T) {
+	t.Parallel()
+	// Feature-state (hover highlighting, selection) targets features by id.
+	// GeoJSON features often lack ids; generateId:true makes MapLibre assign
+	// them so setFeatureState has something to address.
+	html := render(t, maplibre.NewMap(
+		maplibre.WithElementID("m"),
+		maplibre.WithGeoJSONSource("zones", maplibre.FeatureCollection(), maplibre.GenerateFeatureIDs()),
+	))
+	assert.Contains(t, html, `"generateId":true`,
+		"GenerateFeatureIDs must set MapLibre's generateId on the source")
+	// Additive — generateId augments the source spec, it doesn't replace it.
+	assert.Contains(t, html, `"type":"geojson"`,
+		"the source must still be a geojson source")
+	assert.Contains(t, html, "addSource",
+		"the source must still be added")
+}
+
+func TestWithGeoJSONSource_withoutOption_omitsGenerateId(t *testing.T) {
+	t.Parallel()
+	// The default must not silently turn on generateId — a dev who supplies
+	// their own stable feature ids must not have them overwritten.
+	html := render(t, maplibre.NewMap(
+		maplibre.WithElementID("m"),
+		maplibre.WithGeoJSONSource("zones", maplibre.FeatureCollection()),
+	))
+	assert.NotContains(t, html, "generateId",
+		"a source without GenerateFeatureIDs must not emit generateId")
+}
+
 func TestCircleLayer_setsTypeSourceAndNestedPaint(t *testing.T) {
 	t.Parallel()
 	got := maplibre.CircleLayer("dots", "pts",

--- a/plugins/maplibre/doc.go
+++ b/plugins/maplibre/doc.go
@@ -15,7 +15,7 @@
 //	    if p.Map == nil {
 //	        p.Map = maplibre.NewMap(
 //	            maplibre.WithElementID("map"),
-//	            maplibre.WithCenter(-122.42, 37.77), // [lng, lat]
+//	            maplibre.WithCenter(maplibre.At(-122.42, 37.77)),
 //	            maplibre.WithZoom(11),
 //	            maplibre.WithNavigationControl(),
 //	        )
@@ -25,25 +25,43 @@
 //
 //	func (p *Page) View(ctx *via.CtxR) h.H { return p.Map.Mount() }
 //
-//	func (p *Page) GoToTokyo(ctx *via.Ctx) { p.Map.FlyTo(ctx, 139.69, 35.69, 10) }
+//	func (p *Page) GoToTokyo(ctx *via.Ctx) { p.Map.FlyTo(ctx, maplibre.At(139.69, 35.69), 10) }
 //
 // # Coordinate order
 //
-// MapLibre — and this package — take coordinates as [lng, lat] (longitude
-// first), the inverse of the lat/lng most map UIs print. WithCenter, FlyTo,
-// AddMarker, and every GeoJSON coordinate follow this order.
+// Coordinates are [lng, lat] (longitude first), the inverse of the lat/lng most
+// map UIs print. The camera, marker, and center APIs take a [LngLat] whose
+// named fields defuse the swap — build it with maplibre.LngLat{Lng: …, Lat: …}
+// (order-independent) or the maplibre.At(lng, lat) shorthand; box APIs take a
+// [Bounds] with named edges. GeoJSON geometry ([Point], [LineString],
+// [Polygon]) stays as raw [lng, lat] arrays.
 //
 // # Camera
 //
 // FlyTo (curved flight), EaseTo (eased hop), JumpTo (instant), plus SetCenter,
-// SetZoom, SetPitch, SetBearing, and FitBounds(w, s, e, n) to frame a box.
+// SetZoom, SetPitch, SetBearing, and FitBounds([Bounds]) to frame a box.
 //
 // # Markers
 //
-// AddMarker(ctx, id, lng, lat, opts…) places a keyed marker; MoveMarker
+// AddMarker(ctx, id, at, opts…) places a keyed marker (at is a [LngLat]);
+// WithMarker declares a static one at construction; MoveMarker
 // repositions it live (vehicle tracking), RemoveMarker / ClearMarkers tear
 // down. Options: Color, Draggable, Scale, PopupText (XSS-safe, for user
 // content), PopupHTML (trusted markup only — MapLibre does not sanitize it).
+//
+// # Popups (dialogs)
+//
+// ShowPopup(ctx, id, at, text, opts…) opens a keyed popup at a point — the
+// "dialog on click" pattern: from an [OnFeatureClick] / [OnClick] handler,
+// ShowPopup at e.LngLat() with details looked up on the server. Re-using an id
+// replaces rather than stacks; ClosePopup closes it; ShowPopupHTML takes
+// trusted HTML. Options: WithoutCloseButton, WithoutCloseOnClick,
+// PopupMaxWidth, PopupClass.
+//
+//	func (p *Page) Picked(ctx *via.Ctx) {
+//	    e := p.Map.Event(ctx)
+//	    p.Map.ShowPopup(ctx, "info", e.LngLat(), p.lookupName(e.FeatureID))
+//	}
 //
 // # Data layers
 //
@@ -55,6 +73,62 @@
 // Filter options. SetPaintProperty, SetLayerVisibility, RemoveLayer, and
 // RemoveLayerAndSource adjust them after the fact. These ops re-arm on the
 // style-load event, so they're safe to fire before the style finishes loading.
+//
+// # Styling expressions
+//
+// Paint/Layout values can be data-driven MapLibre expressions. Instead of
+// hand-writing the nested []any arrays, compose them with the typed builders:
+// Get (a feature property), FeatureState (runtime state), Zoom, Boolean, Case
+// (+ Branch), Interpolate / Step (+ Stop) for zoom/data ramps, and the sugar
+// WhenHovered / WhenState for the common highlight case. They return Expr (an
+// alias for []any), so they nest freely and stay interchangeable with raw
+// []any:
+//
+//	maplibre.Paint("fill-color", maplibre.WhenHovered("#ffcc00", "#5856d6"))
+//	maplibre.Paint("line-width", maplibre.Interpolate(maplibre.Zoom(),
+//	    maplibre.Stop{At: 5, Value: 2}, maplibre.Stop{At: 12, Value: 6}))
+//
+// # Inbound events
+//
+// Register Go handlers for user gestures so the map drives the server, not
+// just the reverse:
+//
+//   - OnClick — a basemap click (sets Lng/Lat).
+//   - OnMoveEnd — the camera settles after a pan/zoom/rotate (sets the center,
+//     Zoom, Bearing, Pitch, and the bounding box West/South/East/North).
+//   - OnMarkerClick / OnMarkerDragEnd — a marker is clicked or a draggable
+//     marker dropped (sets MarkerID and Lng/Lat).
+//   - OnFeatureClick(layer, method) — a rendered data-layer feature is clicked
+//     (sets FeatureID from the feature's id property, plus the click Lng/Lat).
+//
+// The handler reads the gesture with [Map.Event]:
+//
+//	p.Map = maplibre.NewMap(
+//	    maplibre.WithElementID("map"),
+//	    maplibre.OnClick(p.PlacePin),   // bound method, like the on package
+//	    maplibre.OnMoveEnd(p.LoadView),
+//	)
+//
+//	func (p *Page) PlacePin(ctx *via.Ctx) {
+//	    e := p.Map.Event(ctx) // e.Lng, e.Lat
+//	    p.Map.AddMarker(ctx, "pin", e.LngLat())
+//	}
+//
+//	func (p *Page) LoadView(ctx *via.Ctx) {
+//	    e := p.Map.Event(ctx) // e.Zoom plus bounds e.West/South/East/North
+//	    // fetch features inside the box, then SetGeoJSON them
+//	}
+//
+// Zoom/Bearing/Pitch carry the live camera on every gesture; the bounding box
+// is moveend-only and MarkerID/FeatureID are set only by their own gesture —
+// see [MapEvent]. Clickable features and markers show a pointer cursor on
+// hover, so they read as interactive. OnMapEvent(name, method) is the escape
+// hatch for any other map event (dblclick, contextmenu, zoomend, …).
+//
+// WithFeatureHover(layer) highlights the hovered feature client-side via
+// MapLibre feature-state — no round-trip. Reference ['feature-state','hover']
+// in a paint property to style it, and give the source feature ids with
+// GenerateFeatureIDs() so the highlight can target them.
 //
 // # Lifecycle and escape hatch
 //

--- a/plugins/maplibre/doc.go
+++ b/plugins/maplibre/doc.go
@@ -1,0 +1,77 @@
+// Package maplibre provides a MapLibre GL JS plugin for the Via engine —
+// interactive vector maps driven from Go, with the camera, markers, and data
+// layers updated over SSE.
+//
+// Quick start:
+//
+//	app := via.New(via.WithPlugins(maplibre.Plugin()))
+//
+// Hold a *Map on the page, build it in OnInit, mount it in View, then drive it
+// from actions or a via.Stream ticker:
+//
+//	type Page struct{ Map *maplibre.Map }
+//
+//	func (p *Page) OnInit(ctx *via.Ctx) error {
+//	    if p.Map == nil {
+//	        p.Map = maplibre.NewMap(
+//	            maplibre.WithElementID("map"),
+//	            maplibre.WithCenter(-122.42, 37.77), // [lng, lat]
+//	            maplibre.WithZoom(11),
+//	            maplibre.WithNavigationControl(),
+//	        )
+//	    }
+//	    return nil
+//	}
+//
+//	func (p *Page) View(ctx *via.CtxR) h.H { return p.Map.Mount() }
+//
+//	func (p *Page) GoToTokyo(ctx *via.Ctx) { p.Map.FlyTo(ctx, 139.69, 35.69, 10) }
+//
+// # Coordinate order
+//
+// MapLibre — and this package — take coordinates as [lng, lat] (longitude
+// first), the inverse of the lat/lng most map UIs print. WithCenter, FlyTo,
+// AddMarker, and every GeoJSON coordinate follow this order.
+//
+// # Camera
+//
+// FlyTo (curved flight), EaseTo (eased hop), JumpTo (instant), plus SetCenter,
+// SetZoom, SetPitch, SetBearing, and FitBounds(w, s, e, n) to frame a box.
+//
+// # Markers
+//
+// AddMarker(ctx, id, lng, lat, opts…) places a keyed marker; MoveMarker
+// repositions it live (vehicle tracking), RemoveMarker / ClearMarkers tear
+// down. Options: Color, Draggable, Scale, PopupText (XSS-safe, for user
+// content), PopupHTML (trusted markup only — MapLibre does not sanitize it).
+//
+// # Data layers
+//
+// Declare sources/layers at construction with WithGeoJSONSource + WithLayer,
+// or add them at runtime with AddGeoJSONSource / AddLayer. Push live data with
+// SetGeoJSON(ctx, sourceID, fc). Build GeoJSON with Point, LineString,
+// Polygon, Feature, PointFeature, FeatureCollection; build layers with
+// CircleLayer / LineLayer / FillLayer / SymbolLayer plus Paint / Layout /
+// Filter options. SetPaintProperty, SetLayerVisibility, RemoveLayer, and
+// RemoveLayerAndSource adjust them after the fact. These ops re-arm on the
+// style-load event, so they're safe to fire before the style finishes loading.
+//
+// # Lifecycle and escape hatch
+//
+//   - SetStyle swaps the basemap; Resize recomputes layout; Dispose frees the
+//     WebGL context and registry slot (call on SPA unmount).
+//   - Call(ctx, method, args…) invokes any Map method the typed API misses.
+//   - WithMapOption(key, value) sets any constructor option not covered.
+//
+// # Self-hosting, versions, and CSP
+//
+//	maplibre.Plugin(maplibre.WithVersion("5.24.0")) // pin a CDN version (v5 only)
+//	maplibre.Plugin(maplibre.WithSource("/static/maplibre-gl.js"),
+//	    maplibre.WithStylesheet("/static/maplibre-gl.css")) // self-host
+//	maplibre.Plugin(maplibre.WithCSPBuild()) // inline worker for strict worker-src
+//
+// Pin a v5 release — v6 is ESM-only and drops the maplibregl global the script
+// include relies on. The CSS is required: without it markers, popups, and
+// controls render unstyled. The default style is MapLibre's no-key demo style,
+// intended for demos and CI, not production; supply your own via WithStyle.
+package maplibre

--- a/plugins/maplibre/events.go
+++ b/plugins/maplibre/events.go
@@ -1,0 +1,246 @@
+package maplibre
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/go-via/via"
+	"github.com/go-via/via/internal/spec"
+)
+
+// jsString encodes s as a JS string literal safe to inline in any quoting
+// context. mustJSON (json.Marshal) escapes <, >, &, " and backslash, but NOT
+// the single quote; escaping ' as well means the literal can't break out even
+// when adjacent to single-quoted JS. Used for developer-supplied identifiers
+// (layer ids, feature-property names, MapLibre event names) that go into the
+// _m.on('event', <here>, …) call sites.
+func jsString(s string) string {
+	return strings.ReplaceAll(mustJSON(s), "'", `'`)
+}
+
+// MapEvent is the payload a user gesture carries back to a Go handler. The
+// browser writes these fields as datastar signals before posting the action;
+// [Map.Event] decodes them. Which fields a given gesture sets: a click sets
+// Lng/Lat; a moveend sets the center (Lng/Lat), Zoom, Bearing, Pitch, and the
+// visible bounding box (West/South/East/North).
+//
+// Zoom, Bearing, and Pitch carry the LIVE camera on every gesture, so they are
+// always valid. Lng/Lat are gesture-specific (click point, marker position,
+// feature-click point, or moveend center). The bounding box (West/South/East/
+// North) is set only by a moveend; MarkerID only by a marker gesture; FeatureID
+// only by a feature click. Those last fields are shared signals that carry over
+// their previous value across gesture kinds, so read them only in the handler
+// of the gesture that sets them.
+//
+// Coordinates are [lng, lat] degrees, matching the rest of the package.
+type MapEvent struct {
+	MarkerID  string  `form:"viaMapId"`
+	FeatureID string  `form:"viaMapFeatureId"`
+	Lng       float64 `form:"viaMapLng"`
+	Lat       float64 `form:"viaMapLat"`
+	Zoom      float64 `form:"viaMapZoom"`
+	Bearing   float64 `form:"viaMapBearing"`
+	Pitch     float64 `form:"viaMapPitch"`
+	West      float64 `form:"viaMapW"`
+	South     float64 `form:"viaMapS"`
+	East      float64 `form:"viaMapE"`
+	North     float64 `form:"viaMapN"`
+}
+
+// LngLat is the gesture's position as a [LngLat], so it flows straight into the
+// camera and marker APIs without re-typing the fields:
+//
+//	e := p.Map.Event(ctx)
+//	p.Map.AddMarker(ctx, "pin", e.LngLat())
+func (e MapEvent) LngLat() LngLat { return LngLat{Lng: e.Lng, Lat: e.Lat} }
+
+// cameraExpr assigns the live camera signals from a gesture's evt.detail. Every
+// gesture prepends it (before @post) so [MapEvent] Zoom/Bearing/Pitch are
+// always fresh, not a leftover from the last moveend.
+const cameraExpr = "$viaMapZoom=evt.detail.zoom;$viaMapBearing=evt.detail.bearing;$viaMapPitch=evt.detail.pitch;"
+
+// cameraDetail is the JS object-literal fragment reading the live camera off
+// the map handle (mapVar is "_m" for map-level listeners, "_e.m" for markers).
+func cameraDetail(mapVar string) string {
+	return fmt.Sprintf("zoom:%s.getZoom(),bearing:%s.getBearing(),pitch:%s.getPitch()", mapVar, mapVar, mapVar)
+}
+
+// handler pairs a browser-side custom event with the datastar expression that
+// captures its detail into signals and posts the bound action.
+type handler struct {
+	domEvent string // custom event the container listens for (e.g. "viamapclick")
+	expr     string // datastar expression: assign signals from evt.detail, then @post
+	js       string // initJS body that subscribes to the MapLibre event and dispatches domEvent
+}
+
+// OnClick registers a bound method as the handler for a basemap click. The
+// clicked [lng, lat] arrives in the [MapEvent] read by [Map.Event]. Panics if
+// fn is not a bound method value (e.g. a closure), matching the on package —
+// a closure has no stable action name to POST to.
+func OnClick[F via.Action](fn F) MapOption {
+	method := methodName("OnClick", fn)
+	return func(m *Map) {
+		m.handlers = append(m.handlers, handler{
+			domEvent: "viamapclick",
+			expr:     "$viaMapLng=evt.detail.lng;$viaMapLat=evt.detail.lat;" + cameraExpr + "@post('/_action/" + method + "')",
+			js:       "_m.on('click',function(e){_el.dispatchEvent(new CustomEvent('viamapclick',{detail:{lng:e.lngLat.lng,lat:e.lngLat.lat," + cameraDetail("_m") + "}}))});",
+		})
+	}
+}
+
+// OnMoveEnd registers a bound method to run after the camera settles from a
+// pan, zoom, or rotate. The [MapEvent] carries the new center (Lng/Lat), Zoom,
+// Bearing, Pitch, and the visible bounding box — everything a server needs to
+// load what's now in view. Panics like [OnClick] if fn is not a bound method.
+func OnMoveEnd[F via.Action](fn F) MapOption {
+	method := methodName("OnMoveEnd", fn)
+	return func(m *Map) {
+		m.handlers = append(m.handlers, handler{
+			domEvent: "viamapmove",
+			expr: "$viaMapLng=evt.detail.lng;$viaMapLat=evt.detail.lat;$viaMapZoom=evt.detail.zoom;" +
+				"$viaMapBearing=evt.detail.bearing;$viaMapPitch=evt.detail.pitch;" +
+				"$viaMapW=evt.detail.w;$viaMapS=evt.detail.s;$viaMapE=evt.detail.e;$viaMapN=evt.detail.n;" +
+				"@post('/_action/" + method + "')",
+			js: "_m.on('moveend',function(){var c=_m.getCenter(),b=_m.getBounds();" +
+				"_el.dispatchEvent(new CustomEvent('viamapmove',{detail:{lng:c.lng,lat:c.lat," +
+				cameraDetail("_m") + "," +
+				"w:b.getWest(),s:b.getSouth(),e:b.getEast(),n:b.getNorth()}}))});",
+		})
+	}
+}
+
+// OnMarkerClick registers a bound method to run when any marker is clicked.
+// The [MapEvent] carries the clicked marker's id ([MapEvent.MarkerID]) and its
+// position (Lng/Lat) — enough to select a feature. The marker's click stops
+// propagating, so a basemap [OnClick] does not also fire. Panics like
+// [OnClick] if fn is not a bound method.
+func OnMarkerClick[F via.Action](fn F) MapOption {
+	method := methodName("OnMarkerClick", fn)
+	return func(m *Map) {
+		m.markerClick = true
+		m.handlers = append(m.handlers, handler{
+			domEvent: "viamarkerclick",
+			expr:     "$viaMapId=evt.detail.id;$viaMapLng=evt.detail.lng;$viaMapLat=evt.detail.lat;" + cameraExpr + "@post('/_action/" + method + "')",
+		})
+	}
+}
+
+// OnMarkerDragEnd registers a bound method to run when the user drops a
+// draggable marker (pair with [Draggable]). The [MapEvent] carries the
+// marker's id and its new Lng/Lat. Panics like [OnClick] if fn is not a bound
+// method.
+func OnMarkerDragEnd[F via.Action](fn F) MapOption {
+	method := methodName("OnMarkerDragEnd", fn)
+	return func(m *Map) {
+		m.markerDragEnd = true
+		m.handlers = append(m.handlers, handler{
+			domEvent: "viamarkerdragend",
+			expr:     "$viaMapId=evt.detail.id;$viaMapLng=evt.detail.lng;$viaMapLat=evt.detail.lat;" + cameraExpr + "@post('/_action/" + method + "')",
+		})
+	}
+}
+
+// OnFeatureClick registers a bound method to run when the user clicks a
+// rendered feature in the named layer (declared with [WithLayer] / [Map.AddLayer]).
+// The [MapEvent] carries the clicked feature's identifier in
+// [MapEvent.FeatureID] and the click position (Lng/Lat). idProperty names the
+// feature property holding the identifier (default "id"); if that property is
+// absent the GeoJSON feature id is used. Register the same layer twice (or two
+// layers) for independent handlers. Panics like [OnClick] if fn is not a bound
+// method.
+//
+// This is the server-authoritative selection pattern: the click reports which
+// feature was picked, and the handler looks up that feature's data on the
+// server rather than trusting client-sent properties.
+func OnFeatureClick[F via.Action](layerID string, fn F, idProperty ...string) MapOption {
+	method := methodName("OnFeatureClick", fn)
+	idProp := "id"
+	if len(idProperty) > 0 {
+		idProp = idProperty[0]
+	}
+	return func(m *Map) {
+		dom := "viafeatureclick" + strconv.Itoa(m.featureClicks)
+		m.featureClicks++
+		m.handlers = append(m.handlers, handler{
+			domEvent: dom,
+			expr:     "$viaMapFeatureId=evt.detail.fid;$viaMapLng=evt.detail.lng;$viaMapLat=evt.detail.lat;" + cameraExpr + "@post('/_action/" + method + "')",
+			js: fmt.Sprintf("_m.on('click',%s,function(e){var f=e.features&&e.features[0];if(!f)return;"+
+				"var p=f.properties||{};var fid=(p[%s]!=null?p[%s]:f.id);"+
+				"_el.dispatchEvent(new CustomEvent('%s',{detail:{fid:fid,lng:e.lngLat.lng,lat:e.lngLat.lat,"+cameraDetail("_m")+"}}))});"+
+				"_m.on('mouseenter',%s,function(){_m.getCanvas().style.cursor='pointer'});"+
+				"_m.on('mouseleave',%s,function(){_m.getCanvas().style.cursor=''});",
+				jsString(layerID), jsString(idProp), jsString(idProp), dom,
+				jsString(layerID), jsString(layerID)),
+		})
+	}
+}
+
+// OnMapEvent is the escape hatch for any MapLibre map-level event the typed
+// handlers don't cover — double-click, right-click, zoom/rotate end, drag, and
+// the rest. It wires _m.on(eventName, …) and routes the gesture to the bound
+// method, read via [Map.Event]. The live camera (Zoom/Bearing/Pitch) always
+// arrives; Lng/Lat carry the event's pointer position for pointer events
+// (dblclick, contextmenu, mousedown, …) and are 0 for events without one
+// (zoomend, rotateend, …). Panics like [OnClick] if fn is not a bound method.
+//
+//	maplibre.OnMapEvent("dblclick", p.ZoomToHere)
+//	maplibre.OnMapEvent("contextmenu", p.OpenMenu) // right-click
+func OnMapEvent[F via.Action](eventName string, fn F) MapOption {
+	method := methodName("OnMapEvent", fn)
+	return func(m *Map) {
+		dom := "viamapevent" + strconv.Itoa(m.mapEvents)
+		m.mapEvents++
+		m.handlers = append(m.handlers, handler{
+			domEvent: dom,
+			expr:     "$viaMapLng=evt.detail.lng;$viaMapLat=evt.detail.lat;" + cameraExpr + "@post('/_action/" + method + "')",
+			js: fmt.Sprintf("_m.on(%s,function(e){_el.dispatchEvent(new CustomEvent('%s',"+
+				"{detail:{lng:(e&&e.lngLat?e.lngLat.lng:0),lat:(e&&e.lngLat?e.lngLat.lat:0),%s}}))});",
+				jsString(eventName), dom, cameraDetail("_m")),
+		})
+	}
+}
+
+// WithFeatureHover highlights the feature under the cursor in the named layer,
+// entirely client-side (MapLibre feature-state — no server round-trip, so it
+// feels instant). Reference the state in a paint property to style the
+// highlight, e.g. a data-driven fill color:
+//
+//	maplibre.FillLayer("zones", "zones", maplibre.Paint("fill-color",
+//	    []any{"case", []any{"boolean", []any{"feature-state", "hover"}, false},
+//	        "#ffcc00", "#5856d6"}))
+//
+// The layer's source must give its features ids that feature-state can target —
+// add [GenerateFeatureIDs] to the source, or supply your own feature ids.
+func WithFeatureHover(layerID string) MapOption {
+	return func(m *Map) {
+		m.handlers = append(m.handlers, handler{
+			js: fmt.Sprintf("(function(){var _h=null;"+
+				"_m.on('mousemove',%s,function(e){if(e.features.length>0){var f=e.features[0];"+
+				"if(_h)_m.setFeatureState(_h,{hover:false});_h={source:f.source,id:f.id};_m.setFeatureState(_h,{hover:true})}});"+
+				"_m.on('mouseleave',%s,function(){if(_h)_m.setFeatureState(_h,{hover:false});_h=null});})();",
+				jsString(layerID), jsString(layerID)),
+		})
+	}
+}
+
+// Event decodes the gesture payload carried by the action POST into a typed
+// [MapEvent]. Call it at the top of any handler registered with [OnClick] /
+// [OnMoveEnd] / [OnMarkerClick] / [OnMarkerDragEnd] / [OnFeatureClick] /
+// [OnMapEvent]. Read only the fields the firing gesture sets — see [MapEvent]
+// on why untouched fields are not reliably zero.
+func (m *Map) Event(ctx *via.Ctx) MapEvent {
+	var e MapEvent
+	via.DecodeForm(ctx, &e)
+	return e
+}
+
+// methodName resolves a bound method to its action name, panicking with the
+// on-package-style message when fn is not a bound method.
+func methodName(opt string, fn any) string {
+	name := spec.MethodName(fn)
+	if name == "" {
+		panic("maplibre: " + opt + " requires a bound method value (e.g. maplibre.OnClick(p.Place)); got a closure or non-method")
+	}
+	return name
+}

--- a/plugins/maplibre/events_test.go
+++ b/plugins/maplibre/events_test.go
@@ -1,0 +1,607 @@
+package maplibre_test
+
+import (
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-via/via"
+	"github.com/go-via/via/h"
+	"github.com/go-via/via/plugins/maplibre"
+	"github.com/go-via/via/vt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// eventPage binds a Map with both inbound-event handlers registered and
+// surfaces what Map.Event decoded back into patched signals, so a fired
+// action can be asserted on through the SSE frame.
+type eventPage struct {
+	Map *maplibre.Map
+}
+
+func (p *eventPage) OnInit(ctx *via.Ctx) error {
+	if p.Map == nil {
+		p.Map = maplibre.NewMap(
+			maplibre.WithElementID("m"),
+			maplibre.OnClick(p.PlacePin),
+			maplibre.OnMoveEnd(p.Recenter),
+			maplibre.OnMarkerClick(p.Selected),
+			maplibre.OnMarkerDragEnd(p.Moved),
+			maplibre.OnFeatureClick("countries", p.Picked),
+		)
+	}
+	return nil
+}
+
+func (p *eventPage) View(ctx *via.CtxR) h.H { return p.Map.Mount() }
+
+// AddPin emits a draggable marker so the SSE frame carries its listener JS.
+func (p *eventPage) AddPin(ctx *via.Ctx) {
+	p.Map.AddMarker(ctx, "car", maplibre.At(1, 2), maplibre.Draggable())
+}
+
+// Selected / Moved echo the marker identity + position the gesture posted.
+func (p *eventPage) Selected(ctx *via.Ctx) {
+	e := p.Map.Event(ctx)
+	ctx.Patch.Signals(map[string]any{"gotId": e.MarkerID, "gotLng": e.Lng, "gotLat": e.Lat})
+}
+
+func (p *eventPage) Moved(ctx *via.Ctx) {
+	e := p.Map.Event(ctx)
+	ctx.Patch.Signals(map[string]any{"gotId": e.MarkerID, "gotLng": e.Lng, "gotLat": e.Lat})
+}
+
+// Picked echoes which feature the user clicked in a data layer.
+func (p *eventPage) Picked(ctx *via.Ctx) {
+	e := p.Map.Event(ctx)
+	ctx.Patch.Signals(map[string]any{"gotFid": e.FeatureID, "gotLng": e.Lng, "gotLat": e.Lat})
+}
+
+// PlacePin echoes the clicked coordinates back as signals.
+func (p *eventPage) PlacePin(ctx *via.Ctx) {
+	e := p.Map.Event(ctx)
+	ctx.Patch.Signals(map[string]any{"gotLng": e.Lng, "gotLat": e.Lat})
+}
+
+// Recenter echoes the settled viewport back as signals.
+func (p *eventPage) Recenter(ctx *via.Ctx) {
+	e := p.Map.Event(ctx)
+	ctx.Patch.Signals(map[string]any{
+		"gotZoom": e.Zoom, "gotBearing": e.Bearing, "gotPitch": e.Pitch,
+		"gotW": e.West, "gotS": e.South, "gotE": e.East, "gotN": e.North,
+	})
+}
+
+// newEventMap builds a Map with the given handlers, off-page, for render
+// assertions. The receiver supplies bound methods spec.MethodName can name.
+func newEventMap(opts ...maplibre.MapOption) *maplibre.Map {
+	base := []maplibre.MapOption{maplibre.WithElementID("m")}
+	return maplibre.NewMap(append(base, opts...)...)
+}
+
+func TestMap_OnClick_letsTheBasemapDriveAGoAction(t *testing.T) {
+	t.Parallel()
+	// A click handler is the foundation of click-to-place: the basemap click
+	// must reach a named Go action carrying the clicked lng/lat as signals.
+	p := &eventPage{}
+	html := render(t, newEventMap(maplibre.OnClick(p.PlacePin)))
+
+	assert.Contains(t, html, "data-on:viamapclick",
+		"the container must listen for the dispatched click event")
+	assert.Contains(t, html, "/_action/PlacePin",
+		"the click must POST to the bound method's action endpoint")
+	assert.Contains(t, html, "$viaMapLng=evt.detail.lng",
+		"the clicked longitude must be written to the shared signal")
+	assert.Contains(t, html, "$viaMapLat=evt.detail.lat",
+		"the clicked latitude must be written to the shared signal")
+	assert.Contains(t, html, ".on('click'",
+		"initJS must subscribe to MapLibre's click event")
+	assert.Contains(t, html, "CustomEvent('viamapclick'",
+		"the click listener must dispatch the custom event the container listens for")
+	assert.Contains(t, html, "e.lngLat.lng",
+		"the dispatched detail must carry MapLibre's lngLat")
+}
+
+func TestMap_OnMoveEnd_letsCameraSettleDriveAGoAction(t *testing.T) {
+	t.Parallel()
+	// moveend powers viewport-driven loading: after a pan/zoom the server
+	// needs the new center, zoom, and bounding box to fetch what's in view.
+	p := &eventPage{}
+	html := render(t, newEventMap(maplibre.OnMoveEnd(p.Recenter)))
+
+	assert.Contains(t, html, "data-on:viamapmove",
+		"the container must listen for the dispatched move event")
+	assert.Contains(t, html, "/_action/Recenter",
+		"the move must POST to the bound method's action endpoint")
+	// Every viewport field a moveend carries must be written, or a handler
+	// reading e.Bearing/e.Pitch/e.South/e.East silently gets stale zeros.
+	for _, sig := range []string{
+		"$viaMapZoom=evt.detail.zoom", "$viaMapBearing=evt.detail.bearing",
+		"$viaMapPitch=evt.detail.pitch", "$viaMapW=evt.detail.w",
+		"$viaMapS=evt.detail.s", "$viaMapE=evt.detail.e", "$viaMapN=evt.detail.n",
+	} {
+		assert.Contains(t, html, sig, "moveend must write every viewport signal")
+	}
+	assert.Contains(t, html, ".on('moveend'",
+		"initJS must subscribe to MapLibre's moveend event")
+	for _, read := range []string{
+		"getBounds()", "getCenter()", "getZoom()", "getBearing()", "getPitch()",
+		"getWest()", "getSouth()", "getEast()", "getNorth()",
+	} {
+		assert.Contains(t, html, read, "the moveend listener must read every viewport value")
+	}
+}
+
+func TestMap_OnClick_carriesLiveCameraSoZoomIsNeverStale(t *testing.T) {
+	t.Parallel()
+	// A click handler often needs the current zoom (decide marker detail, snap
+	// precision). Every gesture must carry the LIVE camera, so reading e.Zoom
+	// in a click handler is fresh — not a leftover from the last moveend.
+	p := &eventPage{}
+	html := render(t, newEventMap(maplibre.OnClick(p.PlacePin)))
+
+	for _, sig := range []string{
+		"$viaMapZoom=evt.detail.zoom", "$viaMapBearing=evt.detail.bearing", "$viaMapPitch=evt.detail.pitch",
+	} {
+		assert.Contains(t, html, sig, "a click must write the live camera signals")
+	}
+	for _, read := range []string{"zoom:_m.getZoom()", "bearing:_m.getBearing()", "pitch:_m.getPitch()"} {
+		assert.Contains(t, html, read, "the click listener must read the camera at click time")
+	}
+	// Camera must be ADDITIVE — the click point (lng/lat) must still be carried,
+	// not replaced by the camera fields.
+	assert.Contains(t, html, "$viaMapLng=evt.detail.lng", "the click point must still be carried")
+	assert.Contains(t, html, "$viaMapLat=evt.detail.lat", "the click point must still be carried")
+}
+
+func TestMap_OnFeatureClick_carriesLiveCamera(t *testing.T) {
+	t.Parallel()
+	p := &eventPage{}
+	html := render(t, newEventMap(maplibre.OnFeatureClick("countries", p.Picked)))
+
+	assert.Contains(t, html, "$viaMapZoom=evt.detail.zoom",
+		"a feature click must write the live camera signals")
+	assert.Contains(t, html, "zoom:_m.getZoom()",
+		"the feature-click listener must read the camera at click time")
+}
+
+func TestMap_OnMarkerClick_carriesLiveCameraInExpr(t *testing.T) {
+	t.Parallel()
+	p := &eventPage{}
+	html := render(t, newEventMap(maplibre.OnMarkerClick(p.Selected)))
+	assert.Contains(t, html, "$viaMapZoom=evt.detail.zoom",
+		"a marker click must write the live camera signals")
+}
+
+func TestMap_OnMarkerDragEnd_carriesLiveCameraInExpr(t *testing.T) {
+	t.Parallel()
+	p := &eventPage{}
+	html := render(t, newEventMap(maplibre.OnMarkerDragEnd(p.Moved)))
+	assert.Contains(t, html, "$viaMapZoom=evt.detail.zoom",
+		"a marker drag-end must write the live camera signals")
+}
+
+func TestMap_OnMapEvent_wiresAnyMapLibreEventToAGoAction(t *testing.T) {
+	t.Parallel()
+	// The typed handlers cover the common gestures; OnMapEvent is the escape
+	// hatch so a dev is never blocked by a missing inbound event (dblclick,
+	// contextmenu, …). It must carry the pointer position and the live camera.
+	p := &eventPage{}
+	html := render(t, newEventMap(maplibre.OnMapEvent("dblclick", p.PlacePin)))
+
+	assert.Contains(t, html, "data-on:viamapevent0",
+		"the container must listen for the dispatched generic event")
+	assert.Contains(t, html, `_m.on("dblclick"`,
+		"initJS must subscribe to the named MapLibre event")
+	assert.Contains(t, html, "/_action/PlacePin",
+		"the event must POST to the bound method's action endpoint")
+	assert.Contains(t, html, "$viaMapLng=evt.detail.lng")
+	assert.Contains(t, html, "$viaMapZoom=evt.detail.zoom",
+		"a generic event must still carry the live camera")
+	assert.Contains(t, html, "e.lngLat?e.lngLat.lng:0",
+		"the detail must guard lngLat — some events have no pointer position")
+}
+
+func TestMap_OnMapEvent_distinctEventsRouteIndependently(t *testing.T) {
+	t.Parallel()
+	// dblclick and right-click must reach their own actions, not collide.
+	p := &eventPage{}
+	html := render(t, newEventMap(
+		maplibre.OnMapEvent("dblclick", p.PlacePin),
+		maplibre.OnMapEvent("contextmenu", p.Recenter),
+	))
+	assert.Contains(t, html, "data-on:viamapevent0")
+	assert.Contains(t, html, "data-on:viamapevent1")
+	assert.Contains(t, html, `_m.on("dblclick"`)
+	assert.Contains(t, html, `_m.on("contextmenu"`)
+	assert.Contains(t, html, "/_action/PlacePin")
+	assert.Contains(t, html, "/_action/Recenter")
+}
+
+func TestMap_OnMapEvent_carriesCameraEvenForPointerlessEvents(t *testing.T) {
+	t.Parallel()
+	// zoomend/rotateend have no lngLat, but the camera is exactly what such an
+	// event is about — it must still arrive.
+	p := &eventPage{}
+	html := render(t, newEventMap(maplibre.OnMapEvent("zoomend", p.Recenter)))
+	assert.Contains(t, html, `_m.on("zoomend"`)
+	assert.Contains(t, html, "$viaMapZoom=evt.detail.zoom",
+		"a pointerless event must still carry the live camera")
+}
+
+func TestOnMapEvent_panicsOnNonBoundMethod(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() {
+		maplibre.NewMap(maplibre.OnMapEvent("dblclick", func(ctx *via.Ctx) {}))
+	})
+}
+
+func TestInlinedIdentifiers_escapeSingleQuotesSoTheyCannotBreakOut(t *testing.T) {
+	t.Parallel()
+	// Layer ids / event names are inlined into JS next to single-quoted
+	// literals. json.Marshal leaves a single quote raw, so jsString must escape
+	// it (to ') — a malicious or odd id can't break out of the script.
+	html := render(t, maplibre.NewMap(
+		maplibre.WithElementID("m"),
+		maplibre.WithFeatureHover("a');evil();//"),
+	))
+	assert.Contains(t, html, `a'`, "the single quote must be unicode-escaped")
+	assert.NotContains(t, html, `'a');evil`, "the raw single-quoted breakout must not appear")
+}
+
+func TestMap_WithFeatureHover_highlightsHoveredFeatureClientSide(t *testing.T) {
+	t.Parallel()
+	// Hover-to-highlight is the signature interactive-map behavior. It must be
+	// pure client JS (feature-state, no server round-trip) so it feels instant.
+	html := render(t, maplibre.NewMap(maplibre.WithElementID("m"), maplibre.WithFeatureHover("zones")))
+
+	assert.Contains(t, html, `.on('mousemove',"zones"`,
+		"hovering a feature in the layer must be tracked")
+	assert.Contains(t, html, `.on('mouseleave',"zones"`,
+		"leaving the layer must clear the highlight")
+	assert.Contains(t, html, "setFeatureState",
+		"the highlight must be driven by MapLibre feature-state")
+	assert.Contains(t, html, "{hover:true}",
+		"the hovered feature must enter the hover state")
+	assert.Contains(t, html, "{hover:false}",
+		"the previously hovered feature must leave the hover state")
+}
+
+func TestMap_WithFeatureHover_emitsNoActionAttribute(t *testing.T) {
+	t.Parallel()
+	// Hover is client-only — it must NOT emit a data-on attribute, and above
+	// all not a malformed empty one (datastar rejects data-on:= with
+	// ValueRequired and freezes the page).
+	html := render(t, maplibre.NewMap(maplibre.WithElementID("m"), maplibre.WithFeatureHover("zones")))
+
+	assert.NotContains(t, html, "data-on:=",
+		"a client-only handler must not emit an empty data-on attribute")
+	assert.NotContains(t, html, `data-on:"`,
+		"a client-only handler must not emit a malformed empty-event data-on attribute")
+}
+
+func TestMap_actionHandlerStillEmitsDataOn_afterJSOnlyHandlerSupport(t *testing.T) {
+	t.Parallel()
+	// The domEvent!="" guard that lets hover be attribute-less must NOT drop
+	// real action handlers — OnClick must still wire its data-on.
+	p := &eventPage{}
+	html := render(t, newEventMap(
+		maplibre.OnClick(p.PlacePin),
+		maplibre.WithFeatureHover("zones"),
+	))
+	assert.Contains(t, html, "data-on:viamapclick",
+		"a real action handler must still emit its data-on alongside a hover handler")
+	assert.Contains(t, html, `.on('mousemove',"zones"`,
+		"the hover handler must still wire its client JS")
+}
+
+func TestMap_bothHandlers_coexistOnOneMap(t *testing.T) {
+	t.Parallel()
+	// Registering click AND moveend on the same map must wire both — a
+	// shared storage slot that the second handler clobbers would silently
+	// drop one gesture.
+	p := &eventPage{}
+	html := render(t, newEventMap(
+		maplibre.OnClick(p.PlacePin),
+		maplibre.OnMoveEnd(p.Recenter),
+	))
+	assert.Contains(t, html, "data-on:viamapclick")
+	assert.Contains(t, html, "data-on:viamapmove")
+	assert.Contains(t, html, "/_action/PlacePin")
+	assert.Contains(t, html, "/_action/Recenter")
+	assert.Contains(t, html, ".on('click'")
+	assert.Contains(t, html, ".on('moveend'")
+}
+
+func TestMap_OnMarkerClick_routesMarkerIdentityToAGoAction(t *testing.T) {
+	t.Parallel()
+	// Selecting a feature is the core of any pin-based app: a marker click must
+	// reach a Go action carrying which marker (id) and where (lng/lat).
+	p := &eventPage{}
+	html := render(t, newEventMap(maplibre.OnMarkerClick(p.Selected)))
+
+	assert.Contains(t, html, "data-on:viamarkerclick",
+		"the container must listen for the dispatched marker-click event")
+	assert.Contains(t, html, "/_action/Selected",
+		"the marker click must POST to the bound method's action endpoint")
+	assert.Contains(t, html, "$viaMapId=evt.detail.id",
+		"the clicked marker's id must be written to the shared signal")
+	assert.Contains(t, html, "$viaMapLng=evt.detail.lng")
+	assert.Contains(t, html, "$viaMapLat=evt.detail.lat")
+}
+
+func TestMap_OnMarkerDragEnd_routesDroppedPositionToAGoAction(t *testing.T) {
+	t.Parallel()
+	// Drag-to-reposition (move a vehicle, adjust a geofence) needs the dropped
+	// marker's id and its new lng/lat to reach Go.
+	p := &eventPage{}
+	html := render(t, newEventMap(maplibre.OnMarkerDragEnd(p.Moved)))
+
+	assert.Contains(t, html, "data-on:viamarkerdragend",
+		"the container must listen for the dispatched drag-end event")
+	assert.Contains(t, html, "/_action/Moved")
+	assert.Contains(t, html, "$viaMapId=evt.detail.id")
+	assert.Contains(t, html, "$viaMapLng=evt.detail.lng")
+	assert.Contains(t, html, "$viaMapLat=evt.detail.lat")
+}
+
+func TestMap_AddMarker_attachesClickListenerOnlyWhenHandlerRegistered(t *testing.T) {
+	t.Parallel()
+	// The listener must dispatch the custom event the container routes, stop
+	// propagation so the basemap OnClick doesn't also fire, and carry the
+	// marker's own id + live position.
+	frame := fireEventAction(t, "AddPin", nil, "setLngLat")
+	assert.Contains(t, frame, "addEventListener('click'",
+		"a registered marker-click handler must wire the marker element")
+	assert.Contains(t, frame, "viamarkerclick",
+		"the listener must dispatch the event the container listens for")
+	assert.Contains(t, frame, "stopPropagation",
+		"a marker click must not also trigger the basemap click handler")
+	assert.Contains(t, frame, "getContainer()",
+		"the event must be dispatched on the map container that carries data-on")
+	assert.Contains(t, frame, `id:"car"`,
+		"the dispatched detail must carry this marker's own id (bound to the detail, not just the registry key)")
+	assert.Contains(t, frame, "getElement().style.cursor='pointer'",
+		"a clickable marker must show a pointer cursor so it reads as clickable")
+	assert.Contains(t, frame, "zoom:_e.m.getZoom()",
+		"the marker-click detail must carry the live camera so e.Zoom is fresh")
+}
+
+func TestMap_AddMarker_attachesDragEndListenerWhenHandlerRegistered(t *testing.T) {
+	t.Parallel()
+	frame := fireEventAction(t, "AddPin", nil, "setLngLat")
+	assert.Contains(t, frame, ".on('dragend'",
+		"a registered drag-end handler must subscribe to the marker's dragend")
+	assert.Contains(t, frame, "viamarkerdragend",
+		"the drag-end listener must dispatch the event the container listens for")
+	assert.Contains(t, frame, "zoom:_e.m.getZoom()",
+		"the drag-end detail must carry the live camera so e.Zoom is fresh")
+}
+
+func TestMap_OnFeatureClick_routesClickedFeatureToAGoAction(t *testing.T) {
+	t.Parallel()
+	// Clicking a rendered shape (a country, a route, a zone) must tell Go WHICH
+	// feature — by an identifying property — so a server-authoritative app can
+	// look up that feature's data.
+	p := &eventPage{}
+	html := render(t, newEventMap(maplibre.OnFeatureClick("countries", p.Picked)))
+
+	assert.Contains(t, html, "data-on:viafeatureclick0",
+		"the container must listen for the dispatched feature-click event")
+	assert.Contains(t, html, "/_action/Picked",
+		"the feature click must POST to the bound method's action endpoint")
+	assert.Contains(t, html, "$viaMapFeatureId=evt.detail.fid",
+		"the clicked feature's id must be written to the shared signal")
+	assert.Contains(t, html, "$viaMapLng=evt.detail.lng")
+	assert.Contains(t, html, "$viaMapLat=evt.detail.lat")
+	assert.Contains(t, html, `.on('click',"countries"`,
+		"initJS must subscribe to layer-scoped clicks on the named layer")
+	assert.Contains(t, html, "e.features",
+		"the listener must read the clicked features under the cursor")
+	assert.Contains(t, html, "f.properties",
+		"the listener must read the clicked feature's properties")
+	assert.Contains(t, html, `p["id"]`,
+		"the default identifier property 'id' must be the property read from the feature")
+	assert.Contains(t, html, ":f.id",
+		"when the named property is absent the GeoJSON feature id must be the fallback")
+}
+
+func TestMap_OnFeatureClick_showsPointerCursorOnHover(t *testing.T) {
+	t.Parallel()
+	// A filled polygon or line gives no hint it's clickable. The pointer
+	// cursor on hover is the standard map affordance — without it the feature
+	// looks inert.
+	p := &eventPage{}
+	html := render(t, newEventMap(maplibre.OnFeatureClick("countries", p.Picked)))
+
+	assert.Contains(t, html, `.on('mouseenter',"countries"`,
+		"hovering a clickable layer must be detected")
+	assert.Contains(t, html, `.on('mouseleave',"countries"`,
+		"leaving the layer must be detected to restore the cursor")
+	assert.Contains(t, html, "cursor='pointer'",
+		"the cursor must become a pointer over a clickable feature")
+	assert.Contains(t, html, "cursor=''",
+		"the cursor must reset when the pointer leaves the feature")
+	assert.Contains(t, html, `.on('click',"countries"`,
+		"the click subscription must remain")
+}
+
+func TestMap_OnFeatureClick_honorsConfiguredIdProperty(t *testing.T) {
+	t.Parallel()
+	// Real datasets key features on their own property (iso code, FIPS, a DB
+	// id) — not always a GeoJSON top-level id. The handler must read it.
+	p := &eventPage{}
+	html := render(t, newEventMap(maplibre.OnFeatureClick("countries", p.Picked, "iso")))
+	assert.Contains(t, html, `p["iso"]`,
+		"a configured idProperty must be the property read from the feature")
+}
+
+func TestMap_OnFeatureClick_distinctLayersRouteToDistinctActions(t *testing.T) {
+	t.Parallel()
+	// Two layers, two handlers: each must dispatch its own event to its own
+	// action, or one layer's clicks would be swallowed by the other.
+	p := &eventPage{}
+	html := render(t, newEventMap(
+		maplibre.OnFeatureClick("countries", p.Picked),
+		maplibre.OnFeatureClick("cities", p.Selected),
+	))
+	assert.Contains(t, html, "data-on:viafeatureclick0")
+	assert.Contains(t, html, "data-on:viafeatureclick1")
+	assert.Contains(t, html, "/_action/Picked")
+	assert.Contains(t, html, "/_action/Selected")
+	assert.Contains(t, html, `.on('click',"countries"`)
+	assert.Contains(t, html, `.on('click',"cities"`)
+}
+
+func TestOnFeatureClick_panicsOnNonBoundMethod(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() {
+		maplibre.NewMap(maplibre.OnFeatureClick("countries", func(ctx *via.Ctx) {}))
+	})
+}
+
+func TestMap_Event_returnsClickedFeatureIdPostedFromTheBrowser(t *testing.T) {
+	t.Parallel()
+	// The selected feature's id must round-trip so the handler can look up its
+	// server-side record.
+	frame := fireEventAction(t, "Picked",
+		map[string]any{"viaMapFeatureId": "country-DE", "viaMapLng": 10.25, "viaMapLat": 51.0},
+		"gotFid")
+	assert.Contains(t, frame, `"gotFid":"country-DE"`, "the clicked feature's id must reach the handler")
+	assert.Contains(t, frame, `"gotLng":10.25`, "the click longitude must reach the handler")
+}
+
+func TestMap_AddMarker_skipsListenersWhenNoMarkerHandlerRegistered(t *testing.T) {
+	t.Parallel()
+	// A map with no marker handlers must not pay for listeners — fireMapAction
+	// uses a page that registers none.
+	frame := fireMapAction(t, "AddMarker", "setLngLat")
+	assert.Contains(t, frame, "setLngLat",
+		"the marker is still created — so the NotContains below is meaningful, not vacuous")
+	assert.NotContains(t, frame, "viamarkerclick")
+	assert.NotContains(t, frame, "viamarkerdragend")
+	assert.NotContains(t, frame, "cursor='pointer'",
+		"a marker with no click handler must not be dressed up as clickable")
+}
+
+func TestMap_withoutHandlers_emitsNoEventWiring(t *testing.T) {
+	t.Parallel()
+	// A purely server-driven map must not pay for listeners it never uses,
+	// nor open an action endpoint the developer never wired.
+	html := render(t, maplibre.NewMap(maplibre.WithElementID("m")))
+
+	assert.NotContains(t, html, "viamapclick")
+	assert.NotContains(t, html, "viamapmove")
+}
+
+func TestMap_eventSignals_areNotDatastarLocalSignals(t *testing.T) {
+	t.Parallel()
+	// Datastar never sends signals whose name starts with "_" to the server —
+	// they are client-only "local" signals. If any inbound-event signal used a
+	// leading underscore, every gesture would post empty data and the handler
+	// would silently read zeros. Guard the wire keys against that whole class
+	// of bug (the vt harness can't catch it — it injects signals directly into
+	// the POST body, bypassing datastar's client-side filtering).
+	p := &eventPage{}
+	html := render(t, newEventMap(
+		maplibre.OnClick(p.PlacePin),
+		maplibre.OnMoveEnd(p.Recenter),
+		maplibre.OnMarkerClick(p.Selected),
+		maplibre.OnMarkerDragEnd(p.Moved),
+	))
+	assert.NotContains(t, html, "$_",
+		"event signals must not start with '_' — datastar drops local signals before posting")
+
+	// And the read side: every MapEvent form tag must be a sendable key too.
+	for _, e := range reflect.VisibleFields(reflect.TypeOf(maplibre.MapEvent{})) {
+		tag := e.Tag.Get("form")
+		require.NotEmpty(t, tag, "every MapEvent field needs a form tag")
+		assert.False(t, strings.HasPrefix(tag, "_"),
+			"MapEvent.%s form key %q starts with '_' — datastar won't send it", e.Name, tag)
+	}
+}
+
+func TestOnClick_panicsOnNonBoundMethod(t *testing.T) {
+	t.Parallel()
+	// Mirrors the on package: a closure or top-level func has no stable
+	// action name, so the mistake must surface at construction, not silently.
+	assert.Panics(t, func() {
+		maplibre.NewMap(maplibre.OnClick(func(ctx *via.Ctx) {}))
+	})
+}
+
+func TestOnMoveEnd_panicsOnNonBoundMethod(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() {
+		maplibre.NewMap(maplibre.OnMoveEnd(func(ctx *via.Ctx) {}))
+	})
+}
+
+// fireEventAction boots the eventPage app, fires the named action with the
+// given signals attached, and returns the frame once every needle appears.
+func fireEventAction(t *testing.T, action string, sigs map[string]any, needles ...string) string {
+	t.Helper()
+
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	via.Mount[eventPage](app, "/")
+	t.Cleanup(server.Close)
+
+	tc := vt.NewClient(t, server, "/")
+	frames, cancel := tc.SSEReady()
+	t.Cleanup(cancel)
+
+	call := tc.Action(action)
+	for k, v := range sigs {
+		call = call.WithSignal(k, v)
+	}
+	require.Equal(t, 200, call.Fire())
+	return vt.AwaitFrame(t, frames, 2*time.Second, needles...)
+}
+
+func TestMap_Event_returnsClickedCoordinatesPostedFromTheBrowser(t *testing.T) {
+	t.Parallel()
+	// The whole point: a click in the browser must round-trip into the typed
+	// lng/lat the Go handler reads via Map.Event.
+	frame := fireEventAction(t, "PlacePin",
+		map[string]any{"viaMapLng": -122.42, "viaMapLat": 37.77},
+		"gotLng")
+	// Bind value to its signal key so a stray "37.77" elsewhere in the frame
+	// can't pass the test for the wrong reason.
+	assert.Contains(t, frame, `"gotLng":-122.42`, "the clicked longitude must reach the handler")
+	assert.Contains(t, frame, `"gotLat":37.77`, "the clicked latitude must reach the handler")
+}
+
+func TestMap_Event_returnsClickedMarkerIdentityPostedFromTheBrowser(t *testing.T) {
+	t.Parallel()
+	// The marker's id must round-trip so the handler knows which pin was
+	// selected, not just where it sits.
+	frame := fireEventAction(t, "Selected",
+		map[string]any{"viaMapId": "vehicle-7", "viaMapLng": 13.4, "viaMapLat": 52.5},
+		"gotId")
+	assert.Contains(t, frame, `"gotId":"vehicle-7"`, "the selected marker's id must reach the handler")
+	assert.Contains(t, frame, `"gotLng":13.4`, "the marker's longitude must reach the handler")
+	assert.Contains(t, frame, `"gotLat":52.5`, "the marker's latitude must reach the handler")
+}
+
+func TestMap_Event_returnsSettledViewportPostedFromTheBrowser(t *testing.T) {
+	t.Parallel()
+	// Viewport-driven loading depends on the bounding box and zoom surviving
+	// the round-trip into Map.Event.
+	frame := fireEventAction(t, "Recenter",
+		map[string]any{
+			"viaMapZoom": 9.5, "viaMapBearing": 33.5, "viaMapPitch": 12.5,
+			"viaMapW": -10.5, "viaMapS": 40.25, "viaMapE": 5.75, "viaMapN": 55.25,
+		},
+		"gotZoom")
+	assert.Contains(t, frame, `"gotZoom":9.5`, "the settled zoom must reach the handler")
+	assert.Contains(t, frame, `"gotBearing":33.5`, "the bearing must reach the handler")
+	assert.Contains(t, frame, `"gotPitch":12.5`, "the pitch must reach the handler")
+	assert.Contains(t, frame, `"gotW":-10.5`, "the west bound must reach the handler")
+	assert.Contains(t, frame, `"gotS":40.25`, "the south bound must reach the handler")
+	assert.Contains(t, frame, `"gotE":5.75`, "the east bound must reach the handler")
+	assert.Contains(t, frame, `"gotN":55.25`, "the north bound must reach the handler")
+}

--- a/plugins/maplibre/expr.go
+++ b/plugins/maplibre/expr.go
@@ -1,0 +1,95 @@
+package maplibre
+
+// Expr is a MapLibre style expression — the JSON array form MapLibre evaluates
+// for data-driven paint and layout values (see the MapLibre "expressions"
+// docs). It is a type alias for []any, so the builders below remain fully
+// interchangeable with raw []any: you can nest a hand-written []any inside a
+// [Case], or pass a builder result straight to [Paint] / [Layout] / [Filter].
+type Expr = []any
+
+// Get reads a feature property, e.g. Get("population") -> ["get","population"].
+func Get(property string) Expr { return Expr{"get", property} }
+
+// FeatureState reads a feature-state key set at runtime (see [WithFeatureHover]),
+// e.g. FeatureState("hover") -> ["feature-state","hover"].
+func FeatureState(key string) Expr { return Expr{"feature-state", key} }
+
+// Zoom is the current map zoom as an expression input — pair with [Interpolate]
+// or [Step] for zoom-responsive styling.
+func Zoom() Expr { return Expr{"zoom"} }
+
+// Boolean coerces value to a boolean, using fallback when it is null/undefined.
+// It's what makes a [FeatureState] read safe inside a [Case] test, since the
+// state is undefined on features the user hasn't touched.
+func Boolean(value any, fallback bool) Expr { return Expr{"boolean", value, fallback} }
+
+// Branch is one when→then arm of a [Case].
+type Branch struct {
+	When any // a boolean expression
+	Then any // the value to use when When is true
+}
+
+// Case picks the Then of the first Branch whose When is true, else fallback —
+// ["case", w1, t1, …, fallback].
+//
+// MapLibre requires at least one when→then pair, so a bare ["case", fallback]
+// is rejected at style-parse time. With no branches Case therefore yields a
+// valid standalone expression instead: an expression fallback is returned
+// unchanged, and a scalar fallback is wrapped as ["literal", fallback].
+func Case(fallback any, branches ...Branch) Expr {
+	if len(branches) == 0 {
+		// Expr is an alias for []any, so this also matches a builder result
+		// (e.g. Get) passed straight in as the fallback.
+		if e, ok := fallback.([]any); ok {
+			return e
+		}
+		return Expr{"literal", fallback}
+	}
+	out := Expr{"case"}
+	for _, b := range branches {
+		out = append(out, b.When, b.Then)
+	}
+	return append(out, fallback)
+}
+
+// Stop is one input→output stop of an [Interpolate] or [Step] ramp.
+type Stop struct {
+	At    float64 // the input value (e.g. a zoom level)
+	Value any     // the output at that input
+}
+
+// Interpolate linearly ramps output values across input stops — the workhorse
+// for zoom-responsive sizing, e.g. line width 2 at z5 growing to 6 at z12:
+//
+//	maplibre.Interpolate(maplibre.Zoom(),
+//	    maplibre.Stop{At: 5, Value: 2}, maplibre.Stop{At: 12, Value: 6})
+func Interpolate(input Expr, stops ...Stop) Expr {
+	out := Expr{"interpolate", Expr{"linear"}, input}
+	for _, s := range stops {
+		out = append(out, s.At, s.Value)
+	}
+	return out
+}
+
+// Step produces a stepped (non-interpolated) ramp: base below the first stop,
+// then each stop's Value at and above its input — ["step", input, base, …].
+func Step(input Expr, base any, stops ...Stop) Expr {
+	out := Expr{"step", input, base}
+	for _, s := range stops {
+		out = append(out, s.At, s.Value)
+	}
+	return out
+}
+
+// WhenState returns on while the feature-state key is truthy, else off — the
+// data-driven highlight pattern. Pair the key with the runtime state you set
+// (e.g. "hover" from [WithFeatureHover], or your own "selected").
+func WhenState(key string, on, off any) Expr {
+	return Case(off, Branch{When: Boolean(FeatureState(key), false), Then: on})
+}
+
+// WhenHovered returns on while the feature is hovered (via [WithFeatureHover]),
+// else off:
+//
+//	maplibre.Paint("fill-color", maplibre.WhenHovered("#ffcc00", "#5856d6"))
+func WhenHovered(on, off any) Expr { return WhenState("hover", on, off) }

--- a/plugins/maplibre/expr_test.go
+++ b/plugins/maplibre/expr_test.go
@@ -1,0 +1,109 @@
+package maplibre_test
+
+import (
+	"testing"
+
+	"github.com/go-via/via/plugins/maplibre"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGet_readsAFeatureProperty(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, []any{"get", "name"}, []any(maplibre.Get("name")))
+}
+
+func TestFeatureState_readsAFeatureStateKey(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, []any{"feature-state", "hover"}, []any(maplibre.FeatureState("hover")))
+}
+
+func TestZoom_isTheZoomInputExpression(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, []any{"zoom"}, []any(maplibre.Zoom()))
+}
+
+func TestBoolean_coercesWithAFallback(t *testing.T) {
+	t.Parallel()
+	// A feature-state read can be undefined on un-hovered features; boolean()
+	// with a fallback is what makes a case test safe.
+	assert.Equal(t, []any{"boolean", maplibre.FeatureState("hover"), false},
+		[]any(maplibre.Boolean(maplibre.FeatureState("hover"), false)))
+}
+
+func TestCase_emitsWhenThenPairsThenFallback(t *testing.T) {
+	t.Parallel()
+	got := maplibre.Case("base",
+		maplibre.Branch{When: "w1", Then: "t1"},
+		maplibre.Branch{When: "w2", Then: "t2"},
+	)
+	assert.Equal(t, []any{"case", "w1", "t1", "w2", "t2", "base"}, []any(got))
+}
+
+func TestCase_withNoBranchesIsAValidFallbackExpression(t *testing.T) {
+	t.Parallel()
+	// MapLibre's case requires at least one when/then pair before the fallback:
+	// ["case", fallback] is rejected at style-parse time ("Expected at least 4
+	// arguments"). With no branches we must not emit that invalid shape — a
+	// scalar fallback becomes ["literal", fallback], a valid constant expression.
+	assert.Equal(t, []any{"literal", "base"}, []any(maplibre.Case("base")))
+}
+
+func TestCase_withNoBranchesPassesThroughAnExpressionFallback(t *testing.T) {
+	t.Parallel()
+	// An expression fallback is already valid on its own, so return it as-is
+	// rather than wrapping it in a degenerate (and invalid) case.
+	assert.Equal(t, []any{"get", "color"},
+		[]any(maplibre.Case(maplibre.Get("color"))))
+}
+
+func TestInterpolate_linearlyRampsOutputsAcrossInputStops(t *testing.T) {
+	t.Parallel()
+	// The workhorse for zoom-responsive sizing — line width 2 at z5, 6 at z12.
+	got := maplibre.Interpolate(maplibre.Zoom(),
+		maplibre.Stop{At: 5, Value: 2},
+		maplibre.Stop{At: 12, Value: 6},
+	)
+	assert.Equal(t, []any{"interpolate", []any{"linear"}, []any{"zoom"}, 5.0, 2, 12.0, 6},
+		[]any(got))
+}
+
+func TestStep_emitsBaseThenStops(t *testing.T) {
+	t.Parallel()
+	got := maplibre.Step(maplibre.Zoom(), "small",
+		maplibre.Stop{At: 8, Value: "big"},
+	)
+	assert.Equal(t, []any{"step", []any{"zoom"}, "small", 8.0, "big"}, []any(got))
+}
+
+func TestWhenHovered_isDropInForTheHandWrittenHoverExpression(t *testing.T) {
+	t.Parallel()
+	// This MUST equal the nested expression the example used by hand, so the
+	// sugar is a true drop-in and a future refactor can't silently change the
+	// shape MapLibre receives.
+	handWritten := []any{"case",
+		[]any{"boolean", []any{"feature-state", "hover"}, false},
+		"#ffcc00", "#5856d6"}
+	assert.Equal(t, handWritten, []any(maplibre.WhenHovered("#ffcc00", "#5856d6")))
+}
+
+func TestWhenState_generalizesHoverToAnyStateKey(t *testing.T) {
+	t.Parallel()
+	// Selection highlighting reuses the same shape with a different key.
+	assert.Equal(t, []any{"case",
+		[]any{"boolean", []any{"feature-state", "selected"}, false},
+		"#f00", "#999"},
+		[]any(maplibre.WhenState("selected", "#f00", "#999")))
+}
+
+func TestWhenHovered_dropsIntoPaintWithIdenticalJSON(t *testing.T) {
+	t.Parallel()
+	// Backward-compatible: feeding the sugar to Paint must marshal identically
+	// to feeding the raw []any, so existing layers keep working.
+	sugar := maplibre.FillLayer("zones", "zones",
+		maplibre.Paint("fill-color", maplibre.WhenHovered("#ffcc00", "#5856d6")))
+	raw := maplibre.FillLayer("zones", "zones",
+		maplibre.Paint("fill-color", []any{"case",
+			[]any{"boolean", []any{"feature-state", "hover"}, false},
+			"#ffcc00", "#5856d6"}))
+	assert.JSONEq(t, jsonOf(t, raw), jsonOf(t, sugar))
+}

--- a/plugins/maplibre/helpers_test.go
+++ b/plugins/maplibre/helpers_test.go
@@ -33,37 +33,72 @@ func (p *mapActionPage) View(ctx *via.CtxR) h.H {
 }
 
 // Camera
-func (p *mapActionPage) FlyTo(ctx *via.Ctx)     { p.Map.FlyTo(ctx, -122.42, 37.77, 12) }
-func (p *mapActionPage) EaseTo(ctx *via.Ctx)    { p.Map.EaseTo(ctx, 2.35, 48.85, 9) }
-func (p *mapActionPage) JumpTo(ctx *via.Ctx)    { p.Map.JumpTo(ctx, 139.69, 35.69, 10) }
-func (p *mapActionPage) SetCenter(ctx *via.Ctx) { p.Map.SetCenter(ctx, -0.12, 51.5) }
+func (p *mapActionPage) FlyTo(ctx *via.Ctx)     { p.Map.FlyTo(ctx, maplibre.At(-122.42, 37.77), 12) }
+func (p *mapActionPage) EaseTo(ctx *via.Ctx)    { p.Map.EaseTo(ctx, maplibre.At(2.35, 48.85), 9) }
+func (p *mapActionPage) JumpTo(ctx *via.Ctx)    { p.Map.JumpTo(ctx, maplibre.At(139.69, 35.69), 10) }
+func (p *mapActionPage) SetCenter(ctx *via.Ctx) { p.Map.SetCenter(ctx, maplibre.At(-0.12, 51.5)) }
 func (p *mapActionPage) SetZoom(ctx *via.Ctx)   { p.Map.SetZoom(ctx, 7) }
 func (p *mapActionPage) SetPitch(ctx *via.Ctx)  { p.Map.SetPitch(ctx, 60) }
 func (p *mapActionPage) SetBearing(ctx *via.Ctx) {
 	p.Map.SetBearing(ctx, 90)
 }
-func (p *mapActionPage) FitBounds(ctx *via.Ctx) { p.Map.FitBounds(ctx, -10, 40, 5, 55) }
+func (p *mapActionPage) FitBounds(ctx *via.Ctx) {
+	p.Map.FitBounds(ctx, maplibre.Bounds{West: -10, South: 40, East: 5, North: 55})
+}
 
 // Markers
-func (p *mapActionPage) AddMarker(ctx *via.Ctx) { p.Map.AddMarker(ctx, "a", -122.42, 37.77) }
+func (p *mapActionPage) AddMarker(ctx *via.Ctx) {
+	p.Map.AddMarker(ctx, "a", maplibre.At(-122.42, 37.77))
+}
 func (p *mapActionPage) AddMarkerColor(ctx *via.Ctx) {
-	p.Map.AddMarker(ctx, "a", 1, 2, maplibre.Color("#ff0000"))
+	p.Map.AddMarker(ctx, "a", maplibre.At(1, 2), maplibre.Color("#ff0000"))
 }
 func (p *mapActionPage) AddMarkerPopupText(ctx *via.Ctx) {
-	p.Map.AddMarker(ctx, "a", 1, 2, maplibre.PopupText("Hello there"))
+	p.Map.AddMarker(ctx, "a", maplibre.At(1, 2), maplibre.PopupText("Hello there"))
 }
 func (p *mapActionPage) AddMarkerPopupHTML(ctx *via.Ctx) {
-	p.Map.AddMarker(ctx, "a", 1, 2, maplibre.PopupHTML("<b>trusted</b>"))
+	p.Map.AddMarker(ctx, "a", maplibre.At(1, 2), maplibre.PopupHTML(h.B(h.T("trusted"))))
+}
+func (p *mapActionPage) AddMarkerPopupLastWins(ctx *via.Ctx) {
+	p.Map.AddMarker(ctx, "a", maplibre.At(1, 2),
+		maplibre.PopupHTML(h.B(h.T("html"))), maplibre.PopupText("text"))
 }
 func (p *mapActionPage) AddMarkerXSS(ctx *via.Ctx) {
-	p.Map.AddMarker(ctx, "a", 1, 2, maplibre.PopupText(`</script><img src=x onerror="alert(1)">`))
+	p.Map.AddMarker(ctx, "a", maplibre.At(1, 2), maplibre.PopupText(`</script><img src=x onerror="alert(1)">`))
 }
 func (p *mapActionPage) AddMarkerQuoteID(ctx *via.Ctx) {
-	p.Map.AddMarker(ctx, `a"b`, 1, 2)
+	p.Map.AddMarker(ctx, `a"b`, maplibre.At(1, 2))
 }
-func (p *mapActionPage) MoveMarker(ctx *via.Ctx)   { p.Map.MoveMarker(ctx, "a", 3, 4) }
+func (p *mapActionPage) MoveMarker(ctx *via.Ctx)   { p.Map.MoveMarker(ctx, "a", maplibre.At(3, 4)) }
 func (p *mapActionPage) RemoveMarker(ctx *via.Ctx) { p.Map.RemoveMarker(ctx, "a") }
 func (p *mapActionPage) ClearMarkers(ctx *via.Ctx) { p.Map.ClearMarkers(ctx) }
+
+// Popups (dialogs)
+func (p *mapActionPage) ShowPopup(ctx *via.Ctx) {
+	p.Map.ShowPopup(ctx, "info", maplibre.At(-122.42, 37.77), "Hello there")
+}
+func (p *mapActionPage) ShowPopupHTML(ctx *via.Ctx) {
+	p.Map.ShowPopupHTML(ctx, "info", maplibre.At(1, 2), h.B(h.T("trusted")))
+}
+func (p *mapActionPage) ShowPopupStructured(ctx *via.Ctx) {
+	p.Map.ShowPopupHTML(ctx, "info", maplibre.At(1, 2),
+		h.Div(h.H3(h.T("Title")), h.P(h.T("body text"))))
+}
+func (p *mapActionPage) ShowPopupEscaped(ctx *via.Ctx) {
+	p.Map.ShowPopupHTML(ctx, "info", maplibre.At(1, 2), h.Div(h.T("</script> & <b>evil")))
+}
+func (p *mapActionPage) ShowPopupNilHTML(ctx *via.Ctx) {
+	p.Map.ShowPopupHTML(ctx, "info", maplibre.At(1, 2), nil)
+}
+func (p *mapActionPage) ShowPopupXSS(ctx *via.Ctx) {
+	p.Map.ShowPopup(ctx, "info", maplibre.At(1, 2), `</script><img onerror="alert(1)">`)
+}
+func (p *mapActionPage) ShowPopupOpts(ctx *via.Ctx) {
+	p.Map.ShowPopup(ctx, "info", maplibre.At(1, 2), "x",
+		maplibre.WithoutCloseButton(), maplibre.WithoutCloseOnClick(),
+		maplibre.PopupMaxWidth("240px"), maplibre.PopupClass("card", "lg"))
+}
+func (p *mapActionPage) ClosePopup(ctx *via.Ctx) { p.Map.ClosePopup(ctx, "info") }
 
 // Data
 func (p *mapActionPage) SetGeoJSON(ctx *via.Ctx) error {

--- a/plugins/maplibre/helpers_test.go
+++ b/plugins/maplibre/helpers_test.go
@@ -1,0 +1,126 @@
+package maplibre_test
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-via/via"
+	"github.com/go-via/via/h"
+	"github.com/go-via/via/plugins/maplibre"
+	"github.com/go-via/via/vt"
+	"github.com/stretchr/testify/require"
+)
+
+// mapActionPage binds one Map and exposes every runtime method as an action,
+// so the runtime tests can fire one and assert on the emitted SSE frame.
+type mapActionPage struct {
+	Map *maplibre.Map
+}
+
+func (p *mapActionPage) OnInit(ctx *via.Ctx) error {
+	if p.Map == nil {
+		p.Map = maplibre.NewMap(maplibre.WithElementID("m"))
+	}
+	return nil
+}
+
+func (p *mapActionPage) View(ctx *via.CtxR) h.H {
+	if p.Map == nil {
+		return h.Div()
+	}
+	return p.Map.Mount()
+}
+
+// Camera
+func (p *mapActionPage) FlyTo(ctx *via.Ctx)     { p.Map.FlyTo(ctx, -122.42, 37.77, 12) }
+func (p *mapActionPage) EaseTo(ctx *via.Ctx)    { p.Map.EaseTo(ctx, 2.35, 48.85, 9) }
+func (p *mapActionPage) JumpTo(ctx *via.Ctx)    { p.Map.JumpTo(ctx, 139.69, 35.69, 10) }
+func (p *mapActionPage) SetCenter(ctx *via.Ctx) { p.Map.SetCenter(ctx, -0.12, 51.5) }
+func (p *mapActionPage) SetZoom(ctx *via.Ctx)   { p.Map.SetZoom(ctx, 7) }
+func (p *mapActionPage) SetPitch(ctx *via.Ctx)  { p.Map.SetPitch(ctx, 60) }
+func (p *mapActionPage) SetBearing(ctx *via.Ctx) {
+	p.Map.SetBearing(ctx, 90)
+}
+func (p *mapActionPage) FitBounds(ctx *via.Ctx) { p.Map.FitBounds(ctx, -10, 40, 5, 55) }
+
+// Markers
+func (p *mapActionPage) AddMarker(ctx *via.Ctx) { p.Map.AddMarker(ctx, "a", -122.42, 37.77) }
+func (p *mapActionPage) AddMarkerColor(ctx *via.Ctx) {
+	p.Map.AddMarker(ctx, "a", 1, 2, maplibre.Color("#ff0000"))
+}
+func (p *mapActionPage) AddMarkerPopupText(ctx *via.Ctx) {
+	p.Map.AddMarker(ctx, "a", 1, 2, maplibre.PopupText("Hello there"))
+}
+func (p *mapActionPage) AddMarkerPopupHTML(ctx *via.Ctx) {
+	p.Map.AddMarker(ctx, "a", 1, 2, maplibre.PopupHTML("<b>trusted</b>"))
+}
+func (p *mapActionPage) AddMarkerXSS(ctx *via.Ctx) {
+	p.Map.AddMarker(ctx, "a", 1, 2, maplibre.PopupText(`</script><img src=x onerror="alert(1)">`))
+}
+func (p *mapActionPage) AddMarkerQuoteID(ctx *via.Ctx) {
+	p.Map.AddMarker(ctx, `a"b`, 1, 2)
+}
+func (p *mapActionPage) MoveMarker(ctx *via.Ctx)   { p.Map.MoveMarker(ctx, "a", 3, 4) }
+func (p *mapActionPage) RemoveMarker(ctx *via.Ctx) { p.Map.RemoveMarker(ctx, "a") }
+func (p *mapActionPage) ClearMarkers(ctx *via.Ctx) { p.Map.ClearMarkers(ctx) }
+
+// Data
+func (p *mapActionPage) SetGeoJSON(ctx *via.Ctx) error {
+	return p.Map.SetGeoJSON(ctx, "pts", maplibre.FeatureCollection(
+		maplibre.PointFeature(1, 2, map[string]any{"name": "x"})))
+}
+func (p *mapActionPage) AddSource(ctx *via.Ctx) error {
+	return p.Map.AddGeoJSONSource(ctx, "pts", maplibre.FeatureCollection())
+}
+func (p *mapActionPage) AddCircleLayer(ctx *via.Ctx) error {
+	return p.Map.AddLayer(ctx, maplibre.CircleLayer("dots", "pts",
+		maplibre.Paint("circle-radius", 6), maplibre.Paint("circle-color", "#e55")))
+}
+func (p *mapActionPage) SetPaint(ctx *via.Ctx) error {
+	return p.Map.SetPaintProperty(ctx, "dots", "circle-color", "#00f")
+}
+func (p *mapActionPage) SetPaintBad(ctx *via.Ctx) error {
+	return p.Map.SetPaintProperty(ctx, "dots", "circle-color", make(chan int))
+}
+func (p *mapActionPage) ShowLayer(ctx *via.Ctx) { p.Map.SetLayerVisibility(ctx, "dots", true) }
+func (p *mapActionPage) HideLayer(ctx *via.Ctx) { p.Map.SetLayerVisibility(ctx, "dots", false) }
+func (p *mapActionPage) RemoveLayerSource(ctx *via.Ctx) {
+	p.Map.RemoveLayerAndSource(ctx, "dots", "pts")
+}
+
+// Lifecycle
+func (p *mapActionPage) SetStyle(ctx *via.Ctx) {
+	p.Map.SetStyle(ctx, "https://tiles.example/s.json")
+}
+func (p *mapActionPage) Resize(ctx *via.Ctx)  { p.Map.Resize(ctx) }
+func (p *mapActionPage) Dispose(ctx *via.Ctx) { p.Map.Dispose(ctx) }
+func (p *mapActionPage) DisposeTwice(ctx *via.Ctx) {
+	p.Map.Dispose(ctx)
+	p.Map.Dispose(ctx)
+}
+func (p *mapActionPage) CallEscape(ctx *via.Ctx) error {
+	return p.Map.Call(ctx, "setMaxZoom", 18)
+}
+func (p *mapActionPage) CallBad(ctx *via.Ctx) error {
+	return p.Map.Call(ctx, "panBy", make(chan int))
+}
+
+// fireMapAction boots a one-page app backed by mapActionPage, opens an SSE
+// stream, fires the named action, and waits for a frame containing every
+// needle. Mirrors the echarts plugin's runtime-test harness.
+func fireMapAction(t *testing.T, action string, needles ...string) string {
+	t.Helper()
+
+	var server *httptest.Server
+	app := via.New(via.WithTestServer(&server))
+	via.Mount[mapActionPage](app, "/")
+	t.Cleanup(server.Close)
+
+	tc := vt.NewClient(t, server, "/")
+	frames, cancel := tc.SSEReady()
+	t.Cleanup(cancel)
+
+	require.Equal(t, 200, tc.Action(action).Fire())
+	return vt.AwaitFrame(t, frames, 2*time.Second, needles...)
+}

--- a/plugins/maplibre/lifecycle.go
+++ b/plugins/maplibre/lifecycle.go
@@ -1,0 +1,49 @@
+package maplibre
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-via/via"
+)
+
+// SetStyle swaps the basemap style to a new Style Spec URL — e.g. toggling a
+// streets/satellite/dark basemap. Sources and layers you added are reapplied
+// by MapLibre's style diff where possible.
+func (m *Map) SetStyle(ctx *via.Ctx, url string) {
+	ctx.ExecScript(fmt.Sprintf("%s?.setStyle(%s)", m.mapRef(), mustJSON(url)))
+}
+
+// Resize tells the map to recompute its size. The mounted ResizeObserver
+// already handles container box changes; call this for CSS-driven changes
+// that don't alter the box (a sibling animating, a panel toggling).
+func (m *Map) Resize(ctx *via.Ctx) {
+	ctx.ExecScript(m.mapRef() + "?.resize()")
+}
+
+// Dispose tears the map down — frees the WebGL context, web workers, and DOM
+// listeners, disconnects the ResizeObserver, and drops the registry slot.
+// Call when the container is about to leave the DOM, or the instance leaks
+// for the page's lifetime. Safe to call more than once.
+func (m *Map) Dispose(ctx *via.Ctx) {
+	ctx.ExecScript(fmt.Sprintf(
+		"(function(){var _e=window.__viaMaps&&window.__viaMaps[%d];if(_e){if(_e.ro)_e.ro.disconnect();if(_e.m)_e.m.remove();delete window.__viaMaps[%d]}})()",
+		m.seq, m.seq))
+}
+
+// Call is the escape hatch for any MapLibre Map method the typed helpers don't
+// cover — e.g. Call(ctx, "setMaxZoom", 18) or Call(ctx, "panBy", []float64{100, 0}).
+// Each arg is JSON-encoded as a positional argument. Returns an error only if
+// an arg can't be marshalled.
+func (m *Map) Call(ctx *via.Ctx, method string, args ...any) error {
+	parts := make([]string, len(args))
+	for i, a := range args {
+		s, err := marshal(a)
+		if err != nil {
+			return err
+		}
+		parts[i] = s
+	}
+	ctx.ExecScript(fmt.Sprintf("%s?.%s(%s)", m.mapRef(), method, strings.Join(parts, ",")))
+	return nil
+}

--- a/plugins/maplibre/lifecycle_test.go
+++ b/plugins/maplibre/lifecycle_test.go
@@ -1,0 +1,44 @@
+package maplibre_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapAPI_SetStyle_emitsSetStyleWithURL(t *testing.T) {
+	t.Parallel()
+	fireMapAction(t, "SetStyle", `setStyle("https://tiles.example/s.json")`)
+}
+
+func TestMapAPI_Resize_emitsResizeCall(t *testing.T) {
+	t.Parallel()
+	fireMapAction(t, "Resize", "?.resize()")
+}
+
+func TestMapAPI_Dispose_freesInstanceObserverAndRegistrySlot(t *testing.T) {
+	t.Parallel()
+	// All three must happen or the map leaks: WebGL/listeners via remove(),
+	// the observer via disconnect(), and the retained ref via delete. The
+	// if(_e) guard is what makes a second Dispose a safe no-op.
+	fireMapAction(t, "Dispose", "if(_e)", ".remove()", ".disconnect()", "delete window.__viaMaps")
+}
+
+func TestMapAPI_Dispose_isIdempotentAcrossRepeatCalls(t *testing.T) {
+	t.Parallel()
+	// Disposing twice must not error: the registry-presence guard short-
+	// circuits the second teardown after the slot is deleted.
+	fireMapAction(t, "DisposeTwice", "delete window.__viaMaps")
+}
+
+func TestMapAPI_Call_emitsArbitraryMethodWithJSONArgs(t *testing.T) {
+	t.Parallel()
+	fireMapAction(t, "CallEscape", "?.setMaxZoom(18)")
+}
+
+func TestMapAPI_Call_returnsErrorOnUnmarshallableArg(t *testing.T) {
+	t.Parallel()
+	frame := fireMapAction(t, "CallBad", "maplibre: marshal")
+	assert.NotContains(t, frame, "panBy",
+		"a marshal failure must abort before emitting the call")
+}

--- a/plugins/maplibre/map.go
+++ b/plugins/maplibre/map.go
@@ -33,8 +33,20 @@ type control struct {
 }
 
 type geoSource struct {
-	id   string
-	data map[string]any
+	id    string
+	data  map[string]any
+	genID bool // emit MapLibre generateId:true so features get addressable ids
+}
+
+// SourceOption configures a GeoJSON source declared with [WithGeoJSONSource].
+type SourceOption func(*geoSource)
+
+// GenerateFeatureIDs sets MapLibre's generateId on the source, so its features
+// get stable auto-assigned ids that feature-state ([WithFeatureHover]) and
+// selection can target. Use it when your GeoJSON features have no id of their
+// own; omit it when you supply your own ids (generateId would override them).
+func GenerateFeatureIDs() SourceOption {
+	return func(s *geoSource) { s.genID = true }
 }
 
 // Map is a MapLibre GL map. Construct with [NewMap], render it in View with
@@ -61,9 +73,15 @@ type Map struct {
 	hash        bool
 	extra       map[string]any
 
-	controls []control
-	sources  []geoSource
-	layers   []map[string]any
+	controls       []control
+	sources        []geoSource
+	layers         []map[string]any
+	handlers       []handler
+	markerClick    bool         // attach a click listener to each marker
+	markerDragEnd  bool         // attach a dragend listener to each marker
+	featureClicks  int          // count of OnFeatureClick handlers, for unique event names
+	mapEvents      int          // count of OnMapEvent handlers, for unique event names
+	initialMarkers []markerSpec // markers declared at construction via WithMarker
 }
 
 // MapOption configures a Map. Options are applied in argument order.
@@ -109,13 +127,12 @@ func WithStyle(url string) MapOption {
 	return func(m *Map) { m.style = url }
 }
 
-// WithCenter sets the initial center as longitude, latitude — longitude
-// FIRST, matching MapLibre's [lng, lat] order (the inverse of the lat/lng
-// most map UIs display).
-func WithCenter(lng, lat float64) MapOption {
+// WithCenter sets the initial center. [LngLat]'s named fields keep longitude
+// and latitude from being swapped.
+func WithCenter(at LngLat) MapOption {
 	return func(m *Map) {
-		m.lng = lng
-		m.lat = lat
+		m.lng = at.Lng
+		m.lat = at.Lat
 	}
 }
 
@@ -137,10 +154,10 @@ func WithZoomRange(min, max float64) MapOption {
 	}
 }
 
-// WithMaxBounds restricts panning to the given box, as west, south, east,
-// north — MapLibre's [[sw],[ne]] bounds expressed as edge coordinates.
-func WithMaxBounds(west, south, east, north float64) MapOption {
-	return func(m *Map) { m.maxBounds = &[4]float64{west, south, east, north} }
+// WithMaxBounds restricts panning to the given box. [Bounds]'s named edges
+// keep west/south/east/north from being swapped.
+func WithMaxBounds(b Bounds) MapOption {
+	return func(m *Map) { m.maxBounds = &[4]float64{b.West, b.South, b.East, b.North} }
 }
 
 // WithoutInteraction disables all user interaction (pan/zoom/rotate) for a
@@ -193,8 +210,14 @@ func addControl(expr string, pos []ControlPosition) MapOption {
 // WithGeoJSONSource registers a GeoJSON source added once the style loads.
 // Pair with [WithLayer] to draw it. data is a GeoJSON object (see
 // [FeatureCollection]); the runtime [Map.SetGeoJSON] updates it later.
-func WithGeoJSONSource(id string, data map[string]any) MapOption {
-	return func(m *Map) { m.sources = append(m.sources, geoSource{id: id, data: data}) }
+func WithGeoJSONSource(id string, data map[string]any, opts ...SourceOption) MapOption {
+	return func(m *Map) {
+		s := geoSource{id: id, data: data}
+		for _, o := range opts {
+			o(&s)
+		}
+		m.sources = append(m.sources, s)
+	}
 }
 
 // WithLayer registers a layer added once the style loads. Build spec with
@@ -242,13 +265,22 @@ func NewMap(opts ...MapOption) *Map {
 func (m *Map) Mount() h.H {
 	width := cmp.Or(m.width, "100%")
 	height := cmp.Or(m.height, "400px")
-	return h.Div(
+	kids := []h.H{
 		h.ID(m.elementID),
 		h.Class(m.classes...),
 		h.DataIgnoreMorph(),
 		h.Style(fmt.Sprintf("width:%s;height:%s", width, height)),
-		h.Script(h.Raw(m.initJS())),
-	)
+	}
+	for _, hd := range m.handlers {
+		// A handler with no domEvent is client-only JS (e.g. WithFeatureHover):
+		// it contributes its js in initJS but must not emit a data-on attribute
+		// — an empty data-on: is malformed and datastar rejects it.
+		if hd.domEvent != "" {
+			kids = append(kids, h.Data("on:"+hd.domEvent, hd.expr))
+		}
+	}
+	kids = append(kids, h.Script(h.Raw(m.initJS())))
+	return h.Div(kids...)
 }
 
 func (m *Map) constructorOptions() map[string]any {
@@ -308,7 +340,11 @@ func (m *Map) initJS() string {
 	if len(m.sources) > 0 || len(m.layers) > 0 {
 		b.WriteString("_m.on('load',function(){")
 		for _, s := range m.sources {
-			fmt.Fprintf(&b, "_m.addSource(%s,%s);", mustJSON(s.id), mustJSON(geoJSONSource(s.data)))
+			src := geoJSONSource(s.data)
+			if s.genID {
+				src["generateId"] = true
+			}
+			fmt.Fprintf(&b, "_m.addSource(%s,%s);", mustJSON(s.id), mustJSON(src))
 		}
 		for _, l := range m.layers {
 			fmt.Fprintf(&b, "_m.addLayer(%s);", mustJSON(l))
@@ -316,9 +352,20 @@ func (m *Map) initJS() string {
 		b.WriteString("});")
 	}
 
+	for _, hd := range m.handlers {
+		b.WriteString(hd.js)
+	}
+
 	fmt.Fprintf(&b, "var _ro=new ResizeObserver(function(){var _e=window.__viaMaps[%d];if(_e&&_e.m)_e.m.resize()});", m.seq)
 	b.WriteString("_ro.observe(_el);")
 	fmt.Fprintf(&b, "window.__viaMaps[%d]={m:_m,ro:_ro,markers:{}};", m.seq)
+
+	// Construction markers run last — they look up the registry entry just
+	// assigned above as _e, so they must come after it.
+	for _, ms := range m.initialMarkers {
+		b.WriteString(m.markerScript(ms.id, ms.at, ms.cfg))
+	}
+
 	b.WriteString("})();")
 	return b.String()
 }
@@ -352,4 +399,17 @@ func mustJSON(v any) string {
 		panic(fmt.Errorf("maplibre: internal mustJSON: %v", err))
 	}
 	return string(b)
+}
+
+// renderH renders an [h.H] node to its HTML string for use as popup content. A
+// nil node renders as empty. Rendering into a strings.Builder never errors, so
+// the render error is dropped. Content built with h.T is escaped, so it's safe
+// even for user data; only h.Raw is unescaped.
+func renderH(content h.H) string {
+	if content == nil {
+		return ""
+	}
+	var sb strings.Builder
+	_ = content.Render(&sb)
+	return sb.String()
 }

--- a/plugins/maplibre/map.go
+++ b/plugins/maplibre/map.go
@@ -1,0 +1,355 @@
+package maplibre
+
+import (
+	"cmp"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync/atomic"
+
+	"github.com/go-via/via"
+	"github.com/go-via/via/h"
+)
+
+const defaultStyleURL = "https://demotiles.maplibre.org/style.json"
+
+// mapCounter gives each Map a process-unique registry slot.
+var mapCounter atomic.Uint64
+
+// ControlPosition is one of MapLibre's four control anchors. The zero value
+// means "MapLibre's default" (top-right).
+type ControlPosition string
+
+const (
+	TopLeft     ControlPosition = "top-left"
+	TopRight    ControlPosition = "top-right"
+	BottomLeft  ControlPosition = "bottom-left"
+	BottomRight ControlPosition = "bottom-right"
+)
+
+type control struct {
+	expr string
+	pos  ControlPosition
+}
+
+type geoSource struct {
+	id   string
+	data map[string]any
+}
+
+// Map is a MapLibre GL map. Construct with [NewMap], render it in View with
+// [Map.Mount], then drive it over SSE from actions or a [via.Stream] ticker
+// via the camera ([Map.FlyTo] …), marker ([Map.AddMarker] …), and data
+// ([Map.SetGeoJSON] …) methods, or the [Map.Call] escape hatch.
+type Map struct {
+	seq       uint64
+	elementID string
+	width     string
+	height    string
+	classes   []string
+
+	style       string
+	lng, lat    float64
+	zoom        float64
+	pitch       *float64
+	bearing     *float64
+	minZoom     *float64
+	maxZoom     *float64
+	maxBounds   *[4]float64
+	interactive *bool
+	attribution *bool
+	hash        bool
+	extra       map[string]any
+
+	controls []control
+	sources  []geoSource
+	layers   []map[string]any
+}
+
+// MapOption configures a Map. Options are applied in argument order.
+type MapOption func(*Map)
+
+// WithElementID sets the container element id. Panics on ASCII whitespace —
+// such an id is valid HTML5 but unaddressable by a `#id` selector, so styling
+// and the registry lookup would silently break.
+func WithElementID(id string) MapOption {
+	if strings.ContainsAny(id, " \t\n\r\f") {
+		panic(fmt.Errorf("maplibre: WithElementID: id %q must not contain whitespace", id))
+	}
+	return func(m *Map) { m.elementID = id }
+}
+
+// WithDimensions sets container width and height. An empty side falls back to
+// its default ("100%" width, "400px" height) — a map needs an explicit height
+// or it collapses to zero and renders nothing.
+func WithDimensions(width, height string) MapOption {
+	return func(m *Map) {
+		m.width = width
+		m.height = height
+	}
+}
+
+// WithClass adds CSS classes to the container. Panics if any single arg
+// contains whitespace — "a b" as one arg silently becomes two classes; pass
+// them as separate args.
+func WithClass(parts ...string) MapOption {
+	for _, p := range parts {
+		if strings.ContainsAny(p, " \t\n\r\f") {
+			panic(fmt.Errorf("maplibre: WithClass: class name %q must not contain whitespace (use separate args)", p))
+		}
+	}
+	return func(m *Map) { m.classes = parts }
+}
+
+// WithStyle sets the map style URL (a Style Spec JSON document). The default
+// is MapLibre's no-key demo style, which is meant for demos and CI, not a
+// production SLA — supply your own style (e.g. a MapTiler/Stadia URL) for
+// real use.
+func WithStyle(url string) MapOption {
+	return func(m *Map) { m.style = url }
+}
+
+// WithCenter sets the initial center as longitude, latitude — longitude
+// FIRST, matching MapLibre's [lng, lat] order (the inverse of the lat/lng
+// most map UIs display).
+func WithCenter(lng, lat float64) MapOption {
+	return func(m *Map) {
+		m.lng = lng
+		m.lat = lat
+	}
+}
+
+// WithZoom sets the initial zoom level (0 = whole world).
+func WithZoom(z float64) MapOption { return func(m *Map) { m.zoom = z } }
+
+// WithPitch tilts the camera from straight-down (0) toward the horizon, in
+// degrees (0–85).
+func WithPitch(deg float64) MapOption { return func(m *Map) { m.pitch = &deg } }
+
+// WithBearing rotates the map clockwise from north, in degrees.
+func WithBearing(deg float64) MapOption { return func(m *Map) { m.bearing = &deg } }
+
+// WithZoomRange clamps the user's zoom between min and max.
+func WithZoomRange(min, max float64) MapOption {
+	return func(m *Map) {
+		m.minZoom = &min
+		m.maxZoom = &max
+	}
+}
+
+// WithMaxBounds restricts panning to the given box, as west, south, east,
+// north — MapLibre's [[sw],[ne]] bounds expressed as edge coordinates.
+func WithMaxBounds(west, south, east, north float64) MapOption {
+	return func(m *Map) { m.maxBounds = &[4]float64{west, south, east, north} }
+}
+
+// WithoutInteraction disables all user interaction (pan/zoom/rotate) for a
+// static display map driven entirely from the server.
+func WithoutInteraction() MapOption {
+	return func(m *Map) { f := false; m.interactive = &f }
+}
+
+// WithoutAttribution removes the on-map attribution control. Most tile/style
+// sources require visible attribution by licence — keep it unless you surface
+// the credit elsewhere.
+func WithoutAttribution() MapOption {
+	return func(m *Map) { f := false; m.attribution = &f }
+}
+
+// WithHash syncs the map's center/zoom/bearing/pitch to the URL hash, so a
+// shared link reopens the same view.
+func WithHash() MapOption { return func(m *Map) { m.hash = true } }
+
+// WithNavigationControl adds zoom and compass buttons, optionally at a given
+// position (default top-right).
+func WithNavigationControl(pos ...ControlPosition) MapOption {
+	return addControl("new maplibregl.NavigationControl({})", pos)
+}
+
+// WithScaleControl adds a distance scale bar.
+func WithScaleControl(pos ...ControlPosition) MapOption {
+	return addControl("new maplibregl.ScaleControl({})", pos)
+}
+
+// WithGeolocateControl adds a "find my location" button wired for
+// high-accuracy tracking.
+func WithGeolocateControl(pos ...ControlPosition) MapOption {
+	return addControl("new maplibregl.GeolocateControl({positionOptions:{enableHighAccuracy:true},trackUserLocation:true})", pos)
+}
+
+// WithFullscreenControl adds a fullscreen toggle.
+func WithFullscreenControl(pos ...ControlPosition) MapOption {
+	return addControl("new maplibregl.FullscreenControl({})", pos)
+}
+
+func addControl(expr string, pos []ControlPosition) MapOption {
+	var p ControlPosition
+	if len(pos) > 0 {
+		p = pos[0]
+	}
+	return func(m *Map) { m.controls = append(m.controls, control{expr: expr, pos: p}) }
+}
+
+// WithGeoJSONSource registers a GeoJSON source added once the style loads.
+// Pair with [WithLayer] to draw it. data is a GeoJSON object (see
+// [FeatureCollection]); the runtime [Map.SetGeoJSON] updates it later.
+func WithGeoJSONSource(id string, data map[string]any) MapOption {
+	return func(m *Map) { m.sources = append(m.sources, geoSource{id: id, data: data}) }
+}
+
+// WithLayer registers a layer added once the style loads. Build spec with
+// [CircleLayer] / [LineLayer] / [FillLayer] / [SymbolLayer], or pass a raw
+// layer spec.
+func WithLayer(spec map[string]any) MapOption {
+	return func(m *Map) { m.layers = append(m.layers, spec) }
+}
+
+// WithMapOption is the escape hatch for any MapLibre Map constructor option
+// the typed helpers don't cover (e.g. "projection", "renderWorldCopies").
+// Panics if value can't be marshalled to JSON — a programmer bug surfaced
+// eagerly rather than at render time.
+func WithMapOption(key string, value any) MapOption {
+	if _, err := json.Marshal(value); err != nil {
+		panic(fmt.Errorf("maplibre: WithMapOption %q: %v", key, err))
+	}
+	return func(m *Map) {
+		if m.extra == nil {
+			m.extra = map[string]any{}
+		}
+		m.extra[key] = value
+	}
+}
+
+// NewMap creates a Map. Without [WithElementID] the id is auto-generated from
+// a monotonic counter; without [WithStyle] the no-key demo style is used.
+func NewMap(opts ...MapOption) *Map {
+	m := &Map{seq: mapCounter.Add(1)}
+	for _, opt := range opts {
+		opt(m)
+	}
+	if m.elementID == "" {
+		m.elementID = fmt.Sprintf("maplibre-%d", m.seq)
+	}
+	if m.style == "" {
+		m.style = defaultStyleURL
+	}
+	return m
+}
+
+// Mount returns the container element with the inline init script. Render it
+// in View. The container carries data-ignore-morph so datastar's DOM morphing
+// can't tear out MapLibre's WebGL canvas on a re-render.
+func (m *Map) Mount() h.H {
+	width := cmp.Or(m.width, "100%")
+	height := cmp.Or(m.height, "400px")
+	return h.Div(
+		h.ID(m.elementID),
+		h.Class(m.classes...),
+		h.DataIgnoreMorph(),
+		h.Style(fmt.Sprintf("width:%s;height:%s", width, height)),
+		h.Script(h.Raw(m.initJS())),
+	)
+}
+
+func (m *Map) constructorOptions() map[string]any {
+	opts := map[string]any{
+		"container": m.elementID,
+		"style":     m.style,
+		"center":    []float64{m.lng, m.lat},
+		"zoom":      m.zoom,
+	}
+	if m.pitch != nil {
+		opts["pitch"] = *m.pitch
+	}
+	if m.bearing != nil {
+		opts["bearing"] = *m.bearing
+	}
+	if m.minZoom != nil {
+		opts["minZoom"] = *m.minZoom
+	}
+	if m.maxZoom != nil {
+		opts["maxZoom"] = *m.maxZoom
+	}
+	if m.maxBounds != nil {
+		b := *m.maxBounds
+		opts["maxBounds"] = [][]float64{{b[0], b[1]}, {b[2], b[3]}}
+	}
+	if m.interactive != nil {
+		opts["interactive"] = *m.interactive
+	}
+	if m.attribution != nil {
+		opts["attributionControl"] = *m.attribution
+	}
+	if m.hash {
+		opts["hash"] = true
+	}
+	for k, v := range m.extra {
+		opts[k] = v
+	}
+	return opts
+}
+
+func (m *Map) initJS() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "(function(){window.__viaMaps=window.__viaMaps||{};")
+	fmt.Fprintf(&b, "var _el=document.getElementById(%s);", mustJSON(m.elementID))
+	fmt.Fprintf(&b, "var _m=new maplibregl.Map(%s);", mustJSON(m.constructorOptions()))
+
+	for _, c := range m.controls {
+		if c.pos != "" {
+			fmt.Fprintf(&b, "_m.addControl(%s,%s);", c.expr, mustJSON(string(c.pos)))
+		} else {
+			fmt.Fprintf(&b, "_m.addControl(%s);", c.expr)
+		}
+	}
+
+	// Sources and layers must be added after the style loads, or MapLibre
+	// throws "Style is not done loading".
+	if len(m.sources) > 0 || len(m.layers) > 0 {
+		b.WriteString("_m.on('load',function(){")
+		for _, s := range m.sources {
+			fmt.Fprintf(&b, "_m.addSource(%s,%s);", mustJSON(s.id), mustJSON(geoJSONSource(s.data)))
+		}
+		for _, l := range m.layers {
+			fmt.Fprintf(&b, "_m.addLayer(%s);", mustJSON(l))
+		}
+		b.WriteString("});")
+	}
+
+	fmt.Fprintf(&b, "var _ro=new ResizeObserver(function(){var _e=window.__viaMaps[%d];if(_e&&_e.m)_e.m.resize()});", m.seq)
+	b.WriteString("_ro.observe(_el);")
+	fmt.Fprintf(&b, "window.__viaMaps[%d]={m:_m,ro:_ro,markers:{}};", m.seq)
+	b.WriteString("})();")
+	return b.String()
+}
+
+// mapRef is the optional-chaining expression resolving to this map's instance
+// (or undefined). Prefix it for method calls: mapRef() + "?.flyTo(...)".
+func (m *Map) mapRef() string {
+	return fmt.Sprintf("window.__viaMaps?.[%d]?.m", m.seq)
+}
+
+// execReady runs body (with `_m` bound to the map instance) once the style is
+// loaded — the robust guard for source/layer ops that throw before load.
+func (m *Map) execReady(ctx *via.Ctx, body string) {
+	ctx.ExecScript(fmt.Sprintf(
+		"(function(){var _e=window.__viaMaps&&window.__viaMaps[%d];if(!_e||!_e.m)return;window.__viaMapReady(_e.m,function(){var _m=_e.m;%s})})()",
+		m.seq, body,
+	))
+}
+
+func geoJSONSource(data map[string]any) map[string]any {
+	return map[string]any{"type": "geojson", "data": data}
+}
+
+// mustJSON marshals v with HTML escaping on (Go's default), so `<`, `>`, `&`
+// become \uXXXX — a string value can't break out of the surrounding <script>
+// with a literal `</script>`. Callers pass pre-validated or scalar values, so
+// a marshal error here is an internal bug.
+func mustJSON(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(fmt.Errorf("maplibre: internal mustJSON: %v", err))
+	}
+	return string(b)
+}

--- a/plugins/maplibre/map_test.go
+++ b/plugins/maplibre/map_test.go
@@ -77,7 +77,7 @@ func TestMap_WithCenter_emitsLngLatOrder(t *testing.T) {
 	t.Parallel()
 	// MapLibre coordinates are [lng, lat] — longitude FIRST. Asserting the
 	// exact pair order guards the single most common MapLibre bug.
-	html := render(t, maplibre.NewMap(maplibre.WithCenter(-122.42, 37.77)))
+	html := render(t, maplibre.NewMap(maplibre.WithCenter(maplibre.At(-122.42, 37.77))))
 	assert.Contains(t, html, `"center":[-122.42,37.77]`,
 		"center must serialize as [lng, lat], not [lat, lng]")
 }
@@ -97,7 +97,7 @@ func TestMap_WithZoomPitchBearing_emitsCameraOptions(t *testing.T) {
 func TestMap_WithMaxBounds_emitsSouthWestNorthEast(t *testing.T) {
 	t.Parallel()
 	// maxBounds is [[west,south],[east,north]] = [sw, ne].
-	html := render(t, maplibre.NewMap(maplibre.WithMaxBounds(-10, 40, 5, 55)))
+	html := render(t, maplibre.NewMap(maplibre.WithMaxBounds(maplibre.Bounds{West: -10, South: 40, East: 5, North: 55})))
 	assert.Contains(t, html, `"maxBounds":[[-10,40],[5,55]]`)
 }
 

--- a/plugins/maplibre/map_test.go
+++ b/plugins/maplibre/map_test.go
@@ -1,0 +1,217 @@
+package maplibre_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-via/via/plugins/maplibre"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// render returns the HTML produced by a map's Mount node.
+func render(t *testing.T, m *maplibre.Map) string {
+	t.Helper()
+	var sb strings.Builder
+	require.NoError(t, m.Mount().Render(&sb))
+	return sb.String()
+}
+
+func TestNewMap_assignsAutoIDWhenUnset(t *testing.T) {
+	t.Parallel()
+	html := render(t, maplibre.NewMap())
+	assert.Contains(t, html, `id="maplibre-`,
+		"a map without WithElementID must auto-generate an id matching `maplibre-<seq>`")
+}
+
+func TestNewMap_autoIDsAreUniqueAcrossMaps(t *testing.T) {
+	t.Parallel()
+	// Two maps on one page must land in distinct registry slots, else the
+	// second init clobbers the first's instance + observer.
+	a := render(t, maplibre.NewMap())
+	b := render(t, maplibre.NewMap())
+	assert.NotEqual(t, a, b,
+		"two auto-id maps must render with different seq numbers")
+}
+
+func TestMap_Mount_rendersContainerWithDimensionsAndMorphGuard(t *testing.T) {
+	t.Parallel()
+	html := render(t, maplibre.NewMap(maplibre.WithDimensions("80%", "500px")))
+
+	assert.Contains(t, html, "width:80%")
+	assert.Contains(t, html, "height:500px")
+	assert.Contains(t, html, "data-ignore-morph",
+		"the container must survive datastar morphing or the WebGL canvas is wiped")
+}
+
+func TestMap_Mount_emitsConstructorAndRegistersInstance(t *testing.T) {
+	t.Parallel()
+	html := render(t, maplibre.NewMap(maplibre.WithElementID("m1")))
+
+	assert.Contains(t, html, "new maplibregl.Map(",
+		"Mount must emit the MapLibre constructor")
+	assert.Contains(t, html, `"container":"m1"`,
+		"the constructor must target the container by id")
+	assert.Contains(t, html, "ResizeObserver",
+		"a ResizeObserver keeps the map sized to its container")
+	assert.Contains(t, html, "__viaMaps",
+		"the instance must be parked in the registry for runtime ops")
+}
+
+func TestMap_defaultStyleIsDemotiles(t *testing.T) {
+	t.Parallel()
+	html := render(t, maplibre.NewMap())
+	assert.Contains(t, html, "https://demotiles.maplibre.org/style.json",
+		"the zero-config default must be the no-key demo style")
+}
+
+func TestMap_WithStyle_overridesStyleURL(t *testing.T) {
+	t.Parallel()
+	html := render(t, maplibre.NewMap(maplibre.WithStyle("https://tiles.example/s.json")))
+	assert.Contains(t, html, `"style":"https://tiles.example/s.json"`)
+	assert.NotContains(t, html, "demotiles.maplibre.org",
+		"the default style must not also appear when overridden")
+}
+
+func TestMap_WithCenter_emitsLngLatOrder(t *testing.T) {
+	t.Parallel()
+	// MapLibre coordinates are [lng, lat] — longitude FIRST. Asserting the
+	// exact pair order guards the single most common MapLibre bug.
+	html := render(t, maplibre.NewMap(maplibre.WithCenter(-122.42, 37.77)))
+	assert.Contains(t, html, `"center":[-122.42,37.77]`,
+		"center must serialize as [lng, lat], not [lat, lng]")
+}
+
+func TestMap_WithZoomPitchBearing_emitsCameraOptions(t *testing.T) {
+	t.Parallel()
+	html := render(t, maplibre.NewMap(
+		maplibre.WithZoom(11),
+		maplibre.WithPitch(45),
+		maplibre.WithBearing(30),
+	))
+	assert.Contains(t, html, `"zoom":11`)
+	assert.Contains(t, html, `"pitch":45`)
+	assert.Contains(t, html, `"bearing":30`)
+}
+
+func TestMap_WithMaxBounds_emitsSouthWestNorthEast(t *testing.T) {
+	t.Parallel()
+	// maxBounds is [[west,south],[east,north]] = [sw, ne].
+	html := render(t, maplibre.NewMap(maplibre.WithMaxBounds(-10, 40, 5, 55)))
+	assert.Contains(t, html, `"maxBounds":[[-10,40],[5,55]]`)
+}
+
+func TestMap_WithoutAttribution_emitsAttributionControlFalse(t *testing.T) {
+	t.Parallel()
+	// The valid disable value is `false`; `true` is not a legal value.
+	html := render(t, maplibre.NewMap(maplibre.WithoutAttribution()))
+	assert.Contains(t, html, `"attributionControl":false`)
+	assert.NotContains(t, html, `"attributionControl":true`)
+}
+
+func TestMap_WithoutInteraction_emitsInteractiveFalse(t *testing.T) {
+	t.Parallel()
+	html := render(t, maplibre.NewMap(maplibre.WithoutInteraction()))
+	assert.Contains(t, html, `"interactive":false`)
+}
+
+func TestMap_Controls_addControlForEachKind(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		opt    maplibre.MapOption
+		needle string
+	}{
+		{"navigation", maplibre.WithNavigationControl(), "new maplibregl.NavigationControl("},
+		{"scale", maplibre.WithScaleControl(), "new maplibregl.ScaleControl("},
+		{"geolocate", maplibre.WithGeolocateControl(), "new maplibregl.GeolocateControl("},
+		{"fullscreen", maplibre.WithFullscreenControl(), "new maplibregl.FullscreenControl("},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			html := render(t, maplibre.NewMap(tt.opt))
+			assert.Contains(t, html, ".addControl("+tt.needle)
+		})
+	}
+}
+
+func TestMap_WithNavigationControl_honorsPosition(t *testing.T) {
+	t.Parallel()
+	html := render(t, maplibre.NewMap(maplibre.WithNavigationControl(maplibre.BottomLeft)))
+	assert.Contains(t, html, `"bottom-left"`,
+		"a control position must be passed as the second addControl argument")
+}
+
+func TestMap_WithNavigationControl_omitsPositionArgWhenUnset(t *testing.T) {
+	t.Parallel()
+	// No position arg => MapLibre's default (top-right). The call must end at
+	// the constructor, with no trailing position string.
+	html := render(t, maplibre.NewMap(maplibre.WithNavigationControl()))
+	assert.Contains(t, html, "addControl(new maplibregl.NavigationControl({}));",
+		"omitting a position must emit a single-argument addControl call")
+}
+
+func TestMap_WithHash_emitsHashOption(t *testing.T) {
+	t.Parallel()
+	html := render(t, maplibre.NewMap(maplibre.WithHash()))
+	assert.Contains(t, html, `"hash":true`)
+}
+
+func TestMap_WithZoomRange_emitsMinAndMaxZoom(t *testing.T) {
+	t.Parallel()
+	html := render(t, maplibre.NewMap(maplibre.WithZoomRange(5, 18)))
+	assert.Contains(t, html, `"minZoom":5`)
+	assert.Contains(t, html, `"maxZoom":18`)
+}
+
+func TestMap_WithGeoJSONSourceAndLayer_addInsideLoad(t *testing.T) {
+	t.Parallel()
+	// Construction-time addSource/addLayer must run inside map.on('load'),
+	// else MapLibre throws "Style is not done loading".
+	m := maplibre.NewMap(
+		maplibre.WithGeoJSONSource("pts", maplibre.FeatureCollection()),
+		maplibre.WithLayer(maplibre.CircleLayer("dots", "pts")),
+	)
+	html := render(t, m)
+	assert.Contains(t, html, ".on('load'",
+		"sources and layers must be deferred to the load event")
+	assert.Contains(t, html, ".addSource(")
+	assert.Contains(t, html, ".addLayer(")
+}
+
+func TestMap_WithMapOption_escapeHatchPassesArbitraryConstructorKeys(t *testing.T) {
+	t.Parallel()
+	html := render(t, maplibre.NewMap(maplibre.WithMapOption("renderWorldCopies", false)))
+	assert.Contains(t, html, `"renderWorldCopies":false`)
+}
+
+func TestMap_WithClass_addsContainerClasses(t *testing.T) {
+	t.Parallel()
+	html := render(t, maplibre.NewMap(maplibre.WithClass("rounded", "shadow")))
+	assert.Contains(t, html, `class="rounded shadow"`)
+}
+
+func TestMap_Mount_escapesScriptBreakoutInInlineInitScript(t *testing.T) {
+	t.Parallel()
+	// The init script is inline in the page <script>; a constructor-option
+	// value carrying </script><b> must be unicode-escaped by json.Marshal so
+	// it can't close the script tag or inject markup.
+	html := render(t, maplibre.NewMap(maplibre.WithMapOption("k", "</script><b>x</b>")))
+	assert.Contains(t, html, `</script>`,
+		"the option value's </script> must be unicode-escaped by json.Marshal")
+	assert.NotContains(t, html, "<b>x</b>",
+		"the injected markup must never appear raw in the document")
+}
+
+func TestWithElementID_panicsOnWhitespace(t *testing.T) {
+	t.Parallel()
+	// A whitespaced id is valid HTML5 but unaddressable by `#id` CSS/JS.
+	assert.Panics(t, func() { maplibre.WithElementID("a b") })
+}
+
+func TestWithClass_panicsOnWhitespaceInSingleClass(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() { maplibre.WithClass("a b") })
+}

--- a/plugins/maplibre/markers.go
+++ b/plugins/maplibre/markers.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/go-via/via"
+	"github.com/go-via/via/h"
 )
 
 type markerConfig struct {
@@ -22,8 +23,8 @@ func Color(c string) MarkerOption {
 	return func(m *markerConfig) { m.opts["color"] = c }
 }
 
-// Draggable lets the user drag the marker. Pair with a dragend listener (via
-// a raw style/script) if you need the moved position back.
+// Draggable lets the user drag the marker. Pair with [OnMarkerDragEnd] if you
+// need the moved position back in a Go handler.
 func Draggable() MarkerOption {
 	return func(m *markerConfig) { m.opts["draggable"] = true }
 }
@@ -35,56 +36,97 @@ func Scale(s float64) MarkerOption {
 
 // PopupText attaches a click-to-open popup showing text as a plain DOM text
 // node — XSS-safe, so it's the right choice for user-supplied content. The
-// text is JSON-encoded into the emitted script.
+// text is JSON-encoded into the emitted script. PopupText and [PopupHTML] are
+// mutually exclusive; the last one set wins.
 func PopupText(text string) MarkerOption {
-	return func(m *markerConfig) { m.popupText = &text }
+	return func(m *markerConfig) { m.popupText = &text; m.popupHTML = nil }
 }
 
-// PopupHTML attaches a popup whose body is raw HTML. MapLibre does NOT
-// sanitize it, so use this ONLY with trusted, developer-controlled markup —
-// never with user input (use [PopupText] for that). The string is
-// JSON-encoded so it can't break out of the script, but the rendered HTML
-// still executes in the popup. PopupHTML and PopupText are mutually
+// PopupHTML attaches a popup whose body is an [h.H] node, composed with the
+// same h.* builders as your view. Content built with h.T is escaped (safe for
+// user data); h.Raw is injected unescaped and MapLibre does not sanitize it, so
+// only use h.Raw with trusted markup. PopupHTML and [PopupText] are mutually
 // exclusive; the last one set wins.
-func PopupHTML(html string) MarkerOption {
-	return func(m *markerConfig) { m.popupHTML = &html }
+func PopupHTML(content h.H) MarkerOption {
+	return func(m *markerConfig) { s := renderH(content); m.popupHTML = &s; m.popupText = nil }
 }
 
-// AddMarker places (or replaces) a marker keyed by id at (lng, lat). The id
+// AddMarker places (or replaces) a marker keyed by id at a [LngLat]. The id
 // lets later [Map.MoveMarker] / [Map.RemoveMarker] calls address this exact
 // marker — pass a stable key per logical pin (a vehicle id, a search-result
 // id). Re-adding the same id removes the previous marker first, so a stream
-// can re-emit a marker without stacking duplicates. Coordinates are
-// [lng, lat].
-func (m *Map) AddMarker(ctx *via.Ctx, id string, lng, lat float64, opts ...MarkerOption) {
+// can re-emit a marker without stacking duplicates.
+func (m *Map) AddMarker(ctx *via.Ctx, id string, at LngLat, opts ...MarkerOption) {
 	cfg := &markerConfig{opts: map[string]any{}}
 	for _, o := range opts {
 		o(cfg)
 	}
+	ctx.ExecScript(m.markerScript(id, at, cfg))
+}
 
+// markerScript builds the self-invoking script that creates (or replaces) a
+// keyed marker on this map. Shared by [Map.AddMarker] (runtime, over SSE) and
+// [WithMarker] (construction, inlined in initJS after the registry entry
+// exists). It reads m.markerClick / m.markerDragEnd, so the click/drag wiring
+// is decided at render time, after all options are applied.
+func (m *Map) markerScript(id string, at LngLat, cfg *markerConfig) string {
 	var b strings.Builder
 	jid := mustJSON(id)
 	fmt.Fprintf(&b, "var _e=window.__viaMaps&&window.__viaMaps[%d];if(!_e||!_e.m)return;", m.seq)
 	fmt.Fprintf(&b, "if(_e.markers[%s])_e.markers[%s].remove();", jid, jid)
 	fmt.Fprintf(&b, "var _mk=new maplibregl.Marker(%s).setLngLat(%s);",
-		mustJSON(cfg.opts), mustJSON([]float64{lng, lat}))
+		mustJSON(cfg.opts), mustJSON(at.pair()))
 	if cfg.popupText != nil {
 		fmt.Fprintf(&b, "_mk.setPopup(new maplibregl.Popup({offset:25}).setText(%s));", mustJSON(*cfg.popupText))
 	} else if cfg.popupHTML != nil {
 		fmt.Fprintf(&b, "_mk.setPopup(new maplibregl.Popup({offset:25}).setHTML(%s));", mustJSON(*cfg.popupHTML))
 	}
+	if m.markerClick {
+		b.WriteString("_mk.getElement().style.cursor='pointer';")
+		fmt.Fprintf(&b, "_mk.getElement().addEventListener('click',function(ev){ev.stopPropagation();var ll=_mk.getLngLat();_e.m.getContainer().dispatchEvent(new CustomEvent('viamarkerclick',{detail:{id:%s,lng:ll.lng,lat:ll.lat,%s}}))});", jid, cameraDetail("_e.m"))
+	}
+	if m.markerDragEnd {
+		fmt.Fprintf(&b, "_mk.on('dragend',function(){var ll=_mk.getLngLat();_e.m.getContainer().dispatchEvent(new CustomEvent('viamarkerdragend',{detail:{id:%s,lng:ll.lng,lat:ll.lat,%s}}))});", jid, cameraDetail("_e.m"))
+	}
 	fmt.Fprintf(&b, "_mk.addTo(_e.m);_e.markers[%s]=_mk;", jid)
-	ctx.ExecScript("(function(){" + b.String() + "})()")
+	// Terminate the IIFE with a semicolon: in initJS, construction markers are
+	// concatenated back-to-back, and `})()` followed by the next `(function(){`
+	// would parse as CALLING the first IIFE's (undefined) return value with the
+	// second as an argument — a runtime TypeError aborting every later marker.
+	return "(function(){" + b.String() + "})();"
 }
 
-// MoveMarker repositions an existing marker to (lng, lat) without recreating
-// it — the smooth path for live tracking (a moving vehicle, a cursor). A no-op
-// if no marker holds that id.
-func (m *Map) MoveMarker(ctx *via.Ctx, id string, lng, lat float64) {
+// markerSpec is a marker declared at construction with [WithMarker].
+type markerSpec struct {
+	id  string
+	at  LngLat
+	cfg *markerConfig
+}
+
+// WithMarker places a static marker at construction, so a map with fixed pins
+// needs no OnConnect/AddMarker — it renders in the initial HTML. The id keys it
+// for later [Map.MoveMarker] / [Map.RemoveMarker]; it honors the same
+// [MarkerOption]s and the same [OnMarkerClick] / [OnMarkerDragEnd] wiring as a
+// runtime marker. Drive markers that appear or move after load from an action
+// or ticker with [Map.AddMarker] instead.
+func WithMarker(id string, at LngLat, opts ...MarkerOption) MapOption {
+	cfg := &markerConfig{opts: map[string]any{}}
+	for _, o := range opts {
+		o(cfg)
+	}
+	return func(m *Map) {
+		m.initialMarkers = append(m.initialMarkers, markerSpec{id: id, at: at, cfg: cfg})
+	}
+}
+
+// MoveMarker repositions an existing marker to at without recreating it — the
+// smooth path for live tracking (a moving vehicle, a cursor). A no-op if no
+// marker holds that id.
+func (m *Map) MoveMarker(ctx *via.Ctx, id string, at LngLat) {
 	jid := mustJSON(id)
 	ctx.ExecScript(fmt.Sprintf(
 		"(function(){var _e=window.__viaMaps&&window.__viaMaps[%d];var _mk=_e&&_e.markers&&_e.markers[%s];if(_mk)_mk.setLngLat(%s)})()",
-		m.seq, jid, mustJSON([]float64{lng, lat})))
+		m.seq, jid, mustJSON(at.pair())))
 }
 
 // RemoveMarker removes the marker with the given id. A no-op if absent.

--- a/plugins/maplibre/markers.go
+++ b/plugins/maplibre/markers.go
@@ -1,0 +1,103 @@
+package maplibre
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-via/via"
+)
+
+type markerConfig struct {
+	opts      map[string]any
+	popupText *string
+	popupHTML *string
+}
+
+// MarkerOption configures a marker created by [Map.AddMarker].
+type MarkerOption func(*markerConfig)
+
+// Color tints the default teardrop pin (a CSS color). Ignored if you supply a
+// custom element — color only affects the built-in SVG pin.
+func Color(c string) MarkerOption {
+	return func(m *markerConfig) { m.opts["color"] = c }
+}
+
+// Draggable lets the user drag the marker. Pair with a dragend listener (via
+// a raw style/script) if you need the moved position back.
+func Draggable() MarkerOption {
+	return func(m *markerConfig) { m.opts["draggable"] = true }
+}
+
+// Scale multiplies the default pin size (1 = default).
+func Scale(s float64) MarkerOption {
+	return func(m *markerConfig) { m.opts["scale"] = s }
+}
+
+// PopupText attaches a click-to-open popup showing text as a plain DOM text
+// node — XSS-safe, so it's the right choice for user-supplied content. The
+// text is JSON-encoded into the emitted script.
+func PopupText(text string) MarkerOption {
+	return func(m *markerConfig) { m.popupText = &text }
+}
+
+// PopupHTML attaches a popup whose body is raw HTML. MapLibre does NOT
+// sanitize it, so use this ONLY with trusted, developer-controlled markup —
+// never with user input (use [PopupText] for that). The string is
+// JSON-encoded so it can't break out of the script, but the rendered HTML
+// still executes in the popup. PopupHTML and PopupText are mutually
+// exclusive; the last one set wins.
+func PopupHTML(html string) MarkerOption {
+	return func(m *markerConfig) { m.popupHTML = &html }
+}
+
+// AddMarker places (or replaces) a marker keyed by id at (lng, lat). The id
+// lets later [Map.MoveMarker] / [Map.RemoveMarker] calls address this exact
+// marker — pass a stable key per logical pin (a vehicle id, a search-result
+// id). Re-adding the same id removes the previous marker first, so a stream
+// can re-emit a marker without stacking duplicates. Coordinates are
+// [lng, lat].
+func (m *Map) AddMarker(ctx *via.Ctx, id string, lng, lat float64, opts ...MarkerOption) {
+	cfg := &markerConfig{opts: map[string]any{}}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	var b strings.Builder
+	jid := mustJSON(id)
+	fmt.Fprintf(&b, "var _e=window.__viaMaps&&window.__viaMaps[%d];if(!_e||!_e.m)return;", m.seq)
+	fmt.Fprintf(&b, "if(_e.markers[%s])_e.markers[%s].remove();", jid, jid)
+	fmt.Fprintf(&b, "var _mk=new maplibregl.Marker(%s).setLngLat(%s);",
+		mustJSON(cfg.opts), mustJSON([]float64{lng, lat}))
+	if cfg.popupText != nil {
+		fmt.Fprintf(&b, "_mk.setPopup(new maplibregl.Popup({offset:25}).setText(%s));", mustJSON(*cfg.popupText))
+	} else if cfg.popupHTML != nil {
+		fmt.Fprintf(&b, "_mk.setPopup(new maplibregl.Popup({offset:25}).setHTML(%s));", mustJSON(*cfg.popupHTML))
+	}
+	fmt.Fprintf(&b, "_mk.addTo(_e.m);_e.markers[%s]=_mk;", jid)
+	ctx.ExecScript("(function(){" + b.String() + "})()")
+}
+
+// MoveMarker repositions an existing marker to (lng, lat) without recreating
+// it — the smooth path for live tracking (a moving vehicle, a cursor). A no-op
+// if no marker holds that id.
+func (m *Map) MoveMarker(ctx *via.Ctx, id string, lng, lat float64) {
+	jid := mustJSON(id)
+	ctx.ExecScript(fmt.Sprintf(
+		"(function(){var _e=window.__viaMaps&&window.__viaMaps[%d];var _mk=_e&&_e.markers&&_e.markers[%s];if(_mk)_mk.setLngLat(%s)})()",
+		m.seq, jid, mustJSON([]float64{lng, lat})))
+}
+
+// RemoveMarker removes the marker with the given id. A no-op if absent.
+func (m *Map) RemoveMarker(ctx *via.Ctx, id string) {
+	jid := mustJSON(id)
+	ctx.ExecScript(fmt.Sprintf(
+		"(function(){var _e=window.__viaMaps&&window.__viaMaps[%d];var _mk=_e&&_e.markers&&_e.markers[%s];if(_mk){_mk.remove();delete _e.markers[%s]}})()",
+		m.seq, jid, jid))
+}
+
+// ClearMarkers removes every marker added via [Map.AddMarker].
+func (m *Map) ClearMarkers(ctx *via.Ctx) {
+	ctx.ExecScript(fmt.Sprintf(
+		"(function(){var _e=window.__viaMaps&&window.__viaMaps[%d];if(_e&&_e.markers){Object.keys(_e.markers).forEach(function(k){_e.markers[k].remove()});_e.markers={}}})()",
+		m.seq))
+}

--- a/plugins/maplibre/markers_test.go
+++ b/plugins/maplibre/markers_test.go
@@ -29,6 +29,15 @@ func TestMapAPI_AddMarker_popupHTMLUsesSetHTML(t *testing.T) {
 	fireMapAction(t, "AddMarkerPopupHTML", ".setHTML(")
 }
 
+func TestMapAPI_AddMarker_popupTextAndHTMLAreMutuallyExclusiveLastWins(t *testing.T) {
+	t.Parallel()
+	// Both set in one call (HTML then Text): the later one must win and the
+	// earlier must be fully dropped, so the popup can't render twice.
+	frame := fireMapAction(t, "AddMarkerPopupLastWins", "setLngLat")
+	assert.Contains(t, frame, `.setText("text")`, "the later PopupText must win")
+	assert.NotContains(t, frame, ".setHTML(", "the earlier PopupHTML must be cleared")
+}
+
 func TestMapAPI_AddMarker_escapesScriptBreakoutInPopupText(t *testing.T) {
 	t.Parallel()
 	// json.Marshal HTML-escapes `<` to <, so a popup string carrying a

--- a/plugins/maplibre/markers_test.go
+++ b/plugins/maplibre/markers_test.go
@@ -1,0 +1,87 @@
+package maplibre_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapAPI_AddMarker_emitsMarkerAtLngLat(t *testing.T) {
+	t.Parallel()
+	fireMapAction(t, "AddMarker",
+		"new maplibregl.Marker(", "setLngLat([-122.42,37.77])", "addTo")
+}
+
+func TestMapAPI_AddMarker_carriesColorOption(t *testing.T) {
+	t.Parallel()
+	fireMapAction(t, "AddMarkerColor", `"color":"#ff0000"`)
+}
+
+func TestMapAPI_AddMarker_popupTextUsesSafeSetText(t *testing.T) {
+	t.Parallel()
+	// setText creates a DOM text node — the XSS-safe path for user content.
+	fireMapAction(t, "AddMarkerPopupText", "new maplibregl.Popup(", ".setText(", "Hello there")
+}
+
+func TestMapAPI_AddMarker_popupHTMLUsesSetHTML(t *testing.T) {
+	t.Parallel()
+	fireMapAction(t, "AddMarkerPopupHTML", ".setHTML(")
+}
+
+func TestMapAPI_AddMarker_escapesScriptBreakoutInPopupText(t *testing.T) {
+	t.Parallel()
+	// json.Marshal HTML-escapes `<` to <, so a popup string carrying a
+	// </script><img onerror> breakout can't terminate the SSE-delivered
+	// script nor inject a raw tag. (The frame's own trailing </script> is
+	// datastar's script wrapper, not our content — so assert on the payload.)
+	frame := fireMapAction(t, "AddMarkerXSS", ".setText(")
+	assert.Contains(t, frame, `</script>`,
+		"the content's </script> must be unicode-escaped by the JSON encoder")
+	assert.NotContains(t, frame, "</script><img",
+		"the breakout sequence must not survive as raw markup")
+	assert.NotContains(t, frame, "<img",
+		"the injected tag must be escaped, never emitted raw")
+}
+
+func TestMapAPI_AddMarker_escapesQuoteInMarkerID(t *testing.T) {
+	t.Parallel()
+	// A quote in the id must be JSON-escaped so it stays a valid string key
+	// and can't break out of the registry index expression.
+	frame := fireMapAction(t, "AddMarkerQuoteID", `markers[`)
+	assert.Contains(t, frame, `a\"b`,
+		"a quote in the marker id must be escaped inside the JS string literal")
+}
+
+func TestMapAPI_AddMarker_removesSameIDBeforeAddingToAvoidStacking(t *testing.T) {
+	t.Parallel()
+	// The replace-first guard lets a stream re-emit a marker per tick without
+	// stacking duplicates: the remove must precede the new Marker construction.
+	frame := fireMapAction(t, "AddMarker", `_e.markers["a"]`, ".remove()")
+	assert.Less(t, strings.Index(frame, ".remove()"), strings.Index(frame, "new maplibregl.Marker"),
+		"AddMarker must remove an existing same-id marker before constructing the replacement")
+}
+
+func TestMapAPI_MoveMarker_repositionsWithoutRecreating(t *testing.T) {
+	t.Parallel()
+	frame := fireMapAction(t, "MoveMarker", "setLngLat([3,4])", "if(_mk)")
+	assert.NotContains(t, frame, "new maplibregl.Marker",
+		"MoveMarker must reuse the existing marker, not construct a new one")
+}
+
+func TestMapAPI_RemoveMarker_guardsAgainstMissingMarker(t *testing.T) {
+	t.Parallel()
+	// The if(_mk) guard makes removing an absent id a no-op rather than a
+	// throw on undefined.
+	fireMapAction(t, "RemoveMarker", "if(_mk)", ".remove()")
+}
+
+func TestMapAPI_RemoveMarker_removesAndDropsFromRegistry(t *testing.T) {
+	t.Parallel()
+	fireMapAction(t, "RemoveMarker", ".remove()", "delete")
+}
+
+func TestMapAPI_ClearMarkers_removesEveryMarker(t *testing.T) {
+	t.Parallel()
+	fireMapAction(t, "ClearMarkers", "Object.keys", ".remove()")
+}

--- a/plugins/maplibre/multimap_test.go
+++ b/plugins/maplibre/multimap_test.go
@@ -1,0 +1,114 @@
+package maplibre_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/go-via/via"
+	"github.com/go-via/via/h"
+	"github.com/go-via/via/plugins/maplibre"
+	"github.com/go-via/via/vt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// twoMapPage mounts two independent maps on one page, each with its own click
+// handler, so we can prove they don't clobber each other's registry slot or
+// route a gesture to the wrong action.
+type twoMapPage struct {
+	A *maplibre.Map
+	B *maplibre.Map
+}
+
+func (p *twoMapPage) OnInit(ctx *via.Ctx) error {
+	if p.A == nil {
+		p.A = maplibre.NewMap(maplibre.WithElementID("mapA"), maplibre.OnClick(p.ClickA))
+		p.B = maplibre.NewMap(maplibre.WithElementID("mapB"), maplibre.OnClick(p.ClickB))
+	}
+	return nil
+}
+
+func (p *twoMapPage) View(ctx *via.CtxR) h.H {
+	return h.Body(p.A.Mount(), p.B.Mount())
+}
+
+func (p *twoMapPage) ClickA(ctx *via.Ctx) {
+	e := p.A.Event(ctx)
+	ctx.Patch.Signals(map[string]any{"clicked": "A", "gotLng": e.Lng})
+}
+
+func (p *twoMapPage) ClickB(ctx *via.Ctx) {
+	e := p.B.Event(ctx)
+	ctx.Patch.Signals(map[string]any{"clicked": "B", "gotLng": e.Lng})
+}
+
+// renderTwoMapPage boots a one-page app with two maps and returns the rendered
+// HTML plus the live server for action firing.
+func renderTwoMapPage(t *testing.T) (string, *httptest.Server) {
+	t.Helper()
+	var server *httptest.Server
+	app := via.New(via.WithPlugins(maplibre.Plugin()), via.WithTestServer(&server))
+	via.Mount[twoMapPage](app, "/")
+	t.Cleanup(server.Close)
+
+	resp, err := server.Client().Get(server.URL + "/")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	return string(body), server
+}
+
+func TestTwoMaps_eachGetsItsOwnContainerAndRegistrySlot(t *testing.T) {
+	t.Parallel()
+	html, _ := renderTwoMapPage(t)
+
+	assert.Contains(t, html, `id="mapA"`)
+	assert.Contains(t, html, `id="mapB"`)
+
+	// Two distinct registry slots — if both maps wrote the same slot, the
+	// second init would clobber the first's instance + observer.
+	slots := regexp.MustCompile(`__viaMaps\[(\d+)\]=\{m:_m`).FindAllStringSubmatch(html, -1)
+	require.Len(t, slots, 2, "each map must register exactly one slot")
+	assert.NotEqual(t, slots[0][1], slots[1][1],
+		"the two maps must occupy different registry slots")
+
+	// Two independent map constructors on the one page.
+	assert.Equal(t, 2, len(regexp.MustCompile(`new maplibregl\.Map\(`).FindAllString(html, -1)),
+		"each map must construct its own MapLibre instance")
+}
+
+func TestTwoMaps_clicksRouteToTheirOwnActions(t *testing.T) {
+	t.Parallel()
+	html, _ := renderTwoMapPage(t)
+	// Both containers carry the same custom-event name, but each wires it to
+	// its OWN action — the event is dispatched on its own container and never
+	// crosses to the sibling (non-bubbling), so this is safe.
+	assert.Contains(t, html, "/_action/ClickA")
+	assert.Contains(t, html, "/_action/ClickB")
+	assert.Equal(t, 2, len(regexp.MustCompile(`data-on:viamapclick`).FindAllString(html, -1)),
+		"each container must carry its own click listener")
+}
+
+func TestTwoMaps_eachActionReadsThePostedGesture(t *testing.T) {
+	t.Parallel()
+	_, server := renderTwoMapPage(t)
+
+	tcA := vt.NewClient(t, server, "/")
+	framesA, cancelA := tcA.SSEReady()
+	t.Cleanup(cancelA)
+	require.Equal(t, http.StatusOK,
+		tcA.Action("ClickA").WithSignal("viaMapLng", -50.5).Fire())
+	frameA := vt.AwaitFrame(t, framesA, 2*time.Second, "clicked")
+	assert.Contains(t, frameA, `"clicked":"A"`, "map A's click must run map A's action")
+	assert.Contains(t, frameA, `"gotLng":-50.5`, "map A's action must read the posted gesture")
+
+	require.Equal(t, http.StatusOK,
+		tcA.Action("ClickB").WithSignal("viaMapLng", 12.5).Fire())
+	frameB := vt.AwaitFrame(t, framesA, 2*time.Second, `"clicked":"B"`)
+	assert.Contains(t, frameB, `"gotLng":12.5`, "map B's action must read its own posted gesture")
+}

--- a/plugins/maplibre/plugin.go
+++ b/plugins/maplibre/plugin.go
@@ -1,0 +1,116 @@
+package maplibre
+
+import (
+	"fmt"
+
+	"github.com/go-via/via"
+	"github.com/go-via/via/h"
+)
+
+const (
+	defaultVersion = "5.24.0"
+
+	// dist/maplibre-gl.js is ALREADY the minified production build; there is
+	// no .min.js. The CSP variant swaps the blob-URL web worker for an inline
+	// one so a strict `worker-src` policy (no blob:) doesn't break the map.
+	jsCDN    = "https://cdn.jsdelivr.net/npm/maplibre-gl@%s/dist/maplibre-gl.js"
+	jsCSPCDN = "https://cdn.jsdelivr.net/npm/maplibre-gl@%s/dist/maplibre-gl-csp.js"
+	cssCDN   = "https://cdn.jsdelivr.net/npm/maplibre-gl@%s/dist/maplibre-gl.css"
+)
+
+// registryJS declares the per-page map registry and a re-arming style-ready
+// guard. isStyleLoaded() returns false transiently while a setStyle diff is
+// in flight, so source/layer ops re-arm on 'styledata' rather than no-op or
+// throw during the reload window.
+const registryJS = `window.__viaMaps=window.__viaMaps||{};` +
+	`window.__viaMapReady=window.__viaMapReady||function(m,fn){` +
+	`if(m.isStyleLoaded()){fn()}else{m.once('styledata',function(){window.__viaMapReady(m,fn)})}};`
+
+type pluginOptions struct {
+	version   string
+	jsSource  string
+	cssSource string
+	cspBuild  bool
+}
+
+// PluginOption configures the MapLibre plugin. Options are applied in
+// argument order; each mutates the plugin in place.
+type PluginOption func(*plugin)
+
+// WithVersion pins the MapLibre GL JS CDN version for both the JS and the
+// CSS. Pin a v5 release: v6 is ESM-only and drops the `maplibregl` global a
+// `<script src>` include relies on. Panics on empty string.
+func WithVersion(version string) PluginOption {
+	if version == "" {
+		panic("maplibre: WithVersion: version cannot be empty")
+	}
+	return func(p *plugin) { p.opts.version = version }
+}
+
+// WithSource overrides the maplibre-gl.js URL entirely — for self-hosting
+// (offline / air-gapped / strict CSP), pinning a custom build, or an internal
+// mirror. Takes precedence over WithVersion and WithCSPBuild for the JS; the
+// CSS still follows WithVersion unless WithStylesheet is also set. Panics on
+// empty string, since a silent CDN fallback would defeat opting in.
+func WithSource(url string) PluginOption {
+	if url == "" {
+		panic("maplibre: WithSource: url cannot be empty")
+	}
+	return func(p *plugin) { p.opts.jsSource = url }
+}
+
+// WithStylesheet overrides the maplibre-gl.css URL entirely. The CSS is
+// required — without it popups, markers, and controls render unstyled and
+// mispositioned. Takes precedence over WithVersion for the CSS. Panics on
+// empty string.
+func WithStylesheet(url string) PluginOption {
+	if url == "" {
+		panic("maplibre: WithStylesheet: url cannot be empty")
+	}
+	return func(p *plugin) { p.opts.cssSource = url }
+}
+
+// WithCSPBuild loads the CSP-safe bundle (maplibre-gl-csp.js) instead of the
+// default build. The default build spawns its WebGL worker from a blob: URL,
+// which a strict `worker-src` policy blocks; the CSP build inlines the worker
+// instead. Has no effect when WithSource sets an explicit JS URL.
+func WithCSPBuild() PluginOption {
+	return func(p *plugin) { p.opts.cspBuild = true }
+}
+
+// Plugin integrates MapLibre GL JS. By default it loads the JS + CSS from
+// jsDelivr at the pinned default version and exposes the `maplibregl` global.
+// Hold a [Map] on the page, mount it in View, and drive it from actions or a
+// [via.Stream] ticker over SSE.
+func Plugin(opts ...PluginOption) via.Plugin {
+	p := &plugin{opts: pluginOptions{version: defaultVersion}}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+type plugin struct {
+	opts pluginOptions
+}
+
+func (p *plugin) Register(v *via.App) {
+	js := p.opts.jsSource
+	if js == "" {
+		tmpl := jsCDN
+		if p.opts.cspBuild {
+			tmpl = jsCSPCDN
+		}
+		js = fmt.Sprintf(tmpl, p.opts.version)
+	}
+	css := p.opts.cssSource
+	if css == "" {
+		css = fmt.Sprintf(cssCDN, p.opts.version)
+	}
+
+	// Synchronous, no defer/async: maplibregl must be defined before any
+	// inline map-init script in the body runs.
+	v.AppendToHead(h.Link(h.Rel("stylesheet"), h.Href(css)))
+	v.AppendToHead(h.Script(h.Src(js)))
+	v.AppendToHead(h.Script(h.Raw(registryJS)))
+}

--- a/plugins/maplibre/plugin_test.go
+++ b/plugins/maplibre/plugin_test.go
@@ -1,0 +1,131 @@
+package maplibre_test
+
+import (
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-via/via"
+	"github.com/go-via/via/h"
+	"github.com/go-via/via/plugins/maplibre"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type maplibrePage struct{}
+
+func (p *maplibrePage) View(ctx *via.CtxR) h.H { return h.Div() }
+
+// servePage boots a one-page app with the given plugin options and returns
+// the rendered document HTML.
+func servePage(t *testing.T, opts ...maplibre.PluginOption) string {
+	t.Helper()
+
+	var server *httptest.Server
+	app := via.New(
+		via.WithPlugins(maplibre.Plugin(opts...)),
+		via.WithTestServer(&server),
+	)
+	via.Mount[maplibrePage](app, "/")
+	t.Cleanup(server.Close)
+
+	resp, err := server.Client().Get(server.URL + "/")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	return string(body)
+}
+
+func TestPlugin_injectsJSAndCSSAtDefaultVersion(t *testing.T) {
+	t.Parallel()
+	html := servePage(t)
+
+	assert.Contains(t, html, "maplibre-gl@5.24.0/dist/maplibre-gl.js",
+		"plugin must attach the MapLibre JS at the pinned default version")
+	assert.Contains(t, html, "maplibre-gl@5.24.0/dist/maplibre-gl.css",
+		"the CSS is required — popups/markers/controls break without it")
+	assert.Contains(t, html, `rel="stylesheet"`,
+		"the CSS must be a stylesheet link")
+}
+
+func TestPlugin_usesPlainNotMinJSBundle(t *testing.T) {
+	t.Parallel()
+	// dist/maplibre-gl.js IS the minified build; a .min.js path 404s.
+	html := servePage(t)
+	assert.NotContains(t, html, "maplibre-gl.min.js",
+		"there is no .min.js bundle in dist — that path would 404")
+}
+
+func TestPlugin_WithVersion_pinsBothJSAndCSS(t *testing.T) {
+	t.Parallel()
+	html := servePage(t, maplibre.WithVersion("5.1.0"))
+
+	assert.Contains(t, html, "maplibre-gl@5.1.0/dist/maplibre-gl.js")
+	assert.Contains(t, html, "maplibre-gl@5.1.0/dist/maplibre-gl.css")
+	assert.NotContains(t, html, "5.24.0",
+		"the default version must not leak through when overridden")
+}
+
+func TestPlugin_WithSource_overridesJSURLOnly(t *testing.T) {
+	t.Parallel()
+	html := servePage(t, maplibre.WithSource("/static/maplibre.js"))
+
+	assert.Contains(t, html, `src="/static/maplibre.js"`,
+		"WithSource must drop in the self-hosted JS URL")
+	assert.NotContains(t, html, "cdn.jsdelivr.net/npm/maplibre-gl@5.24.0/dist/maplibre-gl.js",
+		"WithSource must replace the CDN JS, not append alongside it")
+	assert.Contains(t, html, "maplibre-gl@5.24.0/dist/maplibre-gl.css",
+		"WithSource overrides only the JS; the CSS stays on the default CDN")
+}
+
+func TestPlugin_WithStylesheet_overridesCSSURLOnly(t *testing.T) {
+	t.Parallel()
+	html := servePage(t, maplibre.WithStylesheet("/static/maplibre.css"))
+
+	assert.Contains(t, html, `href="/static/maplibre.css"`,
+		"WithStylesheet must drop in the self-hosted CSS URL")
+	assert.Contains(t, html, "maplibre-gl@5.24.0/dist/maplibre-gl.js",
+		"WithStylesheet overrides only the CSS; the JS stays on the default CDN")
+}
+
+func TestPlugin_WithCSPBuild_usesCSPBundle(t *testing.T) {
+	t.Parallel()
+	html := servePage(t, maplibre.WithCSPBuild())
+
+	assert.Contains(t, html, "maplibre-gl-csp.js",
+		"WithCSPBuild must load the CSP-safe bundle for strict worker-src policies")
+	assert.NotContains(t, html, "/dist/maplibre-gl.js",
+		"the blob-worker default bundle must not also load under WithCSPBuild")
+}
+
+func TestPlugin_registersReadyHelperAndRegistry(t *testing.T) {
+	t.Parallel()
+	html := servePage(t)
+
+	assert.Contains(t, html, "__viaMaps",
+		"the plugin must declare the map registry namespace")
+	assert.Contains(t, html, "isStyleLoaded",
+		"the plugin must define the style-ready guard")
+	assert.Contains(t, html, "styledata",
+		"the guard must re-arm on 'styledata' rather than no-op when the style isn't loaded yet")
+}
+
+func TestPlugin_panicsOnEmptyStringOptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		call func()
+	}{
+		{"WithVersion", func() { maplibre.WithVersion("") }},
+		{"WithSource", func() { maplibre.WithSource("") }},
+		{"WithStylesheet", func() { maplibre.WithStylesheet("") }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Panics(t, tt.call,
+				"an empty URL/version produces a broken include and must be rejected at the option boundary")
+		})
+	}
+}

--- a/plugins/maplibre/popups.go
+++ b/plugins/maplibre/popups.go
@@ -1,0 +1,91 @@
+package maplibre
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-via/via"
+	"github.com/go-via/via/h"
+)
+
+// popupConfig holds the MapLibre Popup constructor options a [PopupOption] sets.
+type popupConfig struct {
+	opts map[string]any
+}
+
+// PopupOption configures a popup shown with [Map.ShowPopup] / [Map.ShowPopupHTML].
+type PopupOption func(*popupConfig)
+
+// WithoutCloseButton hides the popup's × button (MapLibre shows it by default).
+func WithoutCloseButton() PopupOption {
+	return func(c *popupConfig) { c.opts["closeButton"] = false }
+}
+
+// WithoutCloseOnClick keeps the popup open when the user clicks the map
+// (MapLibre closes it by default).
+func WithoutCloseOnClick() PopupOption {
+	return func(c *popupConfig) { c.opts["closeOnClick"] = false }
+}
+
+// PopupMaxWidth caps the popup width (any CSS length, e.g. "240px").
+func PopupMaxWidth(s string) PopupOption {
+	return func(c *popupConfig) { c.opts["maxWidth"] = s }
+}
+
+// PopupClass adds CSS classes to the popup container. Panics if any single arg
+// contains whitespace — "a b" as one arg silently becomes two classes; pass
+// them as separate args.
+func PopupClass(parts ...string) PopupOption {
+	for _, p := range parts {
+		if strings.ContainsAny(p, " \t\n\r\f") {
+			panic(fmt.Errorf("maplibre: PopupClass: class name %q must not contain whitespace (use separate args)", p))
+		}
+	}
+	return func(c *popupConfig) { c.opts["className"] = strings.Join(parts, " ") }
+}
+
+// ShowPopup opens (or replaces) a keyed popup at at, with plain-text content
+// rendered as a DOM text node — XSS-safe, so it's the right choice for
+// user-supplied content. Re-using an id replaces the previous popup rather than
+// stacking; [Map.ClosePopup] closes it. This is the "dialog on click" pattern:
+// from an [OnFeatureClick] / [OnClick] handler, ShowPopup at e.LngLat() with
+// details looked up on the server.
+func (m *Map) ShowPopup(ctx *via.Ctx, id string, at LngLat, text string, opts ...PopupOption) {
+	ctx.ExecScript(m.popupScript(id, at, "setText", text, opts))
+}
+
+// ShowPopupHTML is [Map.ShowPopup] with an [h.H] body, so you compose the popup
+// with the same h.* builders as the rest of your view. Content built with h.T
+// is escaped (safe for user data); h.Raw is injected unescaped — MapLibre does
+// not sanitize it, so only use h.Raw with trusted markup.
+func (m *Map) ShowPopupHTML(ctx *via.Ctx, id string, at LngLat, content h.H, opts ...PopupOption) {
+	ctx.ExecScript(m.popupScript(id, at, "setHTML", renderH(content), opts))
+}
+
+// popupScript builds the self-invoking script that opens (or replaces) a keyed
+// popup. setter is "setText" (safe) or "setHTML" (trusted). The popup registry
+// is created lazily so the init registry literal stays untouched.
+func (m *Map) popupScript(id string, at LngLat, setter, content string, opts []PopupOption) string {
+	cfg := &popupConfig{opts: map[string]any{}}
+	for _, o := range opts {
+		o(cfg)
+	}
+	jid := mustJSON(id)
+	var b strings.Builder
+	fmt.Fprintf(&b, "var _e=window.__viaMaps&&window.__viaMaps[%d];if(!_e||!_e.m)return;", m.seq)
+	b.WriteString("var _pp=_e.popups||(_e.popups={});")
+	fmt.Fprintf(&b, "if(_pp[%s])_pp[%s].remove();", jid, jid)
+	fmt.Fprintf(&b, "var _p=new maplibregl.Popup(%s).setLngLat(%s).%s(%s).addTo(_e.m);",
+		mustJSON(cfg.opts), mustJSON(at.pair()), setter, mustJSON(content))
+	fmt.Fprintf(&b, "_p.on('close',function(){delete _pp[%s]});", jid)
+	fmt.Fprintf(&b, "_pp[%s]=_p;", jid)
+	return "(function(){" + b.String() + "})();"
+}
+
+// ClosePopup closes the keyed popup. A no-op if no popup holds that id.
+func (m *Map) ClosePopup(ctx *via.Ctx, id string) {
+	jid := mustJSON(id)
+	ctx.ExecScript(fmt.Sprintf(
+		"(function(){var _e=window.__viaMaps&&window.__viaMaps[%d];var _pp=_e&&_e.popups;var _p=_pp&&_pp[%s];if(_p){_p.remove();delete _pp[%s]}})();",
+		m.seq, jid, jid))
+}

--- a/plugins/maplibre/popups_test.go
+++ b/plugins/maplibre/popups_test.go
@@ -1,0 +1,130 @@
+package maplibre_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-via/via/plugins/maplibre"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShowPopup_opensAKeyedTextPopupAtALocation(t *testing.T) {
+	t.Parallel()
+	// The interactive-dialog pattern: react to a click by showing an info
+	// bubble at a point, driven from Go.
+	frame := fireMapAction(t, "ShowPopup", "new maplibregl.Popup(")
+	assert.Contains(t, frame, "setLngLat([-122.42,37.77])", "at the given LngLat")
+	assert.Contains(t, frame, `.setText("Hello there")`, "with plain-text content (the XSS-safe sink)")
+	assert.Contains(t, frame, "addTo(_e.m)", "added to the map")
+	assert.Contains(t, frame, `_pp["info"]=`, "stored under its id for later ClosePopup")
+	assert.Contains(t, frame, "_e.popups||(_e.popups={})",
+		"the popup registry is lazily created so the initJS registry literal is untouched")
+	// When the user closes the popup themselves (× button or map click), the
+	// registry key must be dropped so it doesn't hold a stale reference.
+	assert.Contains(t, frame, `_p.on('close',function(){delete _pp["info"]})`,
+		"a user-initiated close must clean up the registry entry")
+}
+
+func TestShowPopupHTML_usesTheTrustedHTMLSink(t *testing.T) {
+	t.Parallel()
+	frame := fireMapAction(t, "ShowPopupHTML", "new maplibregl.Popup(")
+	// Content is unicode-escaped by mustJSON for safe <script> transport (the
+	// browser decodes it back), so assert the setHTML SINK, not the literal.
+	assert.Contains(t, frame, ".setHTML(", "HTML content uses the setHTML sink")
+	assert.Contains(t, frame, `trusted`, "carrying the markup")
+	assert.NotContains(t, frame, ".setText(", "HTML mode must not also setText")
+}
+
+func TestShowPopupHTML_composesStructuredContentWithHBuilders(t *testing.T) {
+	t.Parallel()
+	// The point of taking h.H: build popup bodies with the same h.* builders
+	// as the rest of the view, not a hand-concatenated HTML string.
+	frame := fireMapAction(t, "ShowPopupStructured", "new maplibregl.Popup(")
+	assert.Contains(t, frame, ".setHTML(", "structured content uses the HTML sink")
+	assert.Contains(t, frame, "Title", "the rendered node's heading must be present")
+	assert.Contains(t, frame, "body text", "and its body")
+	// The h3/p TAGS must survive rendering. They're real HTML from h.H3/h.P,
+	// unicode-escaped by mustJSON for transport (<h3> -> <h3>), which
+	// proves the h.H was actually Render()ed to structured HTML, not stringified.
+	assert.Contains(t, frame, `\u003ch3\u003e`, "the h3 element must be rendered")
+	assert.Contains(t, frame, `\u003cp\u003e`, "the p element must be rendered")
+}
+
+func TestShowPopupHTML_hTextEscapesUserContentSoItCannotBreakOut(t *testing.T) {
+	t.Parallel()
+	// The safety win of h.H over a raw string: h.T escapes the content, so even
+	// a </script> in user data can't break out of the inline script (and
+	// mustJSON unicode-escapes for transport on top of that).
+	frame := fireMapAction(t, "ShowPopupEscaped", "new maplibregl.Popup(")
+	// Distinguish h.T escaping from mere JSON escaping: h.T turns the user's
+	// '<' into '&lt;' BEFORE mustJSON, so mustJSON escapes the '&' and the frame
+	// shows the entity form &lt;. Raw content (no h.T) would instead let
+	// mustJSON escape the '<' directly to <b>evil — which must NOT
+	// appear. This is exactly the assertion that fails if h.T is bypassed.
+	assert.Contains(t, frame, `\u0026lt;`, "h.T must escape the user's '<' to '&lt;' before transport")
+	assert.NotContains(t, frame, `\u003cb\u003eevil`, "the user's <b> must not survive as a real tag")
+}
+
+func TestShowPopupHTML_nilContentIsASafeEmptyPopup(t *testing.T) {
+	t.Parallel()
+	// A nil h.H must not panic (nil.Render) — it renders an empty body.
+	frame := fireMapAction(t, "ShowPopupNilHTML", "new maplibregl.Popup(")
+	assert.Contains(t, frame, `.setHTML("")`, "nil content renders as an empty popup, not a crash")
+}
+
+func TestShowPopup_escapesScriptBreakoutInTextContent(t *testing.T) {
+	t.Parallel()
+	// The content is inlined into a <script>; a </script> in it must be
+	// unicode-escaped by mustJSON, and setText is the safe DOM sink.
+	frame := fireMapAction(t, "ShowPopupXSS", "new maplibregl.Popup(")
+	assert.NotContains(t, frame, "</script><img", "the breakout must be unicode-escaped")
+	assert.Contains(t, frame, ".setText(", "user content must go through the XSS-safe setText sink")
+}
+
+func TestShowPopup_replacesSameIDInsteadOfStacking(t *testing.T) {
+	t.Parallel()
+	// Re-showing the same id must replace, so repeated clicks don't pile up
+	// popups — mirrors AddMarker's keyed-replace behavior.
+	frame := fireMapAction(t, "ShowPopup", "new maplibregl.Popup(")
+	assert.Contains(t, frame, `if(_pp["info"])_pp["info"].remove()`,
+		"an existing same-id popup must be removed before the new one is added")
+	assert.Less(t, strings.Index(frame, `_pp["info"].remove()`), strings.Index(frame, "new maplibregl.Popup("),
+		"the remove must come before constructing the replacement")
+}
+
+func TestClosePopup_removesTheKeyedPopup(t *testing.T) {
+	t.Parallel()
+	frame := fireMapAction(t, "ClosePopup", "_e.popups")
+	assert.Contains(t, frame, ".remove()", "ClosePopup must remove the popup")
+	assert.Contains(t, frame, `delete _pp["info"]`, "and drop it from the registry")
+	// Closing a popup that was never opened (or already closed) must be a safe
+	// no-op — guard on the registry and the entry both existing.
+	assert.Contains(t, frame, "_e&&_e.popups", "must guard the popup registry existing")
+	assert.Contains(t, frame, "if(_p){", "the remove/delete must be guarded by the popup existing")
+}
+
+func TestShowPopup_optionsConfigureThePopupChrome(t *testing.T) {
+	t.Parallel()
+	frame := fireMapAction(t, "ShowPopupOpts", "new maplibregl.Popup(")
+	assert.Contains(t, frame, `"closeButton":false`, "WithoutCloseButton")
+	assert.Contains(t, frame, `"closeOnClick":false`, "WithoutCloseOnClick")
+	assert.Contains(t, frame, `"maxWidth":"240px"`, "PopupMaxWidth")
+	assert.Contains(t, frame, `"className":"card lg"`, "PopupClass joins parts with a space")
+}
+
+func TestPopupClass_panicsOnWhitespaceInASinglePart(t *testing.T) {
+	t.Parallel()
+	// "a b" as one arg would silently become two classes — surface it eagerly,
+	// like WithClass.
+	assert.Panics(t, func() { maplibre.PopupClass("a b") })
+}
+
+func TestShowPopup_doesNotChangeTheInitRegistryLiteral(t *testing.T) {
+	t.Parallel()
+	// Popups lazily create _e.popups, so the initJS registry assignment must
+	// still be exactly {m:_m,ro:_ro,markers:{}} — marker/ordering tests depend
+	// on that literal.
+	html := render(t, maplibre.NewMap(maplibre.WithElementID("m")))
+	assert.Contains(t, html, "={m:_m,ro:_ro,markers:{}}",
+		"the registry literal must be unchanged by the popup feature")
+}

--- a/plugins/maplibre/withmarker_test.go
+++ b/plugins/maplibre/withmarker_test.go
@@ -1,0 +1,134 @@
+package maplibre_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-via/via"
+	"github.com/go-via/via/h"
+	"github.com/go-via/via/plugins/maplibre"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithMarker_placesAStaticMarkerAtConstruction(t *testing.T) {
+	t.Parallel()
+	html := render(t, maplibre.NewMap(
+		maplibre.WithElementID("m"),
+		maplibre.WithMarker("home", maplibre.At(-0.1, 51.5),
+			maplibre.Color("#ff0000"), maplibre.PopupText("Home")),
+	))
+
+	assert.Contains(t, html, "new maplibregl.Marker(", "the static marker must be constructed")
+	assert.Contains(t, html, "setLngLat([-0.1,51.5])", "at its [lng, lat]")
+	assert.Contains(t, html, `"color":"#ff0000"`, "honoring its MarkerOptions")
+	assert.Contains(t, html, `.setText("Home")`, "including its popup")
+	assert.Contains(t, html, "addTo(_e.m)", "and added to the map")
+	assert.Contains(t, html, `_e.markers["home"]=`, "and stored under its id for later MoveMarker/RemoveMarker")
+}
+
+func TestWithMarker_rendersAfterTheRegistryEntryExists(t *testing.T) {
+	t.Parallel()
+	// markerScript looks up window.__viaMaps[seq] as _e; that slot is assigned
+	// at the end of init, so a construction marker emitted before it would
+	// no-op (the `if(!_e)return` guard). It must come AFTER the assignment.
+	html := render(t, maplibre.NewMap(
+		maplibre.WithElementID("m"),
+		maplibre.WithMarker("home", maplibre.At(-0.1, 51.5)),
+	))
+	registry := strings.Index(html, "={m:_m,ro:_ro,markers:{}}")
+	marker := strings.Index(html, "new maplibregl.Marker(")
+	require.NotEqual(t, -1, registry, "registry entry must be assigned")
+	require.NotEqual(t, -1, marker, "marker must be constructed")
+	assert.Less(t, registry, marker,
+		"the registry entry must be assigned before the construction marker runs")
+}
+
+func TestWithMarker_multipleStaticMarkersEachRender(t *testing.T) {
+	t.Parallel()
+	// Several fixed pins (one bare, one styled) must all render without
+	// clobbering each other's id slot.
+	html := render(t, maplibre.NewMap(
+		maplibre.WithElementID("m"),
+		maplibre.WithMarker("a", maplibre.At(0, 0)),
+		maplibre.WithMarker("b", maplibre.At(1, 1), maplibre.Color("#00ff00")),
+	))
+	assert.Equal(t, 2, strings.Count(html, "new maplibregl.Marker("),
+		"each static marker must be constructed")
+	assert.Contains(t, html, `_e.markers["a"]=`)
+	assert.Contains(t, html, `_e.markers["b"]=`)
+}
+
+func TestWithMarker_adjacentMarkersDoNotFuseIntoACall(t *testing.T) {
+	t.Parallel()
+	// Each construction marker is emitted as a self-invoking IIFE. Without a
+	// statement terminator between them, two adjacent IIFEs read as
+	// `})()(function(){...` — JS parses the second IIFE as an argument to a
+	// CALL on the first IIFE's return value (undefined), throwing a TypeError
+	// at runtime and aborting every marker after the first. The emitted JS
+	// must keep the marker scripts as separate statements.
+	html := render(t, maplibre.NewMap(
+		maplibre.WithElementID("m"),
+		maplibre.WithMarker("a", maplibre.At(0, 0)),
+		maplibre.WithMarker("b", maplibre.At(1, 1)),
+	))
+	assert.NotContains(t, html, "})()(function(){",
+		"adjacent marker IIFEs must not fuse into a call expression")
+}
+
+func TestWithMarker_honorsMarkerClickWiring(t *testing.T) {
+	t.Parallel()
+	// A construction marker on a map with OnMarkerClick must get the same
+	// click listener as a runtime AddMarker would — markerScript reads
+	// m.markerClick at render time, after all options applied.
+	p := &eventPage{}
+	html := render(t, maplibre.NewMap(
+		maplibre.WithElementID("m"),
+		maplibre.OnMarkerClick(p.Selected),
+		maplibre.WithMarker("home", maplibre.At(-0.1, 51.5)),
+	))
+	assert.Contains(t, html, "viamarkerclick",
+		"a construction marker must dispatch the marker-click event when OnMarkerClick is set")
+	assert.Contains(t, html, "getElement().style.cursor='pointer'",
+		"and read as clickable")
+}
+
+// staticMarkerPage has NO OnConnect — the marker is declared at construction.
+type staticMarkerPage struct {
+	Map *maplibre.Map
+}
+
+func (p *staticMarkerPage) OnInit(ctx *via.Ctx) error {
+	if p.Map == nil {
+		p.Map = maplibre.NewMap(
+			maplibre.WithElementID("m"),
+			maplibre.WithMarker("home", maplibre.At(-0.1, 51.5), maplibre.PopupText("Home")),
+		)
+	}
+	return nil
+}
+
+func (p *staticMarkerPage) View(ctx *via.CtxR) h.H { return p.Map.Mount() }
+
+func TestWithMarker_needsNoOnConnectToAppear(t *testing.T) {
+	t.Parallel()
+	// The whole point: a fixed marker must show on first paint, with no
+	// OnConnect and no SSE round-trip — so it's in the GET response body.
+	var server *httptest.Server
+	app := via.New(via.WithPlugins(maplibre.Plugin()), via.WithTestServer(&server))
+	via.Mount[staticMarkerPage](app, "/")
+	t.Cleanup(server.Close)
+
+	resp, err := server.Client().Get(server.URL + "/")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+
+	assert.Contains(t, string(body), "new maplibregl.Marker(",
+		"the static marker must be present in the initial HTML, not an SSE frame")
+	assert.Contains(t, string(body), `_e.markers["home"]=`)
+}


### PR DESCRIPTION
Adds `plugins/maplibre`: a MapLibre GL JS v5 plugin for building **interactive map applications driven entirely from Go over SSE** — no client JavaScript.

## What's included
- **Construction (declarative):** `NewMap` with center/zoom/pitch/bearing, controls, GeoJSON sources + layers, `WithMarker` static markers, `GenerateFeatureIDs`. Coordinates are typed — `LngLat{Lng,Lat}`/`At(lng,lat)` and `Bounds{W,S,E,N}` defuse the lng/lat & bbox swap foot-guns.
- **Outbound (Go → map):** camera (`FlyTo`/`EaseTo`/`JumpTo`/`SetCenter`/`FitBounds`), markers (`AddMarker`/`MoveMarker`/`RemoveMarker`/`ClearMarkers`), GeoJSON data layers, `Call`/`WithMapOption` escape hatches.
- **Inbound (gestures → Go):** `OnClick`, `OnMoveEnd`, `OnMarkerClick`, `OnMarkerDragEnd`, `OnFeatureClick`, and a generic `OnMapEvent` escape hatch — bound methods (via the `via.Action` constraint, **no public `any`**) read a typed `MapEvent` carrying the live camera.
- **Styling:** typed expression builders (`Get`/`FeatureState`/`Zoom`/`Boolean`/`Case`/`Interpolate`/`Step`) + `WhenHovered`/`WhenState` sugar, replacing raw `[]any` trees. `WithFeatureHover` highlights client-side via feature-state.
- **Dialogs:** `ShowPopup`/`ShowPopupHTML`/`ClosePopup` — keyed server-driven popups; the HTML variant and marker `PopupHTML` take an `h.H`, so bodies compose with `h.*` (`h.T` escapes user data).

## Notes / safety
- Inbound-event signals use a non-underscore namespace — datastar silently drops `_`-prefixed local signals (caught via browser testing; guarded by a unit test).
- XSS: user content goes through `setText`/`h.T`; all inlined JS values are unicode-escaped via `mustJSON` so `</script>` can't break out.
- Multi-map pages are isolated by per-map registry slots (verified).

## Verification
- Full unit + integration test suite green (`go test ./...`), `go vet`, `gofmt` clean.
- Browser-verified on localhost: click-to-place, marker click/drag, feature click, hover-highlight, right-click, multi-map routing, and popups.

Docs in `plugins/maplibre/doc.go`; runnable demo in `internal/examples/maps`.