### PR TITLE
feat: WithMaxSessions to bound the live session map

### DIFF
--- a/app.go
+++ b/app.go
@@ -433,7 +433,11 @@ func (a *App) withSession() http.Handler {
 		matched := pattern != ""
 
 		if matched {
-			_ = a.getOrCreateSession(w, r)
+			if a.getOrCreateSession(w, r) == nil {
+				a.logWarn(nil, "max sessions reached (%d); rejecting request", a.cfg.maxSessions)
+				http.Error(w, "server is at capacity", http.StatusServiceUnavailable)
+				return
+			}
 		}
 		// Stamp the app pointer into r so middleware can resolve the
 		// session via via.RequestSession(r) (used by via/sess.Get on

--- a/config.go
+++ b/config.go
@@ -43,6 +43,7 @@ type config struct {
 	maxRequestBody     int64
 	maxUploadSize      int64
 	maxContexts        int
+	maxSessions        int
 	actionErrorHandler func(*Ctx, error)
 	logger             Logger
 	notFoundHandler    http.Handler
@@ -70,6 +71,9 @@ func (c *config) validate() {
 	}
 	if c.maxContexts < 0 {
 		panic(fmt.Sprintf("via.WithMaxContexts: must be >= 0, got %d", c.maxContexts))
+	}
+	if c.maxSessions < 0 {
+		panic(fmt.Sprintf("via.WithMaxSessions: must be >= 0, got %d", c.maxSessions))
 	}
 }
 
@@ -265,6 +269,14 @@ func WithMaxUploadSize(n int64) Option { return func(c *config) { c.maxUploadSiz
 // crude but effective floor against tab-spam DoS. Default 0 (no
 // cap). Tune to (expected peak users × tabs per user × 2).
 func WithMaxContexts(n int) Option { return func(c *config) { c.maxContexts = n } }
+
+// WithMaxSessions caps the number of concurrent live sessions. Once the cap
+// is met, a request that would mint or adopt a NEW session is rejected with
+// 503 instead of growing the session map — a crude floor against the
+// cookieless-crawler flood that would otherwise OOM the pod. A client that
+// already holds a session is unaffected. Default 0 (no cap). Tune to
+// (expected peak users × 2).
+func WithMaxSessions(n int) Option { return func(c *config) { c.maxSessions = n } }
 
 // WithActionErrorHandler replaces the default browser-alert with a custom
 // callback for action errors and panics. The error from a panic is wrapped

--- a/sess.go
+++ b/sess.go
@@ -180,11 +180,17 @@ func (a *App) adoptSession(sid string) *session {
 	if sess, ok := a.sessions[sid]; ok {
 		return sess
 	}
+	if a.cfg.maxSessions > 0 && len(a.sessions) >= a.cfg.maxSessions {
+		return nil // at capacity: refuse to grow the map
+	}
 	sess := &session{id: sid}
 	a.sessions[sid] = sess
 	return sess
 }
 
+// getOrCreateSession returns the request's session, minting or adopting one if
+// needed. Returns nil ONLY when WithMaxSessions is set and the cap is met for a
+// new session — a client that already holds a live session is never refused.
 func (a *App) getOrCreateSession(w http.ResponseWriter, r *http.Request) *session {
 	now := time.Now().UnixNano()
 	if c, err := r.Cookie(a.cookieName()); err == nil {
@@ -202,6 +208,9 @@ func (a *App) getOrCreateSession(w http.ResponseWriter, r *http.Request) *sessio
 		// A malformed value is never adopted; it falls through to a fresh mint.
 		if validSessionID(c.Value) {
 			sess := a.adoptSession(c.Value)
+			if sess == nil {
+				return nil // at capacity
+			}
 			sess.lastAccess.Store(now)
 			r.AddCookie(&http.Cookie{Name: a.cookieName(), Value: sess.id})
 			return sess
@@ -212,6 +221,10 @@ func (a *App) getOrCreateSession(w http.ResponseWriter, r *http.Request) *sessio
 	sess.lastAccess.Store(now)
 
 	a.sessionsMu.Lock()
+	if a.cfg.maxSessions > 0 && len(a.sessions) >= a.cfg.maxSessions {
+		a.sessionsMu.Unlock()
+		return nil // at capacity: refuse to mint, fused with the insert
+	}
 	a.sessions[sess.id] = sess
 	a.sessionsMu.Unlock()
 

--- a/session_cap_test.go
+++ b/session_cap_test.go
@@ -1,0 +1,85 @@
+package via_test
+
+import (
+	"net/http"
+	"net/http/cookiejar"
+	"testing"
+
+	"github.com/go-via/via"
+	"github.com/go-via/via/vt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Without a cap, a cookieless crawler can mint an unbounded number of sessions
+// and OOM the pod. WithMaxSessions is the floor: once the live session map is
+// full, a new cookieless request is refused with 503 rather than minting.
+func TestMaxSessions_rejectsBeyondCap(t *testing.T) {
+	t.Parallel()
+
+	app := via.New(via.WithMaxSessions(2))
+	server := vt.Serve(t, app)
+	via.Mount[maxCtxPage](app, "/")
+
+	// server.Client() carries no cookie jar, so every request is a fresh,
+	// cookieless mint — exactly the crawler-flood shape.
+	for range 2 {
+		resp, err := server.Client().Get(server.URL + "/")
+		require.NoError(t, err)
+		resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode,
+			"requests up to the cap must mint a session")
+	}
+
+	resp, err := server.Client().Get(server.URL + "/")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode,
+		"a new session past the cap must be rejected with 503")
+}
+
+func TestMaxSessions_zeroDisablesTheCap(t *testing.T) {
+	t.Parallel()
+
+	app := via.New() // no WithMaxSessions
+	server := vt.Serve(t, app)
+	via.Mount[maxCtxPage](app, "/")
+
+	for range 5 {
+		resp, err := server.Client().Get(server.URL + "/")
+		require.NoError(t, err)
+		resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode,
+			"an unset cap must not reject any request")
+	}
+}
+
+func TestMaxSessions_negativePanicsAtRegistration(t *testing.T) {
+	t.Parallel()
+
+	assert.PanicsWithValue(t, "via.WithMaxSessions: must be >= 0, got -1", func() {
+		via.New(via.WithMaxSessions(-1))
+	}, "a negative cap is a config error and must fail loudly at startup")
+}
+
+func TestMaxSessions_existingSessionPassesAtCap(t *testing.T) {
+	t.Parallel()
+
+	app := via.New(via.WithMaxSessions(1))
+	server := vt.Serve(t, app)
+	via.Mount[maxCtxPage](app, "/")
+
+	// A client that keeps its cookie reuses its session and must never be
+	// refused once it already holds one, even at cap=1.
+	client := server.Client()
+	cj, err := cookiejar.New(nil)
+	require.NoError(t, err)
+	client.Jar = cj
+	for range 3 {
+		resp, err := client.Get(server.URL + "/")
+		require.NoError(t, err)
+		resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode,
+			"a returning client must reuse its session, not re-mint")
+	}
+}


### PR DESCRIPTION
Critic panel finding #10 (minor; perf + security). The session map had no cap — asymmetric with the existing `WithMaxContexts` — so a cookieless crawler could mint unbounded sessions and OOM the pod.

## Change
`WithMaxSessions(n)`: once the cap is met, a request that would **mint or adopt a new** session is rejected with 503. A client that **already holds** a live session is never refused. The cap check is fused with the map insert under `sessionsMu` (TOCTOU-safe, mirroring `tryRegisterCtx`). Default 0 = no cap.

## Tests
- rejects beyond cap (cookieless flood → 503)
- zero disables the cap
- returning client (cookie jar) reuses its session at cap=1, never 503
- negative value panics at registration

Full `ci-check.sh` green.