### PR TITLE
fix: cancel in-flight backplane I/O on Shutdown

### DIFF
--- a/app.go
+++ b/app.go
@@ -94,6 +94,13 @@ type App struct {
 	backplaneDone     chan struct{}
 	backplaneDoneOnce sync.Once
 
+	// backplaneCtx is the parent of every backplane I/O call (Subscribe, Append,
+	// CAS, LoadSnapshot, Compact). Shutdown cancels it so a wedged backend cannot
+	// keep an in-flight call alive and block the drain — without it those calls
+	// rode context.Background() and could never be aborted.
+	backplaneCtx    context.Context
+	backplaneCancel context.CancelFunc
+
 	middlewareMu sync.Mutex
 	middleware   []Middleware
 
@@ -330,6 +337,7 @@ func New(opts ...Option) *App {
 	verifyMethodNameTrampoline()
 
 	mux := http.NewServeMux()
+	backplaneCtx, backplaneCancel := context.WithCancel(context.Background())
 	a := &App{
 		mux:             mux,
 		contextRegistry: make(map[string]*Ctx),
@@ -340,6 +348,8 @@ func New(opts ...Option) *App {
 		valStates:       make(map[string]*valCell),
 		sessDecoders:    make(map[string]func([]byte) (any, error)),
 		backplaneDone:   make(chan struct{}),
+		backplaneCtx:    backplaneCtx,
+		backplaneCancel: backplaneCancel,
 		cfg: config{
 			addr:              ":3000",
 			logLevel:          LogWarn,

--- a/appval.go
+++ b/appval.go
@@ -1,7 +1,6 @@
 package via
 
 import (
-	"context"
 	"encoding/json"
 	"sync"
 )
@@ -136,7 +135,7 @@ func (a *App) reconcileSessionKey(sess *session, key string) {
 	if decode == nil {
 		return
 	}
-	data, storeRev, ok, _ := a.backplane.LoadSnapshot(context.Background(), sessValKey(sess.id, key))
+	data, storeRev, ok, _ := a.backplane.LoadSnapshot(a.backplaneCtx, sessValKey(sess.id, key))
 	if !ok || storeRev <= sess.loadRev(key) {
 		return
 	}
@@ -159,7 +158,7 @@ func (a *App) reconcileKey(key string) {
 	if vc == nil {
 		return
 	}
-	data, storeRev, ok, _ := a.backplane.LoadSnapshot(context.Background(), valKey(key))
+	data, storeRev, ok, _ := a.backplane.LoadSnapshot(a.backplaneCtx, valKey(key))
 	vc.mu.Lock()
 	changed := false
 	if ok && storeRev > vc.l1Rev {
@@ -179,7 +178,7 @@ func (a *App) reconcileKey(key string) {
 // Store cell to HEAD. The goroutine exits when the Subscribe channel closes
 // (backplane Close on Shutdown).
 func (a *App) startChangesTailer() {
-	ch, err := a.backplane.Subscribe(context.Background(), changesKey, 0)
+	ch, err := a.backplane.Subscribe(a.backplaneCtx, changesKey, 0)
 	if err != nil {
 		return
 	}
@@ -218,7 +217,7 @@ func (a *App) applySessionChange(c change) {
 	if decode == nil {
 		return
 	}
-	data, storeRev, dok, _ := a.backplane.LoadSnapshot(context.Background(), sessValKey(c.Sid, c.Key))
+	data, storeRev, dok, _ := a.backplane.LoadSnapshot(a.backplaneCtx, sessValKey(c.Sid, c.Key))
 	if !dok || storeRev < c.Rev {
 		return // stale replica: never surface a value older than the hint promised
 	}
@@ -260,7 +259,7 @@ func (a *App) applyChangeL1(c change) bool {
 	if c.Rev <= vc.l1Rev {
 		return false
 	}
-	data, storeRev, ok, _ := a.backplane.LoadSnapshot(context.Background(), valKey(c.Key))
+	data, storeRev, ok, _ := a.backplane.LoadSnapshot(a.backplaneCtx, valKey(c.Key))
 	if !ok || storeRev < c.Rev || storeRev <= vc.l1Rev {
 		return false
 	}

--- a/backplane_context_test.go
+++ b/backplane_context_test.go
@@ -1,0 +1,143 @@
+package via_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-via/via"
+	"github.com/go-via/via/h"
+	"github.com/go-via/via/on"
+	"github.com/go-via/via/vt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ctxRecordingBackplane wraps a real in-memory backplane and captures the
+// context handed to its I/O methods, so a test can prove Shutdown cancels
+// in-flight backplane work rather than leaving it to block forever.
+type ctxRecordingBackplane struct {
+	via.Backplane
+	mu      sync.Mutex
+	subCtx  context.Context
+	snapCtx context.Context
+	casCtx  context.Context
+}
+
+func (b *ctxRecordingBackplane) Subscribe(ctx context.Context, key string, from via.Offset) (<-chan via.Record, error) {
+	b.mu.Lock()
+	if b.subCtx == nil {
+		b.subCtx = ctx
+	}
+	b.mu.Unlock()
+	return b.Backplane.Subscribe(ctx, key, from)
+}
+
+func (b *ctxRecordingBackplane) LoadSnapshot(ctx context.Context, key string) ([]byte, via.Rev, bool, error) {
+	b.mu.Lock()
+	if b.snapCtx == nil {
+		b.snapCtx = ctx
+	}
+	b.mu.Unlock()
+	return b.Backplane.LoadSnapshot(ctx, key)
+}
+
+func (b *ctxRecordingBackplane) CAS(ctx context.Context, key string, expected via.Rev, data []byte) (via.Rev, error) {
+	b.mu.Lock()
+	if b.casCtx == nil {
+		b.casCtx = ctx
+	}
+	b.mu.Unlock()
+	return b.Backplane.CAS(ctx, key, expected, data)
+}
+
+func (b *ctxRecordingBackplane) captured() (sub, snap context.Context) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.subCtx, b.snapCtx
+}
+
+func (b *ctxRecordingBackplane) capturedCAS() context.Context {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.casCtx
+}
+
+type bpCtxPage struct {
+	Log via.StateAppEvents[tickEvent, int]
+}
+
+func (p *bpCtxPage) View(ctx *via.CtxR) h.H { return h.Div(p.Log.Text(ctx)) }
+
+// A backend that hangs must not be able to wedge Shutdown: the framework hands
+// every backplane call a context it cancels when the app shuts down. Without
+// that, a stuck Subscribe/Append/CAS keeps its context.Background() alive and
+// the pod can never drain. This is the most concrete production blocker the
+// critic panel flagged.
+func TestShutdownCancelsInflightBackplaneContext(t *testing.T) {
+	t.Parallel()
+
+	bp := &ctxRecordingBackplane{Backplane: via.InMemory()}
+	app := via.New(via.WithBackplane(bp))
+	server := vt.Serve(t, app)
+	via.Mount[bpCtxPage](app, "/")
+	_ = vt.NewClient(t, server, "/")
+
+	var sub, snap context.Context
+	require.Eventually(t, func() bool {
+		sub, snap = bp.captured()
+		return sub != nil && snap != nil
+	}, 2*time.Second, 5*time.Millisecond,
+		"the per-key projector must Subscribe and LoadSnapshot through the bound backplane")
+
+	require.NoError(t, sub.Err(),
+		"the backplane context must be live while the app is running")
+	require.NoError(t, snap.Err(),
+		"the backplane context must be live while the app is running")
+
+	require.NoError(t, app.Shutdown(context.Background()))
+
+	assert.ErrorIs(t, sub.Err(), context.Canceled,
+		"Shutdown must cancel the context handed to in-flight EventLog.Subscribe")
+	assert.ErrorIs(t, snap.Err(), context.Canceled,
+		"Shutdown must cancel the context handed to in-flight Store.LoadSnapshot")
+}
+
+type bpWritePage struct {
+	N via.StateAppNum[int]
+}
+
+func (p *bpWritePage) Inc(ctx *via.Ctx)       { p.N.Op(ctx).Inc() }
+func (p *bpWritePage) View(ctx *via.CtxR) h.H { return h.Div(on.Click(p.Inc), p.N.Text(ctx)) }
+
+// The write path (StateApp.Update's read-modify-write CAS) must ride the same
+// shutdown-cancelled context as reads — otherwise a wedged backend's CAS keeps
+// an action goroutine alive and blocks the drain. This guards the RMW call
+// sites that a read-only fix would miss.
+func TestShutdownCancelsBackplaneWritePathContext(t *testing.T) {
+	t.Parallel()
+
+	bp := &ctxRecordingBackplane{Backplane: via.InMemory()}
+	app := via.New(via.WithBackplane(bp))
+	server := vt.Serve(t, app)
+	via.Mount[bpWritePage](app, "/")
+
+	c := vt.NewClient(t, server, "/")
+	require.Equal(t, 200, c.Action("Inc").Fire())
+
+	var cas context.Context
+	require.Eventually(t, func() bool {
+		cas = bp.capturedCAS()
+		return cas != nil
+	}, 2*time.Second, 5*time.Millisecond,
+		"StateApp.Update must CAS through the bound backplane")
+
+	require.NoError(t, cas.Err(),
+		"the backplane write context must be live while the app is running")
+
+	require.NoError(t, app.Shutdown(context.Background()))
+
+	assert.ErrorIs(t, cas.Err(), context.Canceled,
+		"Shutdown must cancel the context handed to in-flight Store.CAS")
+}

--- a/broadcast.go
+++ b/broadcast.go
@@ -1,7 +1,6 @@
 package via
 
 import (
-	"context"
 	"encoding/json"
 )
 
@@ -97,7 +96,7 @@ func (a *App) BroadcastSignals(values map[string]any) int {
 func (a *App) dispatchBroadcast(rec broadcastRecord) int {
 	if a.cfg.backplane != nil {
 		if b, err := json.Marshal(rec); err == nil {
-			_, _ = a.backplane.Append(context.Background(), broadcastKey, b)
+			_, _ = a.backplane.Append(a.backplaneCtx, broadcastKey, b)
 		}
 		return len(a.snapshotContexts())
 	}
@@ -128,7 +127,7 @@ func (a *App) applyBroadcast(rec broadcastRecord) int {
 // ephemeral, not convergent. The goroutine exits when the Subscribe channel
 // closes (backplane Close on Shutdown). Only started when clustered.
 func (a *App) startBroadcastTailer() {
-	bg := context.Background()
+	bg := a.backplaneCtx
 	head, _, err := a.backplane.Head(bg, broadcastKey)
 	if err != nil {
 		return

--- a/crypto.go
+++ b/crypto.go
@@ -147,7 +147,7 @@ func (a *App) eventDecryptor() eventDecryptFn {
 		return nil
 	}
 	return func(subject string, token json.RawMessage) ([]byte, error) {
-		key, ok, err := ks.Key(context.Background(), subject)
+		key, ok, err := ks.Key(a.backplaneCtx, subject)
 		if err != nil {
 			return nil, err
 		}
@@ -167,7 +167,7 @@ const erasureGenKey = "erasure:gen"
 // (0 if never set). Read at cold start (to invalidate stale snapshots) and at
 // snapshot write (to stamp the checkpoint).
 func (a *App) loadErasureGen() uint64 {
-	data, _, ok, err := a.backplane.LoadSnapshot(context.Background(), erasureGenKey)
+	data, _, ok, err := a.backplane.LoadSnapshot(a.backplaneCtx, erasureGenKey)
 	if err != nil || !ok {
 		return 0
 	}

--- a/onevent.go
+++ b/onevent.go
@@ -126,7 +126,7 @@ func (a *App) registerConsumer(name, key string, deliver func(context.Context, [
 	cs := a.consumers[ck]
 	if cs == nil {
 		cs = &consumerState{}
-		if data, rev, ok, _ := a.backplane.LoadSnapshot(context.Background(), ck); ok {
+		if data, rev, ok, _ := a.backplane.LoadSnapshot(a.backplaneCtx, ck); ok {
 			var off Offset
 			if json.Unmarshal(data, &off) == nil {
 				cs.committed = off
@@ -149,7 +149,7 @@ func (a *App) startConsumer(name, key string, cs *consumerState, deliver func(co
 	go func() {
 		for {
 			from, _ := cs.snapshot()
-			subCtx, cancel := context.WithCancel(context.Background())
+			subCtx, cancel := context.WithCancel(a.backplaneCtx)
 			ch, err := a.backplane.Subscribe(subCtx, key, from)
 			if err != nil {
 				cancel()
@@ -189,9 +189,9 @@ func (a *App) commitConsumer(cs *consumerState, name, key string, off Offset) {
 		return
 	}
 	_, rev := cs.snapshot()
-	newRev, err := a.backplane.CAS(context.Background(), consumerKey(name, key), rev, b)
+	newRev, err := a.backplane.CAS(a.backplaneCtx, consumerKey(name, key), rev, b)
 	if errors.Is(err, ErrCASConflict) {
-		if data, r, ok, _ := a.backplane.LoadSnapshot(context.Background(), consumerKey(name, key)); ok {
+		if data, r, ok, _ := a.backplane.LoadSnapshot(a.backplaneCtx, consumerKey(name, key)); ok {
 			var peer Offset
 			if json.Unmarshal(data, &peer) == nil {
 				cs.mu.Lock()

--- a/server.go
+++ b/server.go
@@ -135,6 +135,11 @@ func (a *App) Shutdown(ctx context.Context) error {
 	// FIRST (close backplaneDone) so a channel close they observe during the
 	// drain is read as "stop", not "transient disconnect → reconnect".
 	a.backplaneDoneOnce.Do(func() { close(a.backplaneDone) })
+	// Cancel the parent of every in-flight backplane call so a wedged backend's
+	// Subscribe/Append/CAS aborts instead of blocking the drain forever.
+	if a.backplaneCancel != nil {
+		a.backplaneCancel()
+	}
 	if a.backplane != nil {
 		_ = a.backplane.Close()
 	}

--- a/stateapp.go
+++ b/stateapp.go
@@ -1,7 +1,6 @@
 package via
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -96,7 +95,7 @@ func (a *StateApp[T]) Update(ctx *Ctx, fn func(T) (T, error)) error {
 		return nil
 	}
 	app := ctx.app
-	bg := context.Background()
+	bg := app.backplaneCtx
 
 	for try := 0; try < updateMaxRetries; try++ {
 		data, rev, ok, err := app.backplane.LoadSnapshot(bg, valKey(a.wireKey))

--- a/stateappevents.go
+++ b/stateappevents.go
@@ -1,7 +1,6 @@
 package via
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -153,9 +152,9 @@ func (l *StateAppEvents[E, V]) Append(ctx *Ctx, ev E) (Offset, error) {
 	if err != nil {
 		return 0, err
 	}
-	// context.Background for now — the in-memory backplane ignores it; wiring
-	// the action's request context for cancellation is a later refinement.
-	return l.app.backplane.Append(context.Background(), l.wireKey, data)
+	// backplaneCtx is cancelled on Shutdown so a wedged backend's Append aborts
+	// with the drain rather than blocking the action goroutine forever.
+	return l.app.backplane.Append(l.app.backplaneCtx, l.wireKey, data)
 }
 
 // marshalEvent builds the wire record for one event: marshal the payload, wrap
@@ -180,7 +179,7 @@ func marshalEvent[E any](a *App, ev E) (out []byte, err error) {
 	if ks := a.cfg.keyStore; ks != nil {
 		if ds, ok := any(ev).(DataSubject); ok {
 			if subject := ds.DataSubject(); subject != "" {
-				key, err := ks.KeyFor(context.Background(), subject)
+				key, err := ks.KeyFor(a.backplaneCtx, subject)
 				if err != nil {
 					return nil, err
 				}

--- a/stateappevents_coldstart.go
+++ b/stateappevents_coldstart.go
@@ -1,7 +1,6 @@
 package via
 
 import (
-	"context"
 	"encoding/json"
 )
 
@@ -12,7 +11,7 @@ import (
 // covered offset only when a bridging seed (matching codec or seeded migration)
 // was installed; otherwise a halt is latched on ls and folding stops.
 func (a *App) coldStartFrom(ls *logState, key string) Offset {
-	data, _, ok, _ := a.backplane.LoadSnapshot(context.Background(), snapKey(key))
+	data, _, ok, _ := a.backplane.LoadSnapshot(a.backplaneCtx, snapKey(key))
 	if !ok {
 		return 0
 	}

--- a/stateappevents_compact.go
+++ b/stateappevents_compact.go
@@ -1,7 +1,5 @@
 package via
 
-import "context"
-
 // maybeCompact reclaims the log prefix a DURABLE snapshot now covers. Called
 // only on a successful snapshot CAS (snapshot-FIRST, compact-SECOND). The floor
 // LAGS one snapshot generation — Compact(before:prevSnapOffset) discards only
@@ -32,7 +30,7 @@ func (a *App) maybeCompact(ls *logState, key string, covered Offset) {
 	if cmin, ok := a.minConsumerOffset(key); ok && cmin < floor {
 		floor = cmin
 	}
-	_ = c.Compact(context.Background(), key, floor) // best-effort; a failure just defers reclamation
+	_ = c.Compact(a.backplaneCtx, key, floor) // best-effort; a failure just defers reclamation
 	ls.mu.Lock()
 	ls.prevSnapOffset = covered
 	ls.mu.Unlock()

--- a/stateappevents_gap.go
+++ b/stateappevents_gap.go
@@ -1,7 +1,6 @@
 package via
 
 import (
-	"context"
 	"encoding/json"
 )
 
@@ -68,7 +67,7 @@ const (
 //
 // The backplane read is OUTSIDE ls.mu; seedFromSnapshot takes the lock.
 func (a *App) classifyGap(ls *logState, key string, cur, needCovered Offset) gapClass {
-	data, _, ok, _ := a.backplane.LoadSnapshot(context.Background(), snapKey(key))
+	data, _, ok, _ := a.backplane.LoadSnapshot(a.backplaneCtx, snapKey(key))
 	if !ok {
 		return gapBenign
 	}

--- a/stateappevents_projector.go
+++ b/stateappevents_projector.go
@@ -1,7 +1,6 @@
 package via
 
 import (
-	"context"
 	"sync"
 	"time"
 )
@@ -89,7 +88,7 @@ func (a *App) startProjector(key string, ls *logState) {
 		// ErrClosed is a graceful stop — exit. Otherwise one network blip would
 		// strand the key forever.
 		for {
-			ch, err := a.backplane.Subscribe(context.Background(), key, from)
+			ch, err := a.backplane.Subscribe(a.backplaneCtx, key, from)
 			if err != nil {
 				return // ErrClosed (or unrecoverable) → stop
 			}

--- a/stateappevents_snapshot.go
+++ b/stateappevents_snapshot.go
@@ -1,7 +1,6 @@
 package via
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 )
@@ -90,14 +89,14 @@ func (a *App) writeSnapshot(ls *logState, key string) {
 	// durable snapshot to cover the prefix it drops) and a peer's gap-reseed
 	// would lose records. Read the current cell, skip if we don't advance it, and
 	// CAS against the rev we just read.
-	curData, curRev, ok, _ := a.backplane.LoadSnapshot(context.Background(), snapKey(key))
+	curData, curRev, ok, _ := a.backplane.LoadSnapshot(a.backplaneCtx, snapKey(key))
 	if ok {
 		var curCp checkpoint
 		if json.Unmarshal(curData, &curCp) == nil && cp.CoveredOffset <= curCp.CoveredOffset {
 			return // a peer's snapshot already covers at least this offset
 		}
 	}
-	_, err = a.backplane.CAS(context.Background(), snapKey(key), curRev, b)
+	_, err = a.backplane.CAS(a.backplaneCtx, snapKey(key), curRev, b)
 	if errors.Is(err, ErrCASConflict) {
 		return // a peer wrote concurrently; retry next interval
 	}

--- a/statesess.go
+++ b/statesess.go
@@ -1,7 +1,6 @@
 package via
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 
@@ -99,7 +98,7 @@ func (s *StateSess[T]) Update(ctx *Ctx, fn func(T) (T, error)) error {
 		return nil
 	}
 	app := ctx.app
-	bg := context.Background()
+	bg := app.backplaneCtx
 	cellKey := sessValKey(sess.id, s.wireKey)
 
 	for try := 0; try < updateMaxRetries; try++ {


### PR DESCRIPTION
## Problem (critic panel blocker #1)

Every backplane call site passed `context.Background()` — `Subscribe`, `Append`, `CAS`, `LoadSnapshot`, `Compact`, and the keystore `Key`/`KeyFor`. A wedged backend could keep an in-flight call alive forever, so `App.Shutdown` could never drain.

## Fix

- App-scoped `backplaneCtx`/`backplaneCancel`, created in `New`, cancelled in `Shutdown`.
- Cancel ordering: after action drain (`srv.Shutdown`) and `OnDispose` (so graceful writes still complete on a live ctx), before `backplane.Close()`.
- Threaded `backplaneCtx` through every backplane I/O call site (incl. `StateApp.Update`'s RMW CAS path).

## Tests

- `TestShutdownCancelsInflightBackplaneContext` — projector's `Subscribe` + `LoadSnapshot` contexts are live while running, `context.Canceled` after `Shutdown`.
- `TestShutdownCancelsBackplaneWritePathContext` — drives `StateApp.Update` and asserts the `CAS` context is cancelled by `Shutdown`.

Full `ci-check.sh` green (gofmt, vet, golangci, govulncheck, -race, alloc gates).