### PR TITLE
feat: default /livez /healthz /readyz health endpoints

### DIFF
--- a/app.go
+++ b/app.go
@@ -94,6 +94,11 @@ type App struct {
 	backplaneDone     chan struct{}
 	backplaneDoneOnce sync.Once
 
+	// draining flips true at the start of Shutdown so /readyz reports
+	// not-ready and the orchestrator stops sending new traffic while the pod
+	// finishes its graceful drain.
+	draining atomic.Bool
+
 	// backplaneCtx is the parent of every backplane I/O call (Subscribe, Append,
 	// CAS, LoadSnapshot, Compact). Shutdown cancels it so a wedged backend cannot
 	// keep an in-flight call alive and block the drain — without it those calls
@@ -111,7 +116,37 @@ type App struct {
 
 // ServeHTTP makes *App an http.Handler.
 func (a *App) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if a.serveHealth(w, r) {
+		return
+	}
 	a.handler.ServeHTTP(w, r)
+}
+
+// serveHealth answers the default liveness/readiness/health probes before the
+// session + middleware chain, so a frequent k8s probe never mints a session or
+// emits an access-log line. /livez and /healthz report the process is up;
+// /readyz reports 503 once Shutdown has begun draining so traffic drains away
+// from a departing pod while liveness stays green. Returns true if it handled
+// the request. Disabled by WithoutHealthEndpoints.
+func (a *App) serveHealth(w http.ResponseWriter, r *http.Request) bool {
+	if a.cfg.noHealth || r.Method != http.MethodGet {
+		return false
+	}
+	switch r.URL.Path {
+	case "/livez", "/healthz":
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	case "/readyz":
+		if a.draining.Load() {
+			http.Error(w, "draining", http.StatusServiceUnavailable)
+			return true
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	default:
+		return false
+	}
+	return true
 }
 
 // Use installs middleware that wraps every via-served request.

--- a/config.go
+++ b/config.go
@@ -44,6 +44,7 @@ type config struct {
 	maxUploadSize      int64
 	maxContexts        int
 	maxSessions        int
+	noHealth           bool
 	actionErrorHandler func(*Ctx, error)
 	logger             Logger
 	notFoundHandler    http.Handler
@@ -277,6 +278,13 @@ func WithMaxContexts(n int) Option { return func(c *config) { c.maxContexts = n 
 // already holds a session is unaffected. Default 0 (no cap). Tune to
 // (expected peak users × 2).
 func WithMaxSessions(n int) Option { return func(c *config) { c.maxSessions = n } }
+
+// WithoutHealthEndpoints disables via's built-in GET /livez, /healthz, and
+// /readyz probes. By default they are served before the session and middleware
+// chain (so a frequent probe never mints a session or logs a request): /livez
+// and /healthz report 200 while the process is up; /readyz reports 503 once
+// Shutdown begins draining. Opt out when the app needs to own those paths.
+func WithoutHealthEndpoints() Option { return func(c *config) { c.noHealth = true } }
 
 // WithActionErrorHandler replaces the default browser-alert with a custom
 // callback for action errors and panics. The error from a panic is wrapped

--- a/health_test.go
+++ b/health_test.go
@@ -1,0 +1,70 @@
+package via_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/go-via/via"
+	"github.com/go-via/via/vt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Orchestrators (k8s, load balancers) need liveness/readiness probes out of the
+// box; without defaults every team rolls their own. /livez and /healthz report
+// the process is up; /readyz additionally reports whether the app can take new
+// traffic.
+func TestHealth_livenessAndHealthzReturn200(t *testing.T) {
+	t.Parallel()
+
+	app := via.New()
+	server := vt.Serve(t, app)
+
+	for _, path := range []string{"/livez", "/healthz", "/readyz"} {
+		resp, err := server.Client().Get(server.URL + path)
+		require.NoError(t, err)
+		resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode,
+			"%s must report healthy on a running app", path)
+	}
+}
+
+// Readiness must flip to 503 once Shutdown begins draining, so the orchestrator
+// stops routing new traffic to a pod that is going away — while liveness stays
+// 200 so the pod isn't force-killed mid-drain.
+func TestHealth_readinessFailsWhileDraining(t *testing.T) {
+	t.Parallel()
+
+	app := via.New()
+	server := vt.Serve(t, app)
+
+	require.NoError(t, app.Shutdown(context.Background()))
+
+	resp, err := server.Client().Get(server.URL + "/readyz")
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode,
+		"/readyz must report not-ready once the app is draining")
+
+	live, err := server.Client().Get(server.URL + "/livez")
+	require.NoError(t, err)
+	live.Body.Close()
+	assert.Equal(t, http.StatusOK, live.StatusCode,
+		"/livez must stay healthy during drain so the pod isn't force-killed")
+}
+
+// The endpoints are conventional infra paths; an app that needs to own them
+// can opt out and serve its own.
+func TestHealth_optOutLeavesPathsUnclaimed(t *testing.T) {
+	t.Parallel()
+
+	app := via.New(via.WithoutHealthEndpoints())
+	server := vt.Serve(t, app)
+
+	resp, err := server.Client().Get(server.URL + "/livez")
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode,
+		"with health endpoints disabled, /livez must not be served by via")
+}

--- a/server.go
+++ b/server.go
@@ -89,6 +89,10 @@ func (a *App) Start() {
 // http.Server's Shutdown is returned; a wedged OnDispose handler does
 // not propagate but is logged.
 func (a *App) Shutdown(ctx context.Context) error {
+	// Flip readiness first so /readyz reports not-ready and the orchestrator
+	// drains traffic away before we start tearing anything down.
+	a.draining.Store(true)
+
 	a.contextRegistryMu.Lock()
 	ctxs := make([]*Ctx, 0, len(a.contextRegistry))
 	for _, c := range a.contextRegistry {


### PR DESCRIPTION
Critic panel finding #8 (major; ops). Via shipped no health/readiness/liveness probes, so every team rolled their own.

## Change
Serve `GET /livez`, `/healthz`, `/readyz` **before** the session + middleware chain, so a frequent orchestrator probe never mints a session or emits an access-log line.
- `/livez` + `/healthz` → 200 while the process is up.
- `/readyz` → 503 once `Shutdown` begins draining (new `draining` flag set at the top of `Shutdown`), so traffic drains away from a departing pod while liveness stays green (no force-kill mid-drain).
- `WithoutHealthEndpoints()` opts out when the app needs to own those paths.

## Tests
- /livez, /healthz, /readyz → 200 on a running app
- /readyz → 503 while draining; /livez stays 200
- opt-out leaves the paths unclaimed (404)

Full `ci-check.sh` green.