### PR TITLE
feat: cross-pod Broadcast + rename Toast→Notify

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -255,9 +255,9 @@ it.
 func MustJSON(v any) string
 
 // ✅ States a non-obvious contract
-// Toast JSON-encodes message so arbitrary user text is safe inside
-// the rendered alert(...) call.
-func (ctx *Ctx) Toast(message string)
+// Notify JSON-encodes message so arbitrary user text is safe inside
+// the rendered toast snippet.
+func (ctx *Ctx) Notify(message string)
 
 // ❌ Restates the name
 // WithTitle sets the chart title.

--- a/action.go
+++ b/action.go
@@ -253,7 +253,7 @@ func (a *App) dispatchActionError(ctx *Ctx, err error, fromPanic bool) {
 	if fromPanic {
 		msg = "Something went wrong"
 	}
-	ctx.Toast(msg)
+	ctx.Notify(msg)
 }
 
 // injectSignals applies signals from a request body into the bound *C's

--- a/app.go
+++ b/app.go
@@ -376,6 +376,13 @@ func New(opts ...Option) *App {
 		a.backplane = InMemory()
 	}
 
+	// Clustered only: tail the shared broadcast feed so site-wide Broadcasts
+	// issued on any pod reach this pod's tabs. The default in-process backplane
+	// has no peers, so a single-pod app applies broadcasts inline instead.
+	if a.cfg.backplane != nil {
+		a.startBroadcastTailer()
+	}
+
 	a.mux.HandleFunc("GET /_datastar.js", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/javascript")
 		_, _ = w.Write(datastarJS)

--- a/broadcast.go
+++ b/broadcast.go
@@ -1,5 +1,28 @@
 package via
 
+import (
+	"context"
+	"encoding/json"
+)
+
+// broadcastKey is the shared EventLog feed carrying broadcast payloads across
+// pods. Unlike the value-less change feed, a broadcast record IS the payload —
+// there is no Store cell behind it, because a broadcast is ephemeral and
+// best-effort (no convergence, no reconcile, no monotone gate).
+const broadcastKey = "via.broadcast"
+
+const (
+	bcScript  = "script"
+	bcSignals = "signals"
+)
+
+// broadcastRecord is one cross-pod broadcast, carried whole on the feed.
+type broadcastRecord struct {
+	Kind    string         `json:"kind"`
+	Script  string         `json:"script,omitempty"`
+	Signals map[string]any `json:"signals,omitempty"`
+}
+
 // Broadcast queues a JavaScript snippet on every currently-live tab's
 // patch queue. The next SSE drain on each tab pushes it to the browser.
 // Useful for "page will reload in 30 seconds" maintenance notices,
@@ -9,26 +32,25 @@ package via
 //	time.Sleep(30 * time.Second)
 //	app.Shutdown(ctx)
 //
-// Returns the number of tabs the script was queued on. Empty script is
-// a no-op.
+// When a backplane is wired (via [WithBackplane]) the script also rides the
+// shared feed and reaches every live tab on every pod; otherwise it stays
+// pod-local. Either way the returned count is THIS pod's live-tab count at call
+// time — the cluster-wide total is unknowable synchronously. Empty script is a
+// no-op.
 func (a *App) Broadcast(script string) int {
 	if script == "" {
 		return 0
 	}
-	ctxs := a.snapshotContexts()
-	for _, c := range ctxs {
-		enqueueScript(c, script)
-	}
-	return len(ctxs)
+	return a.dispatchBroadcast(broadcastRecord{Kind: bcScript, Script: script})
 }
 
-// BroadcastToast shows an XSS-safe toast notification on every currently-live
-// tab — the safe form of [App.Broadcast] for the common site-wide-notice case,
-// so callers never hand-build (and mis-escape) toast JS. message is JSON-encoded,
-// so arbitrary text including markup is inert. Returns the number of tabs it
-// reached; empty message is a no-op. Like Broadcast, this is best-effort and
-// reaches only this pod's live tabs (a tab that connects later won't see it).
-func (a *App) BroadcastToast(message string) int {
+// BroadcastNotify shows an XSS-safe notification on every currently-live tab —
+// the safe form of [App.Broadcast] for the common site-wide-notice case, so
+// callers never hand-build (and mis-escape) the notification JS. message is
+// JSON-encoded, so arbitrary text including markup is inert. Like Broadcast it
+// reaches every pod when a backplane is wired and stays pod-local otherwise;
+// the returned count is this pod's live-tab count. Empty message is a no-op.
+func (a *App) BroadcastNotify(message string) int {
 	if message == "" {
 		return 0
 	}
@@ -53,7 +75,11 @@ func BroadcastSignal[T any](a *App, sig *Signal[T], value T) int {
 // BroadcastSignals pushes a signal patch to every currently-live tab.
 // Useful for site-wide announcements that drive a banner via a
 // client-only signal (e.g. "$_systemNotice = 'planned maintenance'")
-// without rendering each composition. Returns the tab count.
+// without rendering each composition.
+//
+// Like [App.Broadcast], the patch rides the shared feed to every pod when a
+// backplane is wired and stays pod-local otherwise; the returned count is this
+// pod's live-tab count at call time.
 //
 // This is the untyped escape hatch for dynamic / client-only signal
 // keys; when a *Signal[T] handle exists, prefer [BroadcastSignal].
@@ -61,11 +87,65 @@ func (a *App) BroadcastSignals(values map[string]any) int {
 	if len(values) == 0 {
 		return 0
 	}
+	return a.dispatchBroadcast(broadcastRecord{Kind: bcSignals, Signals: values})
+}
+
+// dispatchBroadcast routes one record: when clustered it Appends to the shared
+// feed and lets the tailer apply on EVERY pod (including this one — append-only,
+// never also applied directly, so the originating pod sees it exactly once);
+// otherwise it applies locally in-process. Returns this pod's live-tab count.
+func (a *App) dispatchBroadcast(rec broadcastRecord) int {
+	if a.cfg.backplane != nil {
+		if b, err := json.Marshal(rec); err == nil {
+			_, _ = a.backplane.Append(context.Background(), broadcastKey, b)
+		}
+		return len(a.snapshotContexts())
+	}
+	return a.applyBroadcast(rec)
+}
+
+// applyBroadcast pushes one record onto every live tab's patch queue on THIS
+// pod. It is the single apply path — used directly in single-pod mode and by
+// the cross-pod tailer — so the two never diverge. Returns the tab count.
+func (a *App) applyBroadcast(rec broadcastRecord) int {
 	ctxs := a.snapshotContexts()
-	for _, c := range ctxs {
-		c.patch.Signals(values)
+	switch rec.Kind {
+	case bcScript:
+		for _, c := range ctxs {
+			enqueueScript(c, rec.Script)
+		}
+	case bcSignals:
+		for _, c := range ctxs {
+			c.patch.Signals(rec.Signals)
+		}
 	}
 	return len(ctxs)
+}
+
+// startBroadcastTailer tails the shared broadcast feed and applies each record
+// to this pod's live tabs. It subscribes from the current HEAD so a pod that
+// joins later never replays notices issued before it booted — broadcast is
+// ephemeral, not convergent. The goroutine exits when the Subscribe channel
+// closes (backplane Close on Shutdown). Only started when clustered.
+func (a *App) startBroadcastTailer() {
+	bg := context.Background()
+	head, _, err := a.backplane.Head(bg, broadcastKey)
+	if err != nil {
+		return
+	}
+	ch, err := a.backplane.Subscribe(bg, broadcastKey, head)
+	if err != nil {
+		return
+	}
+	go func() {
+		for rec := range ch {
+			var r broadcastRecord
+			if json.Unmarshal(rec.Data, &r) != nil {
+				continue
+			}
+			a.applyBroadcast(r)
+		}
+	}()
 }
 
 // broadcastRender forces a view re-render on every live *Ctx whose

--- a/broadcast_test.go
+++ b/broadcast_test.go
@@ -2,6 +2,7 @@ package via_test
 
 import (
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -43,6 +44,25 @@ func awaitNeedleOnAll(t *testing.T, frames []<-chan string, needle string, timeo
 	}
 }
 
+// drainFor accumulates everything that arrives on ch for d, then returns it.
+// Used to assert on the absence of a needle (nothing leaked) or to catch a
+// stray duplicate frame after the expected one already landed.
+func drainFor(ch <-chan string, d time.Duration) string {
+	deadline := time.After(d)
+	var b strings.Builder
+	for {
+		select {
+		case f, ok := <-ch:
+			if !ok {
+				return b.String()
+			}
+			b.WriteString(f)
+		case <-deadline:
+			return b.String()
+		}
+	}
+}
+
 func TestBroadcast_pushesScriptToEveryLiveTab(t *testing.T) {
 	t.Parallel()
 
@@ -61,9 +81,9 @@ func TestBroadcast_pushesScriptToEveryLiveTab(t *testing.T) {
 
 // The canonical broadcast — a site-wide notice — needs a safe path: raw
 // Broadcast forces every app to hand-build toast JS and get the XSS escaping
-// right. BroadcastToast reuses the JSON-encoded toast snippet so the message
+// right. BroadcastNotify reuses the JSON-encoded toast snippet so the message
 // is safe even with markup, and reaches every live tab.
-func TestBroadcastToast_pushesAnXSSSafeToastToEveryLiveTab(t *testing.T) {
+func TestBroadcastNotify_pushesAnXSSSafeToastToEveryLiveTab(t *testing.T) {
 	t.Parallel()
 
 	app := via.New()
@@ -74,8 +94,8 @@ func TestBroadcastToast_pushesAnXSSSafeToastToEveryLiveTab(t *testing.T) {
 	defer cancel()
 
 	// A message with markup must arrive JSON/HTML-escaped, never as live HTML.
-	assert.Equal(t, 2, app.BroadcastToast("Deploy soon"),
-		"BroadcastToast should report the tab count it reached")
+	assert.Equal(t, 2, app.BroadcastNotify("Deploy soon"),
+		"BroadcastNotify should report the tab count it reached")
 	// Both needles are in the one script frame (`via-toast` proves the safe
 	// toast snippet, "Deploy soon" is its JSON-encoded message argument), so
 	// match them in a single AwaitFrame per channel — a second call would wait
@@ -125,4 +145,161 @@ func TestBroadcast_emptyIsNoOp(t *testing.T) {
 	_ = vt.NewClient(t, server, "/")
 	assert.Equal(t, 0, app.Broadcast(""),
 		"empty script should be reported as 0 tabs")
+}
+
+// A site-wide notice must reach live tabs on EVERY pod when the app is
+// clustered via a shared backplane, not just the pod the call landed on. A
+// Broadcast on pod A has to surface on pod B's live tab — which only happens if
+// the payload travels the backplane and B applies it from its own tailer, since
+// A never touches B's tab. The originating pod's own tab is reached the same
+// way (append-only: the payload is applied through the tailer, never twice).
+func TestBroadcast_reachesTabsOnEveryPodWhenClustered(t *testing.T) {
+	t.Parallel()
+
+	shared := via.InMemory()
+
+	appA := via.New(via.WithBackplane(shared))
+	serverA := vt.Serve(t, appA)
+	via.Mount[broadcastPage](appA, "/")
+
+	appB := via.New(via.WithBackplane(shared))
+	serverB := vt.Serve(t, appB)
+	via.Mount[broadcastPage](appB, "/")
+
+	a := vt.NewClient(t, serverA, "/")
+	framesA, cancelA := a.SSEReady()
+	defer cancelA()
+	b := vt.NewClient(t, serverB, "/")
+	framesB, cancelB := b.SSEReady()
+	defer cancelB()
+
+	const msg = `console.log("cluster-wide")`
+	appA.Broadcast(msg)
+
+	vt.AwaitFrame(t, framesA, 2*time.Second, msg)
+	vt.AwaitFrame(t, framesB, 2*time.Second, msg)
+}
+
+// The signal-patch broadcast carries its payload across pods too: a
+// BroadcastSignals on pod A must drive the same client-only signal on pod B's
+// live tab, proving the values map itself rides the backplane feed.
+func TestBroadcastSignals_reachTabsOnEveryPodWhenClustered(t *testing.T) {
+	t.Parallel()
+
+	shared := via.InMemory()
+
+	appA := via.New(via.WithBackplane(shared))
+	serverA := vt.Serve(t, appA)
+	via.Mount[broadcastPage](appA, "/")
+
+	appB := via.New(via.WithBackplane(shared))
+	serverB := vt.Serve(t, appB)
+	via.Mount[broadcastPage](appB, "/")
+
+	a := vt.NewClient(t, serverA, "/")
+	framesA, cancelA := a.SSEReady()
+	defer cancelA()
+	b := vt.NewClient(t, serverB, "/")
+	framesB, cancelB := b.SSEReady()
+	defer cancelB()
+
+	appA.BroadcastSignals(map[string]any{"_systemNotice": "maintenance soon"})
+
+	vt.AwaitFrame(t, framesA, 2*time.Second, "maintenance soon")
+	vt.AwaitFrame(t, framesB, 2*time.Second, "maintenance soon")
+}
+
+// A pod that joins (boots, opens its tab) AFTER a broadcast was issued must NOT
+// receive that historical notice — broadcast is best-effort and ephemeral, so
+// the tailer starts at the feed HEAD rather than replaying from offset 0. A
+// late tab seeing a stale "maintenance in 30s" alert would be a real bug.
+//
+// The test pins HEAD-vs-0 by issuing a SECOND broadcast after B has booted: B
+// must receive the fresh notice (proving its tailer is live and cross-pod works
+// at all) while that same frame stream never carries the stale, pre-boot one. A
+// from-0 subscribe would replay the stale notice; a from-HEAD subscribe skips it.
+func TestBroadcast_doesNotReplayHistoryToLateJoiners(t *testing.T) {
+	t.Parallel()
+
+	shared := via.InMemory()
+
+	appA := via.New(via.WithBackplane(shared))
+	_ = vt.Serve(t, appA)
+	via.Mount[broadcastPage](appA, "/")
+
+	const stale = `console.log("stale notice")`
+	appA.Broadcast(stale)
+
+	// Pod B boots only now, well after A's broadcast already committed to the
+	// shared feed; its fresh tab must never see the bygone notice.
+	appB := via.New(via.WithBackplane(shared))
+	serverB := vt.Serve(t, appB)
+	via.Mount[broadcastPage](appB, "/")
+
+	b := vt.NewClient(t, serverB, "/")
+	framesB, cancelB := b.SSEReady()
+	defer cancelB()
+
+	const fresh = `console.log("fresh notice")`
+	appA.Broadcast(fresh)
+
+	got := vt.AwaitFrame(t, framesB, 2*time.Second, fresh)
+	assert.NotContains(t, got, stale,
+		"a late-joining pod must receive post-boot broadcasts but never replay one issued before it booted")
+}
+
+// Append-only delivery: the originating pod applies a clustered broadcast
+// THROUGH its own tailer, never also directly — so a tab on the pod that issued
+// the call sees the notice exactly once. A belt-and-suspenders impl that applied
+// locally AND re-applied from the tailer would double-fire every site-wide alert.
+func TestBroadcast_appliesExactlyOnceOnTheOriginatingPodWhenClustered(t *testing.T) {
+	t.Parallel()
+
+	shared := via.InMemory()
+
+	app := via.New(via.WithBackplane(shared))
+	server := vt.Serve(t, app)
+	via.Mount[broadcastPage](app, "/")
+
+	a := vt.NewClient(t, server, "/")
+	frames, cancel := a.SSEReady()
+	defer cancel()
+
+	const msg = `console.log("once-only-marker")`
+	app.Broadcast(msg)
+
+	// Wait for it to land, then keep draining briefly to catch a stray second
+	// copy. Exactly one occurrence across all frames is the contract.
+	got := vt.AwaitFrame(t, frames, 2*time.Second, msg)
+	got += drainFor(frames, 300*time.Millisecond)
+	assert.Equal(t, 1, strings.Count(got, msg),
+		"a clustered broadcast must reach the originating pod's tab exactly once")
+}
+
+// The "single pod by default" contract: with no shared backplane wired, a
+// broadcast stays strictly pod-local — it must never leak into an unrelated App.
+// This guards against a future refactor that wires a process-global backplane by
+// default and silently turns every Broadcast cluster-wide.
+func TestBroadcast_staysPodLocalWithoutASharedBackplane(t *testing.T) {
+	t.Parallel()
+
+	appA := via.New()
+	serverA := vt.Serve(t, appA)
+	via.Mount[broadcastPage](appA, "/")
+
+	appB := via.New()
+	serverB := vt.Serve(t, appB)
+	via.Mount[broadcastPage](appB, "/")
+
+	_ = vt.NewClient(t, serverA, "/")
+	b := vt.NewClient(t, serverB, "/")
+	framesB, cancelB := b.SSEReady()
+	defer cancelB()
+
+	const msg = `console.log("local only")`
+	appA.Broadcast(msg)
+
+	got := drainFor(framesB, 500*time.Millisecond)
+	assert.NotContains(t, got, msg,
+		"a broadcast must not reach an unrelated App when no backplane is shared")
 }

--- a/csp_push_test.go
+++ b/csp_push_test.go
@@ -15,7 +15,7 @@ import (
 type cspPushPage struct{}
 
 func (p *cspPushPage) PopToast(ctx *via.Ctx) error {
-	ctx.Toast("hi")
+	ctx.Notify("hi")
 	return nil
 }
 
@@ -102,7 +102,7 @@ func TestPushedScript_hasNoNonceWithoutCSP(t *testing.T) {
 type cspPushNonceViewPage struct{}
 
 func (p *cspPushNonceViewPage) PopToast(ctx *via.Ctx) error {
-	ctx.Toast("hi")
+	ctx.Notify("hi")
 	return nil
 }
 

--- a/ctx.go
+++ b/ctx.go
@@ -344,7 +344,7 @@ func (ctx *Ctx) SyncNow() {
 // surfaces the value via the normal dirty-bit path.
 //
 // Explicit publish primitives (ctx.Patch().{Signal,Signals,Element,Elements},
-// ExecScript, Toast, Reload, Redirect) are NOT suppressed by SyncOff
+// ExecScript, Notify, Reload, Redirect) are NOT suppressed by SyncOff
 // — they enqueue patches directly rather than through the dirty-bit
 // flush. This is deliberate so a panic-recovery error toast still
 // reaches the user even when the action was running silent.

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -375,7 +375,7 @@ func TestCtx_coreHelpersTolerateNilReceiver(t *testing.T) {
 	}
 }
 
-// Reload / Toast / Redirect — ctx imperative helpers emit SSE frames
+// Reload / Notify / Redirect — ctx imperative helpers emit SSE frames
 
 type ctxScriptPage struct{}
 
@@ -385,24 +385,24 @@ func (p *ctxScriptPage) DoReload(ctx *via.Ctx) error {
 }
 
 func (p *ctxScriptPage) DoToast(ctx *via.Ctx) error {
-	ctx.Toast("saved!")
+	ctx.Notify("saved!")
 	return nil
 }
 
 func (p *ctxScriptPage) DoToastSpecial(ctx *via.Ctx) error {
 	// Embedded quotes, newline, and a backslash exercise escape paths
 	// where Go's %q diverges from JSON / JS string literal syntax.
-	ctx.Toast(`he said "ok\n done"`)
+	ctx.Notify(`he said "ok\n done"`)
 	return nil
 }
 
 func (p *ctxScriptPage) DoToastHTML(ctx *via.Ctx) error {
-	ctx.Toast(`<img src=x onerror="boom()">`)
+	ctx.Notify(`<img src=x onerror="boom()">`)
 	return nil
 }
 
 func (p *ctxScriptPage) DoToastScriptBreakout(ctx *via.Ctx) error {
-	ctx.Toast(`</script><img src=x onerror=boom()>`)
+	ctx.Notify(`</script><img src=x onerror=boom()>`)
 	return nil
 }
 
@@ -421,7 +421,7 @@ func (p *redirectPage) Go(ctx *via.Ctx) error {
 }
 
 func (p *redirectPage) Ack(ctx *via.Ctx) error {
-	ctx.Toast("ack")
+	ctx.Notify("ack")
 	return nil
 }
 
@@ -444,7 +444,7 @@ func TestCtx_Reload_emitsLocationReloadScript(t *testing.T) {
 	vt.AwaitFrame(t, frames, 2*time.Second, "location.reload()")
 }
 
-func TestCtx_Toast_rendersStyledToastNotAlert(t *testing.T) {
+func TestCtx_Notify_rendersStyledToastNotAlert(t *testing.T) {
 	t.Parallel()
 
 	app := via.New()
@@ -461,11 +461,11 @@ func TestCtx_Toast_rendersStyledToastNotAlert(t *testing.T) {
 		"default toast must not fall back to a blocking window.alert")
 }
 
-func TestCtx_Toast_injectsMessageAsJSStringLiteral(t *testing.T) {
+func TestCtx_Notify_injectsMessageAsJSStringLiteral(t *testing.T) {
 	t.Parallel()
 	// The message rides into the toast script as a JSON-encoded literal:
 	// the inner quote becomes \" and the newline \n, matching how a JS
-	// engine parses a string literal. Catches a regression where Toast
+	// engine parses a string literal. Catches a regression where Notify
 	// interpolated the raw message into the script and let it break out
 	// of the string context.
 	app := via.New()
@@ -482,7 +482,7 @@ func TestCtx_Toast_injectsMessageAsJSStringLiteral(t *testing.T) {
 	assert.NotContains(t, frame, "alert(")
 }
 
-func TestCtx_Toast_escapesHTMLMarkupInMessage(t *testing.T) {
+func TestCtx_Notify_escapesHTMLMarkupInMessage(t *testing.T) {
 	t.Parallel()
 	// json.Marshal HTML-escapes the angle brackets and ampersand to their
 	// unicode-escaped forms, so an HTML payload reaches the wire as an
@@ -503,7 +503,7 @@ func TestCtx_Toast_escapesHTMLMarkupInMessage(t *testing.T) {
 		"user HTML must be escaped, never emitted as live markup")
 }
 
-func TestCtx_Toast_cannotBreakOutOfTheScriptElement(t *testing.T) {
+func TestCtx_Notify_cannotBreakOutOfTheScriptElement(t *testing.T) {
 	t.Parallel()
 	// datastar delivers the toast snippet inside a <script>…</script>
 	// element, so a message carrying a literal </script> is the
@@ -573,7 +573,7 @@ func TestCtx_Redirect_allowsSafeURLs(t *testing.T) {
 func TestCtx_Redirect_dropsDangerousURLs(t *testing.T) {
 	t.Parallel()
 	// Open-redirect / XSS vectors must not reach the client. The Redirect
-	// patch is dropped; a subsequent observable patch (Toast) confirms the
+	// patch is dropped; a subsequent observable patch (Notify) confirms the
 	// SSE stream is still alive and that the dangerous URL never appears
 	// in any frame that did arrive.
 	cases := []struct {
@@ -922,7 +922,7 @@ func (p *syncOffExplicitPage) View(ctx *via.CtxR) h.H { return h.Div() }
 
 func (p *syncOffExplicitPage) SilentToast(ctx *via.Ctx) error {
 	ctx.SyncOff()
-	ctx.Toast("ping")
+	ctx.Notify("ping")
 	return nil
 }
 
@@ -941,7 +941,7 @@ func (p *syncOffExplicitPage) SilentSyncElements(ctx *via.Ctx) error {
 func TestSyncOff_doesNotSuppressExplicitPublishPrimitives(t *testing.T) {
 	t.Parallel()
 	// SyncOff gates dirty-bit-driven publishing. PatchSignal /
-	// SyncElements / Toast write directly onto the patch queue and
+	// SyncElements / Notify write directly onto the patch queue and
 	// must surface even while silent — they're how user code signals
 	// "publish this regardless of pending dirty bits".
 	cases := []struct {
@@ -949,7 +949,7 @@ func TestSyncOff_doesNotSuppressExplicitPublishPrimitives(t *testing.T) {
 		action string
 		expect string
 	}{
-		{"Toast", "SilentToast", "ping"},
+		{"Notify", "SilentToast", "ping"},
 		{"PatchSignal", "SilentPatchSignal", "hello"},
 		{"SyncElements", "SilentSyncElements", `id="marker"`},
 	}

--- a/docs/actions-and-lifecycle.md
+++ b/docs/actions-and-lifecycle.md
@@ -40,8 +40,8 @@ Named event helpers include `Click`, `Change`, `Input`, `Submit`, `Focus`,
 - Write typed state: `c.Hits.Write(ctx, …)` or `c.Hits.Op(ctx).Add(1)`.
 - Push targeted patches: `ctx.Patch().Elements(h.Ul(h.ID("list"), …))`.
 - Push raw signals: `ctx.Patch().Signal("_picoTheme", "purple")`.
-- Show a quick toast: `ctx.Toast("saved!")` — a styled, non-blocking notice
-  that auto-dismisses (JSON-safe, zero setup).
+- Show a quick notification: `ctx.Notify("saved!")` — a styled, non-blocking
+  toast that auto-dismisses (JSON-safe, zero setup).
 - Redirect: `ctx.Redirect("/profile")`. Only http/https/relative URLs are
   honoured; `javascript:`, `data:`, protocol-relative `//`, and backslash
   variants are dropped and logged (open-redirect / XSS defence).

--- a/internal/examples/maps/main.go
+++ b/internal/examples/maps/main.go
@@ -181,14 +181,14 @@ func (p *Page) DropPin(ctx *via.Ctx) {
 func (p *Page) FocusMarker(ctx *via.Ctx) {
 	e := p.Map.Event(ctx)
 	p.Map.FlyTo(ctx, e.LngLat(), 6)
-	ctx.Toast(fmt.Sprintf("Selected %s", e.MarkerID))
+	ctx.Notify(fmt.Sprintf("Selected %s", e.MarkerID))
 }
 
 // PinMoved reports where a dragged marker was dropped — drag-to-reposition,
 // driven entirely from Go.
 func (p *Page) PinMoved(ctx *via.Ctx) {
 	e := p.Map.Event(ctx)
-	ctx.Toast(fmt.Sprintf("%s moved to %.4f, %.4f", e.MarkerID, e.Lat, e.Lng))
+	ctx.Notify(fmt.Sprintf("%s moved to %.4f, %.4f", e.MarkerID, e.Lat, e.Lng))
 }
 
 // ZoneClicked opens a popup ("dialog") at the clicked feature, showing details
@@ -205,7 +205,7 @@ func (p *Page) ZoneClicked(ctx *via.Ctx) {
 // hatch, reporting where and at what zoom.
 func (p *Page) RightClicked(ctx *via.Ctx) {
 	e := p.Map.Event(ctx)
-	ctx.Toast(fmt.Sprintf("Right-clicked %.3f, %.3f @ z%.1f", e.Lat, e.Lng, e.Zoom))
+	ctx.Notify(fmt.Sprintf("Right-clicked %.3f, %.3f @ z%.1f", e.Lat, e.Lng, e.Zoom))
 }
 
 func (p *Page) View(ctx *via.CtxR) h.H {

--- a/push.go
+++ b/push.go
@@ -11,7 +11,7 @@ import (
 // Imperative client-push helpers on *Ctx: ways for the server to tell
 // the browser "patch these signals / morph these elements / run this JS
 // / navigate / alert / reload" at the next flush. [Ctx.Redirect] and
-// [Ctx.Toast] are convenience wrappers over the same patch queue; all of
+// [Ctx.Notify] are convenience wrappers over the same patch queue; all of
 // these queue side effects directly rather than returning errors.
 
 // Patch groups the low-level wire-push primitives — push a signal value
@@ -123,7 +123,8 @@ func (ctx *Ctx) Reload() {
 	ctx.ExecScript("location.reload()")
 }
 
-// Toast shows message as a small, styled, non-blocking notice that slides
+// Notify shows message as a transient notification. The default (and
+// currently only) surface is a small, styled, non-blocking toast that slides
 // into a fixed overlay and auto-dismisses after a few seconds. It is the
 // default surface for recovered action-handler panics, and the "show a
 // quick notice and move on" sugar for app code. Zero setup: the first
@@ -134,7 +135,7 @@ func (ctx *Ctx) Reload() {
 // encoded into the snippet so it can neither break out of the JS string
 // nor inject markup — Go's json HTML-escaping also neutralises a
 // </script> breakout of the surrounding datastar script element.
-func (ctx *Ctx) Toast(message string) {
+func (ctx *Ctx) Notify(message string) {
 	if ctx == nil || message == "" {
 		return
 	}
@@ -145,7 +146,7 @@ func (ctx *Ctx) Toast(message string) {
 
 // buildToastScript wraps message into the self-contained, XSS-safe toast
 // snippet (JSON-encoded so arbitrary text — including markup — is inert).
-// Shared by [Ctx.Toast] and [App.BroadcastToast]. ok is false only when the
+// Shared by [Ctx.Notify] and [App.BroadcastNotify]. ok is false only when the
 // message can't be JSON-encoded, which for a string never happens.
 func buildToastScript(message string) (string, bool) {
 	b, err := json.Marshal(message)
@@ -156,7 +157,7 @@ func buildToastScript(message string) (string, bool) {
 }
 
 // toastScriptHead / toastScriptTail wrap a JSON-encoded message into the
-// self-contained toast snippet ctx.Toast emits. It rides ExecScript — the
+// self-contained toast snippet ctx.Notify emits. It rides ExecScript — the
 // same script-frame path the previous alert() used — so there is no
 // document change, no new public API, and no CSP posture shift versus the
 // alert it replaces. The <style> and container are keyed by element id so

--- a/push_test.go
+++ b/push_test.go
@@ -60,7 +60,7 @@ func TestCtx_pushHelpersToleratesNilReceiver(t *testing.T) {
 	}{
 		{"ExecScript", func() { ctx.ExecScript("x") }},
 		{"Reload", func() { ctx.Reload() }},
-		{"Toast", func() { ctx.Toast("hi") }},
+		{"Notify", func() { ctx.Notify("hi") }},
 		{"Redirect", func() { ctx.Redirect("/") }},
 	}
 	for _, c := range cases {

--- a/viashowcase/internal/ui/home.go
+++ b/viashowcase/internal/ui/home.go
@@ -42,7 +42,7 @@ func (c *Home) Create(ctx *via.Ctx) error {
 		// A poll with no valid choices renders zero vote buttons and rejects
 		// every vote — a dead room. Refuse to create it.
 		if choices = core.PollChoices(c.Choices.Read(ctx)); len(choices) == 0 {
-			ctx.Toast("A poll needs at least one choice.")
+			ctx.Notify("A poll needs at least one choice.")
 			return nil
 		}
 	}

--- a/viashowcase/internal/ui/profile.go
+++ b/viashowcase/internal/ui/profile.go
@@ -109,7 +109,7 @@ func (p *Profile) Upload(ctx *via.Ctx) error {
 		// HTML that avatarHandler would serve inline (stored XSS). Reject
 		// anything that isn't a safe raster image.
 		if !core.IsAllowedAvatarType(ct) {
-			ctx.Toast("Avatar must be a PNG, JPEG, GIF or WebP image.")
+			ctx.Notify("Avatar must be a PNG, JPEG, GIF or WebP image.")
 			http.Redirect(ctx.Writer(), ctx.Request(), "/app/profile", http.StatusSeeOther)
 			return nil
 		}

--- a/viashowcase/internal/ui/room_join.go
+++ b/viashowcase/internal/ui/room_join.go
@@ -84,7 +84,7 @@ func (j *Join) Vote(ctx *via.Ctx) error {
 	})
 	j.Draft.Op(ctx).Clear()
 	if err == nil {
-		ctx.Toast("Vote counted ✓") // phone feedback — the tap registered
+		ctx.Notify("Vote counted ✓") // phone feedback — the tap registered
 	}
 	return err
 }
@@ -99,7 +99,7 @@ func (j *Join) Ask(ctx *via.Ctx) error {
 	_, err := j.QA.Append(ctx, core.QAEvent{Room: j.Code, Kind: "ask", ID: id, Text: t, By: j.nick(ctx)})
 	j.Draft.Op(ctx).Clear()
 	if err == nil {
-		ctx.Toast("Question posted ✓")
+		ctx.Notify("Question posted ✓")
 	}
 	return err
 }
@@ -121,7 +121,7 @@ func (j *Join) DropPin(ctx *via.Ctx) error {
 		Room: j.Code, Lng: j.Lng.Read(ctx), Lat: j.Lat.Read(ctx), By: j.nick(ctx),
 	})
 	if err == nil {
-		ctx.Toast("Pin added ✓")
+		ctx.Notify("Pin added ✓")
 	}
 	return err
 }


### PR DESCRIPTION
## What

Two related changes to the notification surface.

### Cross-pod `Broadcast`

The `App.Broadcast*` family now reaches live tabs on **every pod** when a backplane is wired via `WithBackplane`, staying pod-local otherwise.

- New `via.broadcast` EventLog feed carries the payload itself (`{kind: script|signals}`). Unlike the value-less `via.changes` feed there is no Store cell behind it — a broadcast is ephemeral and best-effort (no convergence, no reconcile, no monotone gate).
- A per-pod tailer subscribes from feed **HEAD** (not 0), so a late-joining pod never replays notices issued before it booted.
- **Append-only / uniform apply**: the originating pod applies through its own tailer, never also directly, so each tab sees a notice exactly once.
- Cross-pod append fires only when `cfg.backplane != nil`; the in-process default stays single-pod and applies inline.
- Return value stays *this pod's* live-tab count (the cluster-wide total is unknowable synchronously) — re-documented.
- `BroadcastNotify` and `BroadcastSignal[T]` funnel through the same path and inherit cross-pod delivery; toast XSS escaping is preserved across the feed.

### Rename `Toast` → `Notify`

The public notification verb is renamed (`Ctx.Toast`→`Ctx.Notify`, `App.BroadcastToast`→`App.BroadcastNotify`): the verb names *intent*, not rendering, leaving room for future surfaces under one name. The concrete renderer stays named `toast` (`buildToastScript`, `via-toast` CSS) — that's accurately what it is. No deprecated alias (clean pre-1.0 break).

`Ctx.Notify` is deliberately single-tab/pod-local; `App.BroadcastNotify` is its cluster-wide counterpart.

## Tests

Built via the RYGBA TDD cycle. New cross-pod tests (two Apps sharing one in-memory backplane): script + signals delivery, late-joiner does-not-replay (pins HEAD-vs-0), exactly-once on the originating pod, and pod-local-without-backplane. Existing single-pod broadcast/notify coverage unchanged. `go test -race ./...` green, `go vet ./...` clean.