### PR TITLE
feat: WithRequestTooLarge hook + friendly showcase oversize-upload message

### DIFF
--- a/action.go
+++ b/action.go
@@ -103,7 +103,14 @@ func (a *App) handleAction(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		var mb *http.MaxBytesError
 		if errors.As(err, &mb) {
-			http.Error(w, "request too large", http.StatusRequestEntityTooLarge)
+			// The body cap trips here, before the action handler runs, so a
+			// friendly response (vs the bare 413) is only reachable via the
+			// app-level WithRequestTooLarge hook.
+			if h := a.cfg.tooLargeHandler; h != nil {
+				h.ServeHTTP(w, r)
+			} else {
+				http.Error(w, "request too large", http.StatusRequestEntityTooLarge)
+			}
 			return
 		}
 		// Malformed body / wrong content type — fall through to the

--- a/config.go
+++ b/config.go
@@ -46,6 +46,7 @@ type config struct {
 	actionErrorHandler func(*Ctx, error)
 	logger             Logger
 	notFoundHandler    http.Handler
+	tooLargeHandler    http.Handler
 	metrics            Metrics
 	backplane          Backplane
 }
@@ -283,6 +284,17 @@ func WithLogger(l Logger) Option { return func(c *config) { c.logger = l } }
 // and decide whether to redirect, render a "not found" composition, or
 // short-circuit with an empty body.
 func WithNotFound(h http.Handler) Option { return func(c *config) { c.notFoundHandler = h } }
+
+// WithRequestTooLarge sets the handler invoked when an action POST exceeds the
+// body cap (WithMaxRequestBody / WithMaxUploadSize) — the limit trips in
+// MaxBytesReader before any action handler runs, so this is the only place to
+// turn the default bare "request too large" 413 into a friendly response (e.g.
+// redirect a too-large file upload back to its form with a flash message).
+// h receives the raw request; without this option the framework writes a plain
+// 413.
+func WithRequestTooLarge(h http.Handler) Option {
+	return func(c *config) { c.tooLargeHandler = h }
+}
 
 // WithMetrics installs a [Metrics] backend that receives counter / gauge
 // / histogram events for actions, renders, SSE connect/disconnect, and

--- a/file_test.go
+++ b/file_test.go
@@ -479,3 +479,25 @@ func TestUpload_plainFormPostBindsFileAndReturnsHandlerRedirect(t *testing.T) {
 	assert.Equal(t, int64(7), plainUploadGot.Load(),
 		"the avatar file must bind from the multipart form POST")
 }
+
+// An oversize upload trips MaxBytesReader before any action handler runs, so the
+// only way to give it a friendly response (instead of the bare 413 text page) is
+// a framework hook. WithRequestTooLarge installs one.
+func TestWithRequestTooLarge_invokesCustomHandlerInsteadOfBare413(t *testing.T) {
+	t.Parallel()
+	app := via.New(
+		via.WithMaxUploadSize(64),
+		via.WithRequestTooLarge(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusTeapot) // sentinel proving our handler ran
+		})),
+	)
+	server := vt.Serve(t, app)
+	via.Mount[uploadPage](app, "/")
+
+	tc := vt.NewClient(t, server, "/")
+	got := tc.Action("Upload").
+		WithFile("avatar", "big.bin", bytes.Repeat([]byte("X"), 4096)).
+		Fire()
+	assert.Equal(t, http.StatusTeapot, got,
+		"an oversize upload must route to WithRequestTooLarge, not the bare 413")
+}

--- a/viashowcase/cmd/showcase/main.go
+++ b/viashowcase/cmd/showcase/main.go
@@ -94,6 +94,12 @@ func run() error {
 		via.WithBackplane(bp),
 		via.WithInsecureCookies(), // demo runs over plain http behind the LB
 		via.WithMaxUploadSize(maxUpload),
+		// The avatar upload is the only oversize-prone action; a too-large file
+		// would otherwise hit a bare 413 page. Bounce back to the profile with a
+		// flag it renders as a friendly message.
+		via.WithRequestTooLarge(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "/app/profile?avatarTooBig=1", http.StatusSeeOther)
+		})),
 		via.WithLogger(via.SlogLogger(slog.Default())),
 		via.WithMetrics(logMetrics{}),
 	)

--- a/viashowcase/internal/ui/profile.go
+++ b/viashowcase/internal/ui/profile.go
@@ -20,6 +20,9 @@ type Profile struct {
 	Name   via.SignalStr `via:"display"`
 	Theme  via.SignalStr `via:"theme"`
 	Mode   via.SignalStr `via:"mode"`
+	// AvatarTooBig is set ("1") when WithRequestTooLarge bounced an oversize
+	// avatar back here, so the page shows a friendly message instead of a 413.
+	AvatarTooBig string `query:"avatarTooBig"`
 }
 
 // OnInit loads the saved preference into the bound signals and reflects
@@ -150,6 +153,9 @@ func (p *Profile) View(ctx *via.CtxR) h.H {
 		),
 		h.Article(h.Class("form-card"),
 			h.H3(h.Text("Avatar")),
+			h.If(p.AvatarTooBig != "", h.Small(h.Role("alert"), h.Class("hint"),
+				h.Style("color:var(--pico-del-color,#b3261e)"),
+				h.Text("That image was over 10 MB — please choose a smaller one."))),
 			// Plain multipart form: file bytes can't ride a Datastar JSON @post.
 			h.Form(
 				h.Method("POST"),


### PR DESCRIPTION
Finishes the avatar-upload UX started in #106.

## Problem
An action POST that exceeds the body cap (`WithMaxRequestBody` / `WithMaxUploadSize`) trips `MaxBytesReader` **before** any action handler runs, so the app can't catch it — every oversize upload dead-ends on a bare `413 "request too large"` page (`T9-UX-413`).

## Change
- **Core:** `WithRequestTooLarge(h http.Handler)` — invoked on the action 413 path instead of the bare `http.Error`. Mirrors `WithNotFound`; default (plain 413) unchanged. Test: `TestWithRequestTooLarge_invokesCustomHandlerInsteadOfBare413` (and the existing bare-413 test still passes).
- **Showcase:** registers it to redirect a too-large avatar back to `/app/profile?avatarTooBig=1`; the profile page reads the flag via a `query:"avatarTooBig"` field and renders an inline "image was over 10 MB" `role=alert` message instead of a 413.

## Verified
Root `gofmt`/`golangci-lint`/`go test -race ./...` green; viashowcase builds, vets, and tests green. (viashowcase isn't covered by CI — verified locally.)