### PR TITLE
ci: skip the Go pipeline on docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,25 +13,61 @@ permissions:
 
 jobs:
   build-test:
+    # NOTE: this job always RUNS and reports, even for docs-only changes — only
+    # its heavy steps are skipped (see the "Detect" step). Keeping the job (and
+    # its "Build and Test" name) unconditional is deliberate: it is a required
+    # status check, and a `paths`/`paths-ignore` trigger filter would make the
+    # workflow not run on a docs-only PR, leaving the required check pending
+    # forever and blocking the merge.
     name: Build and Test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # need history to diff against the base for the docs-only check
+
+      - name: Detect code (non-docs) changes
+        id: changes
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          [ -n "$base" ] || base="${{ github.event.before }}"
+          zero="0000000000000000000000000000000000000000"
+          # Unknown/zero/unreachable base (first push, force-push, new branch) →
+          # run the full pipeline (fail safe; never skip CI on uncertainty).
+          if [ -z "$base" ] || [ "$base" = "$zero" ] || ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            # Capture changed files that are NOT markdown / not under docs/. Using
+            # a non-empty check (not `grep -q`'s exit code) keeps this correct
+            # across grep implementations. `|| true` guards the no-match exit
+            # under `set -e`-style runners.
+            nondoc="$(git diff --name-only "$base" "${{ github.sha }}" | grep -vE '(\.md$|^docs/)' || true)"
+            if [ -n "$nondoc" ]; then
+              echo "code=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "code=false" >> "$GITHUB_OUTPUT"
+              echo "Only markdown/docs changed — skipping the Go CI pipeline."
+            fi
+          fi
 
       - name: Setup Go
+        if: steps.changes.outputs.code == 'true'
         uses: actions/setup-go@v5
         with:
           go-version: '1.26.4'
           cache: true
 
       - name: Setup Node
+        if: steps.changes.outputs.code == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
 
       - name: Install markdownlint-cli
+        if: steps.changes.outputs.code == 'true'
         run: npm install -g markdownlint-cli
 
       - name: Run CI checks
+        if: steps.changes.outputs.code == 'true'
         run: bash ./ci-check.sh


### PR DESCRIPTION
Follow-up to #93. Makes a **docs-only** push/PR (markdown anywhere, or anything under `docs/`) skip the Go CI pipeline (gofmt / vet / golangci-lint / govulncheck / build / `-race` tests / alloc gates), finishing in seconds instead of minutes.

## Why not `paths`/`paths-ignore`
"Build and Test" is a **required** status check. A trigger-level `paths` filter would make the workflow *not run at all* on a docs-only PR → the required check stays pending forever → the PR can never merge (the classic GitHub footgun).

## Approach
The `build-test` job stays unconditional (so the required check always runs and reports), but its heavy steps are gated on a first-party git-diff step (no third-party action):
- `Detect code (non-docs) changes` diffs the PR/push base against `HEAD`; `code=true` iff any changed file is **not** markdown and **not** under `docs/`.
- Setup Go/Node + `ci-check.sh` run only when `code == 'true'`; otherwise the job logs "skipping" and goes green.
- **Fail-safe:** an unknown/zero/unreachable base (first push, force-push, new branch) runs the full pipeline — never skip CI on uncertainty.

Verified the heuristic locally: docs-only → skip; code-only → run; **mixed (code + docs) → run**; empty → skip. (Used a non-empty-output check rather than `grep -q`'s exit code so it's correct across grep implementations.)

This PR itself touches a workflow file (not docs), so it runs the full pipeline.