### PR TITLE
docs: cover the maplibre plugin's interactive features

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -32,6 +32,7 @@ walked through step by step in the [tutorial](tutorial).
 | [auth](https://github.com/go-via/via/tree/main/internal/examples/auth) | Typed sessions, `requireAuth` middleware, and `sess.Rotate` after login. |
 | [todos](https://github.com/go-via/via/tree/main/internal/examples/todos) | `StateSess[T]` survives reload, `h.Each`, and `on.SetSignal` for client-bundled writes. |
 | [sysmon](https://github.com/go-via/via/tree/main/internal/examples/sysmon) | An `OnConnect`-driven ticker streaming CPU / RAM / disk / net into ECharts, with a pause + interval-slider UI via `via.Ticker`. |
+| [maps](https://github.com/go-via/via/tree/main/internal/examples/maps) | `maplibre.Plugin()` driving an interactive world map — city fly-to, a ticker-moved "drone", click-to-place pins, marker & feature clicks, hover highlight, and popups, all from Go over SSE. |
 | [upload](https://github.com/go-via/via/tree/main/internal/examples/upload) | A `via.File` field bound to a `multipart/form-data` `<form>`, persisted to disk with a redirect back. |
 | [feed](https://github.com/go-via/via/tree/main/internal/examples/feed) | An append-only / bounded-ring slice stream driven by `Signal[[]T].Update`, paused and cleared from actions. |
 

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -13,4 +13,4 @@ Task-focused references for the parts of an app.
 - [Rendering (h)](rendering) — the HTML DSL.
 - [Routing, sessions & middleware](routing-sessions-middleware).
 - [File uploads](file-uploads) — the `via.File` field.
-- [Plugins](plugins) — picocss, echarts, and writing your own.
+- [Plugins](plugins) — picocss, echarts, maplibre, and writing your own.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -125,6 +125,19 @@ The runtime surface, all delivered over SSE:
   with `SetGeoJSON(ctx, sourceID, fc)`. Build GeoJSON with `Point`,
   `LineString`, `Polygon`, `Feature`, `FeatureCollection`; build layers with
   `CircleLayer` / `LineLayer` / `FillLayer` / `SymbolLayer`.
+- Events — drive Go from user gestures: `OnClick`, `OnMoveEnd`,
+  `OnMarkerClick`, `OnMarkerDragEnd`, `OnFeatureClick`, and a generic
+  `OnMapEvent` escape hatch (right-click, double-click, …). Each takes a bound
+  method that reads a typed `MapEvent` — the clicked `LngLat`, the `MarkerID` /
+  `FeatureID`, and the live camera — via `p.Map.Event(ctx)`. `WithFeatureHover`
+  highlights the hovered feature client-side, with no round-trip.
+- Styling — compose data-driven paint/layout values with typed expression
+  builders instead of raw `[]any`: `Get`, `FeatureState`, `Zoom`, `Boolean`,
+  `Case`, `Interpolate`, `Step`, plus `WhenHovered` / `WhenState` sugar (e.g.
+  `Paint("fill-color", WhenHovered("#ffcc00", "#5856d6"))`).
+- Dialogs — `ShowPopup(ctx, id, at, text)` / `ShowPopupHTML` (an `h.H` body) /
+  `ClosePopup` show keyed, server-driven popups; the "open a popup at the
+  clicked feature" pattern pairs naturally with `OnFeatureClick`.
 - Lifecycle — `SetStyle`, `Resize`, `Dispose`, and the `Call(ctx, method,
   args…)` escape hatch for any Map method the typed API misses.
 


### PR DESCRIPTION
Follow-up to #91. The plugins guide only described the base map; document the interactive surface that shipped in v0.4.2 — events, WithFeatureHover, typed styling expressions, and popups — add the `maps` example to the examples table, and list maplibre in the guides plugin line.