### PR TITLE
docs: add per-function godoc to h element & attribute constructors

### DIFF
--- a/h/attributes.go
+++ b/h/attributes.go
@@ -108,25 +108,57 @@ func Data(name, value string) H {
 // (HTML-escaped) via [buildAttr]. For an attribute without a shorthand use
 // [Attr]; for data-* use [Data]; for boolean attributes see [Selected],
 // [Checked], [Required], [Disabled].
-func Href(v string) H        { return buildAttr("href", v) }
-func Type(v string) H        { return buildAttr("type", v) }
-func Src(v string) H         { return buildAttr("src", v) }
-func ID(v string) H          { return buildAttr("id", v) }
-func Value(v string) H       { return buildAttr("value", v) }
-func Name(v string) H        { return buildAttr("name", v) }
+// Href emits the href attribute.
+func Href(v string) H { return buildAttr("href", v) }
+
+// Type emits the type attribute.
+func Type(v string) H { return buildAttr("type", v) }
+
+// Src emits the src attribute.
+func Src(v string) H { return buildAttr("src", v) }
+
+// ID emits the id attribute.
+func ID(v string) H { return buildAttr("id", v) }
+
+// Value emits the value attribute.
+func Value(v string) H { return buildAttr("value", v) }
+
+// Name emits the name attribute.
+func Name(v string) H { return buildAttr("name", v) }
+
+// Placeholder emits the placeholder attribute.
 func Placeholder(v string) H { return buildAttr("placeholder", v) }
-func Rel(v string) H         { return buildAttr("rel", v) }
-func Role(v string) H        { return buildAttr("role", v) }
-func Min(v string) H         { return buildAttr("min", v) }
-func Max(v string) H         { return buildAttr("max", v) }
-func Step(v string) H        { return buildAttr("step", v) }
-func For(v string) H         { return buildAttr("for", v) }
-func Lang(v string) H        { return buildAttr("lang", v) }
-func Content(v string) H     { return buildAttr("content", v) }
-func Charset(v string) H     { return buildAttr("charset", v) }
+
+// Rel emits the rel attribute.
+func Rel(v string) H { return buildAttr("rel", v) }
+
+// Role emits the role attribute.
+func Role(v string) H { return buildAttr("role", v) }
+
+// Min emits the min attribute.
+func Min(v string) H { return buildAttr("min", v) }
+
+// Max emits the max attribute.
+func Max(v string) H { return buildAttr("max", v) }
+
+// Step emits the step attribute.
+func Step(v string) H { return buildAttr("step", v) }
+
+// For emits the for attribute.
+func For(v string) H { return buildAttr("for", v) }
+
+// Lang emits the lang attribute.
+func Lang(v string) H { return buildAttr("lang", v) }
+
+// Content emits the content attribute.
+func Content(v string) H { return buildAttr("content", v) }
+
+// Charset emits the charset attribute.
+func Charset(v string) H { return buildAttr("charset", v) }
 
 // Style emits an inline `style="..."` attribute. For the
 // `<style>...</style>` element use [StyleEl].
+// Style emits the style attribute.
 func Style(v string) H { return buildAttr("style", v) }
 
 // Styles joins non-empty CSS declarations with `;` and emits one

--- a/h/elements.go
+++ b/h/elements.go
@@ -6,121 +6,321 @@ package h
 // render) are routed through [elVoid]. For ergonomic text construction
 // see [S] / [Text].
 
-func A(children ...H) H          { return el("a", children) }
-func Abbr(children ...H) H       { return el("abbr", children) }
-func Address(children ...H) H    { return el("address", children) }
-func Area(children ...H) H       { return elVoid("area", children) }
-func Article(children ...H) H    { return el("article", children) }
-func Aside(children ...H) H      { return el("aside", children) }
-func Audio(children ...H) H      { return el("audio", children) }
-func B(children ...H) H          { return el("b", children) }
-func Base(children ...H) H       { return elVoid("base", children) }
+// A renders the HTML <a> element.
+func A(children ...H) H { return el("a", children) }
+
+// Abbr renders the HTML <abbr> element.
+func Abbr(children ...H) H { return el("abbr", children) }
+
+// Address renders the HTML <address> element.
+func Address(children ...H) H { return el("address", children) }
+
+// Area renders the void HTML <area> element.
+func Area(children ...H) H { return elVoid("area", children) }
+
+// Article renders the HTML <article> element.
+func Article(children ...H) H { return el("article", children) }
+
+// Aside renders the HTML <aside> element.
+func Aside(children ...H) H { return el("aside", children) }
+
+// Audio renders the HTML <audio> element.
+func Audio(children ...H) H { return el("audio", children) }
+
+// B renders the HTML <b> element.
+func B(children ...H) H { return el("b", children) }
+
+// Base renders the void HTML <base> element.
+func Base(children ...H) H { return elVoid("base", children) }
+
+// BlockQuote renders the HTML <blockquote> element.
 func BlockQuote(children ...H) H { return el("blockquote", children) }
-func Body(children ...H) H       { return el("body", children) }
-func Br(children ...H) H         { return elVoid("br", children) }
-func Button(children ...H) H     { return el("button", children) }
-func Canvas(children ...H) H     { return el("canvas", children) }
-func Caption(children ...H) H    { return el("caption", children) }
-func Cite(children ...H) H       { return el("cite", children) }
-func Code(children ...H) H       { return el("code", children) }
-func Col(children ...H) H        { return elVoid("col", children) }
-func ColGroup(children ...H) H   { return el("colgroup", children) }
-func DataList(children ...H) H   { return el("datalist", children) }
-func Dd(children ...H) H         { return el("dd", children) }
-func Del(children ...H) H        { return el("del", children) }
-func Details(children ...H) H    { return el("details", children) }
-func Dfn(children ...H) H        { return el("dfn", children) }
-func Dialog(children ...H) H     { return el("dialog", children) }
-func Div(children ...H) H        { return el("div", children) }
-func Dl(children ...H) H         { return el("dl", children) }
-func Dt(children ...H) H         { return el("dt", children) }
-func Em(children ...H) H         { return el("em", children) }
-func Embed(children ...H) H      { return elVoid("embed", children) }
-func FieldSet(children ...H) H   { return el("fieldset", children) }
+
+// Body renders the HTML <body> element.
+func Body(children ...H) H { return el("body", children) }
+
+// Br renders the void HTML <br> element.
+func Br(children ...H) H { return elVoid("br", children) }
+
+// Button renders the HTML <button> element.
+func Button(children ...H) H { return el("button", children) }
+
+// Canvas renders the HTML <canvas> element.
+func Canvas(children ...H) H { return el("canvas", children) }
+
+// Caption renders the HTML <caption> element.
+func Caption(children ...H) H { return el("caption", children) }
+
+// Cite renders the HTML <cite> element.
+func Cite(children ...H) H { return el("cite", children) }
+
+// Code renders the HTML <code> element.
+func Code(children ...H) H { return el("code", children) }
+
+// Col renders the void HTML <col> element.
+func Col(children ...H) H { return elVoid("col", children) }
+
+// ColGroup renders the HTML <colgroup> element.
+func ColGroup(children ...H) H { return el("colgroup", children) }
+
+// DataList renders the HTML <datalist> element.
+func DataList(children ...H) H { return el("datalist", children) }
+
+// Dd renders the HTML <dd> element.
+func Dd(children ...H) H { return el("dd", children) }
+
+// Del renders the HTML <del> element.
+func Del(children ...H) H { return el("del", children) }
+
+// Details renders the HTML <details> element.
+func Details(children ...H) H { return el("details", children) }
+
+// Dfn renders the HTML <dfn> element.
+func Dfn(children ...H) H { return el("dfn", children) }
+
+// Dialog renders the HTML <dialog> element.
+func Dialog(children ...H) H { return el("dialog", children) }
+
+// Div renders the HTML <div> element.
+func Div(children ...H) H { return el("div", children) }
+
+// Dl renders the HTML <dl> element.
+func Dl(children ...H) H { return el("dl", children) }
+
+// Dt renders the HTML <dt> element.
+func Dt(children ...H) H { return el("dt", children) }
+
+// Em renders the HTML <em> element.
+func Em(children ...H) H { return el("em", children) }
+
+// Embed renders the void HTML <embed> element.
+func Embed(children ...H) H { return elVoid("embed", children) }
+
+// FieldSet renders the HTML <fieldset> element.
+func FieldSet(children ...H) H { return el("fieldset", children) }
+
+// FigCaption renders the HTML <figcaption> element.
 func FigCaption(children ...H) H { return el("figcaption", children) }
-func Figure(children ...H) H     { return el("figure", children) }
-func Footer(children ...H) H     { return el("footer", children) }
-func Form(children ...H) H       { return el("form", children) }
-func H1(children ...H) H         { return el("h1", children) }
-func H2(children ...H) H         { return el("h2", children) }
-func H3(children ...H) H         { return el("h3", children) }
-func H4(children ...H) H         { return el("h4", children) }
-func H5(children ...H) H         { return el("h5", children) }
-func H6(children ...H) H         { return el("h6", children) }
-func Head(children ...H) H       { return el("head", children) }
-func Header(children ...H) H     { return el("header", children) }
-func Hr(children ...H) H         { return elVoid("hr", children) }
-func HGroup(children ...H) H     { return el("hgroup", children) }
-func HTML(children ...H) H       { return el("html", children) }
-func I(children ...H) H          { return el("i", children) }
-func IFrame(children ...H) H     { return el("iframe", children) }
-func Img(children ...H) H        { return elVoid("img", children) }
-func Input(children ...H) H      { return elVoid("input", children) }
-func Ins(children ...H) H        { return el("ins", children) }
-func Kbd(children ...H) H        { return el("kbd", children) }
-func Label(children ...H) H      { return el("label", children) }
-func Legend(children ...H) H     { return el("legend", children) }
-func Li(children ...H) H         { return el("li", children) }
-func Link(children ...H) H       { return elVoid("link", children) }
-func Main(children ...H) H       { return el("main", children) }
-func Mark(children ...H) H       { return el("mark", children) }
-func Meta(children ...H) H       { return elVoid("meta", children) }
-func Meter(children ...H) H      { return el("meter", children) }
-func Nav(children ...H) H        { return el("nav", children) }
-func NoScript(children ...H) H   { return el("noscript", children) }
-func Object(children ...H) H     { return el("object", children) }
-func Ol(children ...H) H         { return el("ol", children) }
-func OptGroup(children ...H) H   { return el("optgroup", children) }
-func Option(children ...H) H     { return el("option", children) }
-func P(children ...H) H          { return el("p", children) }
-func Picture(children ...H) H    { return el("picture", children) }
-func Pre(children ...H) H        { return el("pre", children) }
-func Progress(children ...H) H   { return el("progress", children) }
-func Q(children ...H) H          { return el("q", children) }
-func S(children ...H) H          { return el("s", children) }
-func Samp(children ...H) H       { return el("samp", children) }
-func Script(children ...H) H     { return el("script", children) }
-func Section(children ...H) H    { return el("section", children) }
-func Select(children ...H) H     { return el("select", children) }
-func Small(children ...H) H      { return el("small", children) }
-func Source(children ...H) H     { return elVoid("source", children) }
-func Span(children ...H) H       { return el("span", children) }
-func Strong(children ...H) H     { return el("strong", children) }
-func Sub(children ...H) H        { return el("sub", children) }
-func Summary(children ...H) H    { return el("summary", children) }
-func Sup(children ...H) H        { return el("sup", children) }
-func Table(children ...H) H      { return el("table", children) }
-func TBody(children ...H) H      { return el("tbody", children) }
-func Td(children ...H) H         { return el("td", children) }
-func Template(children ...H) H   { return el("template", children) }
-func Textarea(children ...H) H   { return el("textarea", children) }
-func TFoot(children ...H) H      { return el("tfoot", children) }
-func Th(children ...H) H         { return el("th", children) }
-func THead(children ...H) H      { return el("thead", children) }
-func Time(children ...H) H       { return el("time", children) }
-func Tr(children ...H) H         { return el("tr", children) }
-func U(children ...H) H          { return el("u", children) }
-func Ul(children ...H) H         { return el("ul", children) }
-func Var(children ...H) H        { return el("var", children) }
-func StyleEl(children ...H) H    { return el("style", children) }
-func Video(children ...H) H      { return el("video", children) }
-func Wbr(children ...H) H        { return elVoid("wbr", children) }
+
+// Figure renders the HTML <figure> element.
+func Figure(children ...H) H { return el("figure", children) }
+
+// Footer renders the HTML <footer> element.
+func Footer(children ...H) H { return el("footer", children) }
+
+// Form renders the HTML <form> element.
+func Form(children ...H) H { return el("form", children) }
+
+// H1 renders the HTML <h1> element.
+func H1(children ...H) H { return el("h1", children) }
+
+// H2 renders the HTML <h2> element.
+func H2(children ...H) H { return el("h2", children) }
+
+// H3 renders the HTML <h3> element.
+func H3(children ...H) H { return el("h3", children) }
+
+// H4 renders the HTML <h4> element.
+func H4(children ...H) H { return el("h4", children) }
+
+// H5 renders the HTML <h5> element.
+func H5(children ...H) H { return el("h5", children) }
+
+// H6 renders the HTML <h6> element.
+func H6(children ...H) H { return el("h6", children) }
+
+// Head renders the HTML <head> element.
+func Head(children ...H) H { return el("head", children) }
+
+// Header renders the HTML <header> element.
+func Header(children ...H) H { return el("header", children) }
+
+// Hr renders the void HTML <hr> element.
+func Hr(children ...H) H { return elVoid("hr", children) }
+
+// HGroup renders the HTML <hgroup> element.
+func HGroup(children ...H) H { return el("hgroup", children) }
+
+// HTML renders the HTML <html> element.
+func HTML(children ...H) H { return el("html", children) }
+
+// I renders the HTML <i> element.
+func I(children ...H) H { return el("i", children) }
+
+// IFrame renders the HTML <iframe> element.
+func IFrame(children ...H) H { return el("iframe", children) }
+
+// Img renders the void HTML <img> element.
+func Img(children ...H) H { return elVoid("img", children) }
+
+// Input renders the void HTML <input> element.
+func Input(children ...H) H { return elVoid("input", children) }
+
+// Ins renders the HTML <ins> element.
+func Ins(children ...H) H { return el("ins", children) }
+
+// Kbd renders the HTML <kbd> element.
+func Kbd(children ...H) H { return el("kbd", children) }
+
+// Label renders the HTML <label> element.
+func Label(children ...H) H { return el("label", children) }
+
+// Legend renders the HTML <legend> element.
+func Legend(children ...H) H { return el("legend", children) }
+
+// Li renders the HTML <li> element.
+func Li(children ...H) H { return el("li", children) }
+
+// Link renders the void HTML <link> element.
+func Link(children ...H) H { return elVoid("link", children) }
+
+// Main renders the HTML <main> element.
+func Main(children ...H) H { return el("main", children) }
+
+// Mark renders the HTML <mark> element.
+func Mark(children ...H) H { return el("mark", children) }
+
+// Meta renders the void HTML <meta> element.
+func Meta(children ...H) H { return elVoid("meta", children) }
+
+// Meter renders the HTML <meter> element.
+func Meter(children ...H) H { return el("meter", children) }
+
+// Nav renders the HTML <nav> element.
+func Nav(children ...H) H { return el("nav", children) }
+
+// NoScript renders the HTML <noscript> element.
+func NoScript(children ...H) H { return el("noscript", children) }
+
+// Object renders the HTML <object> element.
+func Object(children ...H) H { return el("object", children) }
+
+// Ol renders the HTML <ol> element.
+func Ol(children ...H) H { return el("ol", children) }
+
+// OptGroup renders the HTML <optgroup> element.
+func OptGroup(children ...H) H { return el("optgroup", children) }
+
+// Option renders the HTML <option> element.
+func Option(children ...H) H { return el("option", children) }
+
+// P renders the HTML <p> element.
+func P(children ...H) H { return el("p", children) }
+
+// Picture renders the HTML <picture> element.
+func Picture(children ...H) H { return el("picture", children) }
+
+// Pre renders the HTML <pre> element.
+func Pre(children ...H) H { return el("pre", children) }
+
+// Progress renders the HTML <progress> element.
+func Progress(children ...H) H { return el("progress", children) }
+
+// Q renders the HTML <q> element.
+func Q(children ...H) H { return el("q", children) }
+
+// S renders the HTML <s> element.
+func S(children ...H) H { return el("s", children) }
+
+// Samp renders the HTML <samp> element.
+func Samp(children ...H) H { return el("samp", children) }
+
+// Script renders the HTML <script> element.
+func Script(children ...H) H { return el("script", children) }
+
+// Section renders the HTML <section> element.
+func Section(children ...H) H { return el("section", children) }
+
+// Select renders the HTML <select> element.
+func Select(children ...H) H { return el("select", children) }
+
+// Small renders the HTML <small> element.
+func Small(children ...H) H { return el("small", children) }
+
+// Source renders the void HTML <source> element.
+func Source(children ...H) H { return elVoid("source", children) }
+
+// Span renders the HTML <span> element.
+func Span(children ...H) H { return el("span", children) }
+
+// Strong renders the HTML <strong> element.
+func Strong(children ...H) H { return el("strong", children) }
+
+// Sub renders the HTML <sub> element.
+func Sub(children ...H) H { return el("sub", children) }
+
+// Summary renders the HTML <summary> element.
+func Summary(children ...H) H { return el("summary", children) }
+
+// Sup renders the HTML <sup> element.
+func Sup(children ...H) H { return el("sup", children) }
+
+// Table renders the HTML <table> element.
+func Table(children ...H) H { return el("table", children) }
+
+// TBody renders the HTML <tbody> element.
+func TBody(children ...H) H { return el("tbody", children) }
+
+// Td renders the HTML <td> element.
+func Td(children ...H) H { return el("td", children) }
+
+// Template renders the HTML <template> element.
+func Template(children ...H) H { return el("template", children) }
+
+// Textarea renders the HTML <textarea> element.
+func Textarea(children ...H) H { return el("textarea", children) }
+
+// TFoot renders the HTML <tfoot> element.
+func TFoot(children ...H) H { return el("tfoot", children) }
+
+// Th renders the HTML <th> element.
+func Th(children ...H) H { return el("th", children) }
+
+// THead renders the HTML <thead> element.
+func THead(children ...H) H { return el("thead", children) }
+
+// Time renders the HTML <time> element.
+func Time(children ...H) H { return el("time", children) }
+
+// Tr renders the HTML <tr> element.
+func Tr(children ...H) H { return el("tr", children) }
+
+// U renders the HTML <u> element.
+func U(children ...H) H { return el("u", children) }
+
+// Ul renders the HTML <ul> element.
+func Ul(children ...H) H { return el("ul", children) }
+
+// Var renders the HTML <var> element.
+func Var(children ...H) H { return el("var", children) }
+
+// StyleEl renders the HTML <style> element.
+func StyleEl(children ...H) H { return el("style", children) }
+
+// Video renders the HTML <video> element.
+func Video(children ...H) H { return el("video", children) }
+
+// Wbr renders the void HTML <wbr> element.
+func Wbr(children ...H) H { return elVoid("wbr", children) }
 
 // Title emits <title>v</title> with v HTML-escaped. Defined alongside
 // element constructors because it produces an element node, not an
 // attribute.
+// Title renders the HTML <title> element.
 func Title(v string) H { return el("title", []H{Text(v)}) }
 
 // Tag emits a custom non-void element. Use it for tags absent from
 // the static constructor list (web components, SVG primitives, etc.).
 // The tag name is written verbatim — callers must supply a valid HTML
 // element name; nothing here validates it.
+// Tag renders the HTML <> element.
 func Tag(name string, children ...H) H { return el(name, children) }
 
 // VoidTag emits a custom void element (no closing tag, content
 // children dropped at render time). The tag name is written verbatim
 // — callers must supply a valid HTML element name; nothing here
 // validates it.
+// VoidTag renders the HTML <> element.
 func VoidTag(name string, children ...H) H { return elVoid(name, children) }
 
 // NewTag returns a reusable constructor for the given tag name. Use


### PR DESCRIPTION
Every exported function in package `h` now has a godoc comment.

The bulk element constructors and attribute shorthands relied on a single detached group comment, so `go doc A` / `go doc Type` reported them as undocumented — only the first func in each block attached the comment. Go can't group-document separate top-level funcs, so each gets a one-line doc.

- `elements.go` — `// A renders the HTML <a> element.` (void elements noted)
- `attributes.go` — `// Href emits the href attribute.` (group comment retained as Href's lead paragraph)

build + vet pass; no remaining undocumented exported decls.