### PR TITLE
chore: encapsulate Ctx.Patch behind a method

### DIFF
--- a/action_test.go
+++ b/action_test.go
@@ -293,7 +293,7 @@ func (p *queueOrderPage) BumpAndOverride(ctx *via.Ctx) error {
 	if err := p.N.Update(ctx, func(n int) (int, error) { return n + 1, nil }); err != nil {
 		return err
 	}
-	ctx.Patch.Elements(h.Div(h.ID("n"), h.Text("OVERRIDE")))
+	ctx.Patch().Elements(h.Div(h.ID("n"), h.Text("OVERRIDE")))
 	return nil
 }
 
@@ -435,16 +435,16 @@ func TestPanickingRenderDoesNotEraseQueuedGoodRender(t *testing.T) {
 type explicitQueuePage struct{}
 
 func (p *explicitQueuePage) PushA(ctx *via.Ctx) {
-	ctx.Patch.Elements(h.Div(h.ID("a"), h.Text("PATCH-A")))
+	ctx.Patch().Elements(h.Div(h.ID("a"), h.Text("PATCH-A")))
 }
 
 func (p *explicitQueuePage) PushB(ctx *via.Ctx) {
-	ctx.Patch.Elements(h.Div(h.ID("b"), h.Text("PATCH-B")))
+	ctx.Patch().Elements(h.Div(h.ID("b"), h.Text("PATCH-B")))
 }
 
 func (p *explicitQueuePage) PushSilent(ctx *via.Ctx) {
 	ctx.SyncOff()
-	ctx.Patch.Elements(h.Div(h.ID("a"), h.Text("PATCH-A")))
+	ctx.Patch().Elements(h.Div(h.ID("a"), h.Text("PATCH-A")))
 }
 
 func (p *explicitQueuePage) View(ctx *via.CtxR) h.H { return h.Div(h.ID("root")) }

--- a/broadcast.go
+++ b/broadcast.go
@@ -46,7 +46,7 @@ func (a *App) BroadcastSignals(values map[string]any) int {
 	}
 	ctxs := a.snapshotContexts()
 	for _, c := range ctxs {
-		c.Patch.Signals(values)
+		c.patch.Signals(values)
 	}
 	return len(ctxs)
 }

--- a/ctx.go
+++ b/ctx.go
@@ -78,7 +78,7 @@ type Ctx struct {
 	// `func(*Ctx) error` shape; nil means "no such hook".
 	viewFn    func(*CtxR) h.H
 	ctxR      *CtxR  // read-only view, allocated eagerly in newCtx
-	Patch     *Patch // wire-push primitives, allocated eagerly in newCtx
+	patch     *Patch // wire-push primitives, allocated eagerly in newCtx
 	initFn    func(*Ctx) error
 	connectFn func(*Ctx) error
 	disposeFn func(*Ctx)
@@ -226,6 +226,14 @@ func (ctx *Ctx) Request() *http.Request {
 	return ctx.r
 }
 
+// Patch returns the imperative client-push handle for this request —
+// the escape hatch for pushing a signal value to a key not bound to a
+// typed Signal[T], or morphing an arbitrary element fragment into the
+// live DOM. See [Patch] for the primitives. The handle is allocated
+// eagerly in newCtx, so this is a plain field load that never returns
+// nil for a live ctx.
+func (ctx *Ctx) Patch() *Patch { return ctx.patch }
+
 // Session returns a [Session] bound to ctx. Stores performed through
 // the returned handle mark the page dirty and fan out to subscribed
 // tabs. Survives tab close; expires per [WithSessionTTL].
@@ -335,7 +343,7 @@ func (ctx *Ctx) SyncNow() {
 // browser this action. A later loud action that re-touches the state
 // surfaces the value via the normal dirty-bit path.
 //
-// Explicit publish primitives (ctx.Patch.{Signal,Signals,Element,Elements},
+// Explicit publish primitives (ctx.Patch().{Signal,Signals,Element,Elements},
 // ExecScript, Toast, Reload, Redirect) are NOT suppressed by SyncOff
 // — they enqueue patches directly rather than through the dirty-bit
 // flush. This is deliberate so a panic-recovery error toast still

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -239,7 +239,7 @@ func (c *connectStateCheck) OnConnect(ctx *via.Ctx) error {
 	}
 	// Drive a signal so the SSE drain has something to flush — that's
 	// the await condition below.
-	ctx.Patch.Signal("_connected", true)
+	ctx.Patch().Signal("_connected", true)
 	return nil
 }
 
@@ -928,13 +928,13 @@ func (p *syncOffExplicitPage) SilentToast(ctx *via.Ctx) error {
 
 func (p *syncOffExplicitPage) SilentPatchSignal(ctx *via.Ctx) error {
 	ctx.SyncOff()
-	ctx.Patch.Signal("_marker", "hello")
+	ctx.Patch().Signal("_marker", "hello")
 	return nil
 }
 
 func (p *syncOffExplicitPage) SilentSyncElements(ctx *via.Ctx) error {
 	ctx.SyncOff()
-	ctx.Patch.Elements(h.Div(h.ID("marker"), h.Text("morphed")))
+	ctx.Patch().Elements(h.Div(h.ID("marker"), h.Text("morphed")))
 	return nil
 }
 

--- a/patch_test.go
+++ b/patch_test.go
@@ -10,19 +10,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ctx.Patch.* groups the low-level wire-push primitives behind a single
+// ctx.Patch().* groups the low-level wire-push primitives behind a single
 // sub-object so they don't crowd the top-level Ctx surface and read as
 // what they are: emit-a-frame, not the first-reach for typed state.
 
 type patchPage struct{}
 
 func (p *patchPage) PushSignal(ctx *via.Ctx) error {
-	ctx.Patch.Signal("_picoTheme", "purple")
+	ctx.Patch().Signal("_picoTheme", "purple")
 	return nil
 }
 
 func (p *patchPage) PushSignalsBatch(ctx *via.Ctx) error {
-	ctx.Patch.Signals(map[string]any{
+	ctx.Patch().Signals(map[string]any{
 		"_picoTheme": "amber",
 		"_density":   3,
 	})
@@ -30,12 +30,12 @@ func (p *patchPage) PushSignalsBatch(ctx *via.Ctx) error {
 }
 
 func (p *patchPage) PushElement(ctx *via.Ctx) error {
-	ctx.Patch.Element(h.Div(h.ID("solo"), h.Text("only")))
+	ctx.Patch().Element(h.Div(h.ID("solo"), h.Text("only")))
 	return nil
 }
 
 func (p *patchPage) PushElements(ctx *via.Ctx) error {
-	ctx.Patch.Elements(
+	ctx.Patch().Elements(
 		h.Div(h.ID("a"), h.Text("first")),
 		h.Div(h.ID("b"), h.Text("second")),
 	)
@@ -43,12 +43,12 @@ func (p *patchPage) PushElements(ctx *via.Ctx) error {
 }
 
 func (p *patchPage) EmptyGuards(ctx *via.Ctx) error {
-	ctx.Patch.Signal("", "ignored")
-	ctx.Patch.Signals(nil)
-	ctx.Patch.Signals(map[string]any{})
-	ctx.Patch.Element(nil)
-	ctx.Patch.Elements()
-	ctx.Patch.Elements(nil, nil)
+	ctx.Patch().Signal("", "ignored")
+	ctx.Patch().Signals(nil)
+	ctx.Patch().Signals(map[string]any{})
+	ctx.Patch().Element(nil)
+	ctx.Patch().Elements()
+	ctx.Patch().Elements(nil, nil)
 	return nil
 }
 

--- a/plugins/maplibre/events_test.go
+++ b/plugins/maplibre/events_test.go
@@ -45,30 +45,30 @@ func (p *eventPage) AddPin(ctx *via.Ctx) {
 // Selected / Moved echo the marker identity + position the gesture posted.
 func (p *eventPage) Selected(ctx *via.Ctx) {
 	e := p.Map.Event(ctx)
-	ctx.Patch.Signals(map[string]any{"gotId": e.MarkerID, "gotLng": e.Lng, "gotLat": e.Lat})
+	ctx.Patch().Signals(map[string]any{"gotId": e.MarkerID, "gotLng": e.Lng, "gotLat": e.Lat})
 }
 
 func (p *eventPage) Moved(ctx *via.Ctx) {
 	e := p.Map.Event(ctx)
-	ctx.Patch.Signals(map[string]any{"gotId": e.MarkerID, "gotLng": e.Lng, "gotLat": e.Lat})
+	ctx.Patch().Signals(map[string]any{"gotId": e.MarkerID, "gotLng": e.Lng, "gotLat": e.Lat})
 }
 
 // Picked echoes which feature the user clicked in a data layer.
 func (p *eventPage) Picked(ctx *via.Ctx) {
 	e := p.Map.Event(ctx)
-	ctx.Patch.Signals(map[string]any{"gotFid": e.FeatureID, "gotLng": e.Lng, "gotLat": e.Lat})
+	ctx.Patch().Signals(map[string]any{"gotFid": e.FeatureID, "gotLng": e.Lng, "gotLat": e.Lat})
 }
 
 // PlacePin echoes the clicked coordinates back as signals.
 func (p *eventPage) PlacePin(ctx *via.Ctx) {
 	e := p.Map.Event(ctx)
-	ctx.Patch.Signals(map[string]any{"gotLng": e.Lng, "gotLat": e.Lat})
+	ctx.Patch().Signals(map[string]any{"gotLng": e.Lng, "gotLat": e.Lat})
 }
 
 // Recenter echoes the settled viewport back as signals.
 func (p *eventPage) Recenter(ctx *via.Ctx) {
 	e := p.Map.Event(ctx)
-	ctx.Patch.Signals(map[string]any{
+	ctx.Patch().Signals(map[string]any{
 		"gotZoom": e.Zoom, "gotBearing": e.Bearing, "gotPitch": e.Pitch,
 		"gotW": e.West, "gotS": e.South, "gotE": e.East, "gotN": e.North,
 	})

--- a/plugins/maplibre/map_test.go
+++ b/plugins/maplibre/map_test.go
@@ -246,12 +246,12 @@ func (p *twoMapPage) View(ctx *via.CtxR) h.H {
 
 func (p *twoMapPage) ClickA(ctx *via.Ctx) {
 	e := p.A.Event(ctx)
-	ctx.Patch.Signals(map[string]any{"clicked": "A", "gotLng": e.Lng})
+	ctx.Patch().Signals(map[string]any{"clicked": "A", "gotLng": e.Lng})
 }
 
 func (p *twoMapPage) ClickB(ctx *via.Ctx) {
 	e := p.B.Event(ctx)
-	ctx.Patch.Signals(map[string]any{"clicked": "B", "gotLng": e.Lng})
+	ctx.Patch().Signals(map[string]any{"clicked": "B", "gotLng": e.Lng})
 }
 
 // renderTwoMapPage boots a one-page app with two maps and returns the rendered

--- a/push.go
+++ b/push.go
@@ -19,13 +19,13 @@ import (
 // element fragment into the live DOM. Reach for these only when the
 // typed path (Signal[T].Set, View re-render) doesn't fit:
 //
-//	ctx.Patch.Signal("_picoTheme", "purple")           // ad-hoc client signal
-//	ctx.Patch.Signals(map[string]any{"a": 1, "b": 2})  // batched merge
-//	ctx.Patch.Element(h.Div(h.ID("toast"), ...))       // single morph
-//	ctx.Patch.Elements(div1, div2)                     // variadic morph batch
+//	ctx.Patch().Signal("_picoTheme", "purple")           // ad-hoc client signal
+//	ctx.Patch().Signals(map[string]any{"a": 1, "b": 2})  // batched merge
+//	ctx.Patch().Element(h.Div(h.ID("toast"), ...))       // single morph
+//	ctx.Patch().Elements(div1, div2)                     // variadic morph batch
 //
-// The Patch handle is allocated eagerly in newCtx; access is a plain
-// field load with no allocation. Mirrors how *CtxR is cached.
+// The Patch handle is allocated eagerly in newCtx; ctx.Patch() is a
+// plain field load with no allocation. Mirrors how *CtxR is cached.
 type Patch struct {
 	ctx *Ctx
 }

--- a/push_test.go
+++ b/push_test.go
@@ -14,7 +14,7 @@ import (
 type syncPage struct{}
 
 func (p *syncPage) PushList(ctx *via.Ctx) error {
-	ctx.Patch.Elements(
+	ctx.Patch().Elements(
 		h.Ul(h.ID("results"),
 			h.Li(h.Text("first")),
 			h.Li(h.Text("second")),
@@ -24,7 +24,7 @@ func (p *syncPage) PushList(ctx *via.Ctx) error {
 }
 
 func (p *syncPage) PickTheme(ctx *via.Ctx) error {
-	ctx.Patch.Signal("_picoTheme", "purple")
+	ctx.Patch().Signal("_picoTheme", "purple")
 	return nil
 }
 

--- a/render.go
+++ b/render.go
@@ -254,7 +254,7 @@ func (a *App) renderFragment(ctx *Ctx) string {
 	buf := getRenderBuf()
 	defer putRenderBuf(buf)
 	// View runs without queue.mu held — user code is allowed to call
-	// ctx.Patch.Signal / ctx.Patch.Elements, which would deadlock on a
+	// ctx.Patch().Signal / ctx.Patch().Elements, which would deadlock on a
 	// re-entrant queue.mu acquisition.
 	ctx.beginRender()
 	defer ctx.endRender()

--- a/runtime.go
+++ b/runtime.go
@@ -140,7 +140,7 @@ func newCtx(a *App, d *cmpDescriptor, cmpVal reflect.Value, id string) *Ctx {
 	}
 	ctx.app = a
 	ctx.ctxR = &CtxR{ctx: ctx}
-	ctx.Patch = &Patch{ctx: ctx}
+	ctx.patch = &Patch{ctx: ctx}
 	ctx.touch()
 	ctx.cmpReflect = cmpVal
 	bindSlots(ctx, cmpVal, d)


### PR DESCRIPTION
Next API-surface cleanup (follows #97).

## Finding
`Ctx.Patch` was the **only exported field** across every otherwise-opaque runtime type (`Ctx`, `CtxR`, `Session`, `File`, `Ticker`, `App`, `Group`) — all of which expose state via methods. A lone mutable public field let callers do `ctx.Patch = nil` / swap the handle, and broke the all-methods consistency of `Ctx`.

## Change
- Unexport the field `Patch` → `patch`.
- Add `func (ctx *Ctx) Patch() *Patch`, mirroring `Request()` / `Session()` / `Writer()`. Still a plain field load (handle allocated eagerly in `newCtx`).
- Call sites: `ctx.Patch.Signal(...)` → `ctx.Patch().Signal(...)`.

**Breaking change**, but pre-1.0 (v0.5.0) and a strict hardening — the runtime's push handle can no longer be reassigned out from under it.

## Verification
`go build`, `go vet`, `gofmt -l` (clean), `go test -race ./...` — all green (incl. maplibre plugin tests that used the handle).