### PR TITLE
docs: correct on.Click compile-safety claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,11 @@ go get github.com/go-via/via
 Two counters, two scopes. `Local` is per-tab server state; `Shared` is one
 value across every session — clicking `+1` bumps `Local` only in that tab, but
 `Shared` everywhere at once. No `Broadcast`, no WebSocket, no client JS.
-`on.Click(p.IncShared)` is a typed method reference — a typo is a compile
-error.
+`on.Click(p.IncShared)` is a typed method reference: the handler signature is
+compile-checked and a misspelled method name won't build. It must be a real
+bound method, though — a closure or plain function satisfies the type but has
+no name to route to, so it panics at the first render rather than at compile
+time.
 
 ```go
 package main

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -64,7 +64,10 @@ go run .
 ```
 
 No template files. No build step. No hand-written JavaScript.
-`on.Click(c.Inc)` is a typed method reference — a typo is a compile error.
+`on.Click(c.Inc)` is a typed method reference: the handler signature is
+compile-checked and a misspelled method name won't build. It must be a real
+bound method — a closure or plain function type-checks but panics at the first
+render, since it has no name to route to.
 
 ## What just happened
 


### PR DESCRIPTION
Critic panel finding #7 (docs honesty). README:40 and docs/getting-started.md:67 claimed "a typo is a compile error" for `on.Click(p.Method)`.

That overstates it. The handler **signature** and a **misspelled method name** are genuinely compile-checked, but the method-name → handler routing is reflection-based (the `-fm` trampoline), so a **closure or plain function** type-checks against the `Action` union yet panics at the **first render** (handler.go:7-9). Docs now state the real contract: it must be a bound method value.

Docs-only; no behavior change.