### PR TITLE
fix(showcase): avatar upload rejected real photos (4 MiB → 10 MiB) + core regression test

### DIFF
--- a/file_test.go
+++ b/file_test.go
@@ -9,8 +9,8 @@ import (
 	"net/http/cookiejar"
 	"os"
 	"path/filepath"
-	"testing"
 	"sync/atomic"
+	"testing"
 	"time"
 
 	"github.com/go-via/via"

--- a/file_test.go
+++ b/file_test.go
@@ -4,10 +4,13 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
+	"net/http/cookiejar"
 	"os"
 	"path/filepath"
 	"testing"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-via/via"
@@ -403,4 +406,76 @@ func TestFile_saveSurfacesOpenFileError(t *testing.T) {
 	frame := vt.AwaitFrame(t, frames, 2*time.Second, "savebad=")
 	assert.Contains(t, frame, "via-missing-dir-xyz",
 		"Save must return the os.OpenFile error when the destination is unwritable")
+}
+
+var plainUploadGot atomic.Int64
+
+type plainUploadPage struct {
+	Avatar via.File `via:"avatar"`
+}
+
+// Upload mirrors the showcase avatar flow: a plain <form> POST (not a datastar
+// @post), and the handler answers with an http.Redirect 303 rather than a
+// datastar response.
+func (p *plainUploadPage) Upload(ctx *via.Ctx) error {
+	if p.Avatar.Present() {
+		b, err := p.Avatar.Bytes()
+		if err != nil {
+			return err
+		}
+		plainUploadGot.Store(int64(len(b)))
+	}
+	http.Redirect(ctx.Writer(), ctx.Request(), "/done", http.StatusSeeOther)
+	return nil
+}
+
+func (p *plainUploadPage) View(ctx *via.CtxR) h.H {
+	return h.Form(h.Method("POST"), h.Action("/_action/Upload"),
+		h.Attr("enctype", "multipart/form-data"),
+		h.Input(h.Type("hidden"), h.Name("via_tab"), h.Value(ctx.ID())),
+		h.Input(h.Type("file"), h.Name("avatar")))
+}
+
+// Reproduces the showcase avatar upload end-to-end: a real browser <form>
+// (multipart, via_tab as a form field, full-page navigation) POSTing to an
+// action whose handler returns http.Redirect(303). The action must bind the
+// file AND the 303 must reach the browser unmangled — Via must not overwrite
+// the handler's redirect with a datastar/200 action response.
+func TestUpload_plainFormPostBindsFileAndReturnsHandlerRedirect(t *testing.T) {
+	t.Parallel()
+	plainUploadGot.Store(0)
+	app := via.New(via.WithInsecureCookies())
+	server := vt.Serve(t, app)
+	via.Mount[plainUploadPage](app, "/up")
+
+	jar, _ := cookiejar.New(nil)
+	httpc := &http.Client{Jar: jar, CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse // capture the 303, don't follow it
+	}}
+
+	resp, err := httpc.Get(server.URL + "/up")
+	require.NoError(t, err)
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	tab := vt.TabIDFromHTML(string(body))
+	require.NotEmpty(t, tab, "page must render a via_tab")
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, _ := mw.CreateFormFile("avatar", "a.png")
+	_, _ = fw.Write([]byte("PNGDATA"))
+	_ = mw.WriteField("via_tab", tab)
+	_ = mw.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, server.URL+"/_action/Upload", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	pr, err := httpc.Do(req)
+	require.NoError(t, err)
+	defer pr.Body.Close()
+
+	assert.Equal(t, http.StatusSeeOther, pr.StatusCode,
+		"a plain-form action must return the handler's 303, not a datastar 200")
+	assert.Equal(t, "/done", pr.Header.Get("Location"), "the handler's redirect target must survive")
+	assert.Equal(t, int64(7), plainUploadGot.Load(),
+		"the avatar file must bind from the multipart form POST")
 }

--- a/viashowcase/cmd/showcase/main.go
+++ b/viashowcase/cmd/showcase/main.go
@@ -27,7 +27,10 @@ import (
 	"github.com/go-via/viashowcase/internal/ui"
 )
 
-const maxUpload = 4 << 20 // 4 MiB avatars
+// maxUpload caps the avatar multipart body. 4 MiB rejected typical phone
+// photos (often 3–8 MiB) with a bare 413 — "upload didn't work". 10 MiB
+// comfortably fits a full-res photo; the form hint states the limit.
+const maxUpload = 10 << 20 // 10 MiB avatars
 
 func main() {
 	if err := run(); err != nil {

--- a/viashowcase/internal/ui/profile.go
+++ b/viashowcase/internal/ui/profile.go
@@ -158,7 +158,7 @@ func (p *Profile) View(ctx *via.CtxR) h.H {
 				h.Input(h.Type("hidden"), h.Name("via_tab"), h.Value(ctx.ID())),
 				h.Label(h.Text("Choose an image"),
 					h.Input(h.Type("file"), h.Name("avatar"), h.Attr("accept", "image/*"), h.Required()),
-					h.Small(h.Class("hint"), h.Text("Square images look best. PNG, JPG, GIF or WebP."))),
+					h.Small(h.Class("hint"), h.Text("Square images look best. PNG, JPG, GIF or WebP, up to 10 MB."))),
 				h.Button(h.Type("submit"), h.Text("Upload avatar")),
 			),
 		),


### PR DESCRIPTION
## Symptom
Avatar upload "didn't work" on the showcase for normal photos.

## Root cause
The showcase set `maxUpload = 4 MiB`, but typical phone photos are 3–8+ MiB. The multipart `MaxBytesReader` trips during parse and returns a bare `413 "request too large"` — and because the avatar form is a full-page `<form>` submit (not a datastar fetch), the browser just navigates to that 413 page, so it looks like the upload silently failed.

Confirmed against the running instance:
- 5 MiB multipart POST `/_action/Upload` → **413**
- sub-limit body → got past the size gate (404 on a bogus `via_tab`)

## Fix
- Raise `maxUpload` 4 MiB → **10 MiB** (comfortably fits a full-res photo).
- State the limit in the form hint (“… up to 10 MB.”).

## via core was correct
The file-binding + plain-`<form>` POST + `http.Redirect(303)` path works as intended — it was the showcase's chosen limit that was too low. Added a **root regression test** (`TestUpload_plainFormPostBindsFileAndReturnsHandlerRedirect`) that reproduces the exact showcase contract end-to-end: a multipart `<form>` POST carrying `via_tab` as a form field binds the `via.File`, and the handler's 303 reaches the client unmangled (Via must not clobber it with a datastar/200 action response).

(Separately tracked in `critique-council.md`: `T9-UX-413` — oversize uploads should fail with a friendly in-form message rather than a bare 413; that's a framework-level change.)