### PR TITLE
docs: 0.6.0 cohesion pass — upload limits, Ctx.Patch, WithRequestTooLarge scope

### DIFF
--- a/config.go
+++ b/config.go
@@ -291,7 +291,9 @@ func WithNotFound(h http.Handler) Option { return func(c *config) { c.notFoundHa
 // turn the default bare "request too large" 413 into a friendly response (e.g.
 // redirect a too-large file upload back to its form with a flash message).
 // h receives the raw request; without this option the framework writes a plain
-// 413.
+// 413. This covers action POSTs only: an oversize SSE-close body always gets
+// the bare 413, since that payload is Datastar's internal reconnect frame, not
+// a user-facing submit.
 func WithRequestTooLarge(h http.Handler) Option {
 	return func(c *config) { c.tooLargeHandler = h }
 }

--- a/docs/actions-and-lifecycle.md
+++ b/docs/actions-and-lifecycle.md
@@ -38,8 +38,8 @@ Named event helpers include `Click`, `Change`, `Input`, `Submit`, `Focus`,
 ## What an action body can do
 
 - Write typed state: `c.Hits.Write(ctx, …)` or `c.Hits.Op(ctx).Add(1)`.
-- Push targeted patches: `ctx.Patch.Elements(h.Ul(h.ID("list"), …))`.
-- Push raw signals: `ctx.Patch.Signal("_picoTheme", "purple")`.
+- Push targeted patches: `ctx.Patch().Elements(h.Ul(h.ID("list"), …))`.
+- Push raw signals: `ctx.Patch().Signal("_picoTheme", "purple")`.
 - Show a quick toast: `ctx.Toast("saved!")` — a styled, non-blocking notice
   that auto-dismisses (JSON-safe, zero setup).
 - Redirect: `ctx.Redirect("/profile")`. Only http/https/relative URLs are

--- a/docs/file-uploads.md
+++ b/docs/file-uploads.md
@@ -55,8 +55,11 @@ Once read, typed `via.File` fields on the same action will be empty for any
 parts already advanced past.
 
 {: .note }
-`WithMaxRequestBody(n)` caps total body size (default 1 MiB); oversized
-requests return `413 Request Entity Too Large`.
+Two separate caps apply. `WithMaxRequestBody(n)` caps plain action POST and
+SSE-close bodies (default 1 MiB); `WithMaxUploadSize(n)` caps
+`multipart/form-data` bodies (default 32 MiB), since file parts inflate the
+body well past the JSON cap. Either overflow returns `413 Too Large`.
+Customise that response with `WithRequestTooLarge(h)`.
 
 See `internal/examples/upload` for a `<form>`-driven upload persisted to
 disk with a redirect-back-to-`/`.

--- a/docs/production.md
+++ b/docs/production.md
@@ -65,7 +65,9 @@ behaviour. Common production knobs:
 - **CSP:** `mw.CSP()` emits a strict header with a per-request nonce
   reachable via `ctx.CSPNonce()`.
 - **Body limits:** `WithMaxRequestBody(n)` (default 1 MiB) caps action POST
-  and SSE-close bodies; oversized requests return 413.
+  and SSE-close bodies; `WithMaxUploadSize(n)` (default 32 MiB) caps
+  `multipart/form-data` bodies. Either overflow returns 413; customise it
+  with `WithRequestTooLarge(h)`.
 - **Open redirects:** `ctx.Redirect` rejects `javascript:`/`data:`/
   protocol-relative/backslash and whitespace-only URLs.
 - **Panic sanitization:** action panics surface as `"Something went wrong"`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -74,11 +74,13 @@ at boot rather than at request time.
 
 ## An oversized upload / POST returns 413
 
-**Cause:** `WithMaxRequestBody(n)` (default 1 MiB) caps action POST and
-SSE-close bodies.
+**Cause:** two separate caps apply. `WithMaxRequestBody(n)` (default 1 MiB)
+caps plain action POST and SSE-close bodies; `WithMaxUploadSize(n)` (default
+32 MiB) caps `multipart/form-data` bodies.
 
-**Fix:** raise the limit for routes that accept large uploads:
-`via.New(via.WithMaxRequestBody(20 << 20))`.
+**Fix:** raise the matching limit — `via.New(via.WithMaxUploadSize(64 << 20))`
+for file uploads, `WithMaxRequestBody` for large JSON actions. Use
+`WithRequestTooLarge(h)` to customise the 413 response.
 
 ## State doesn't update across tabs
 


### PR DESCRIPTION
Pre-release cohesion pass for **v0.6.0**. Doc/godoc only — no behavior change.

## Changes
- Document `WithMaxUploadSize` (32 MiB multipart cap) + `WithRequestTooLarge` hook across file-uploads, production, troubleshooting guides — previously only `WithMaxRequestBody` (1 MiB) was mentioned.
- Fix stale `ctx.Patch` field form → `ctx.Patch()` method in actions-and-lifecycle (post #98).
- `WithRequestTooLarge` godoc: note it covers action POSTs only; oversize SSE-close bodies always get the bare 413.

## Context
Found by a full docs↔code audit ahead of the 0.6.0 tag. Name `WithRequestTooLarge` retained (mirrors `WithNotFound`). Tag `v0.6.0` is already pushed pointing at this commit; once this merges via merge-commit it stays reachable from `main`. **If the repo squash-merges, the tag must be re-pointed at the resulting main commit.**