### PR TITLE
feat: WithVerboseErrors to surface real panic messages in dev

### DIFF
--- a/action.go
+++ b/action.go
@@ -250,7 +250,7 @@ func (a *App) dispatchActionError(ctx *Ctx, err error, fromPanic bool) {
 		return
 	}
 	msg := err.Error()
-	if fromPanic {
+	if fromPanic && !a.cfg.verboseErrors {
 		msg = "Something went wrong"
 	}
 	ctx.Notify(msg)

--- a/config.go
+++ b/config.go
@@ -45,6 +45,7 @@ type config struct {
 	maxContexts        int
 	maxSessions        int
 	noHealth           bool
+	verboseErrors      bool
 	actionErrorHandler func(*Ctx, error)
 	logger             Logger
 	notFoundHandler    http.Handler
@@ -285,6 +286,14 @@ func WithMaxSessions(n int) Option { return func(c *config) { c.maxSessions = n 
 // and /healthz report 200 while the process is up; /readyz reports 503 once
 // Shutdown begins draining. Opt out when the app needs to own those paths.
 func WithoutHealthEndpoints() Option { return func(c *config) { c.noHealth = true } }
+
+// WithVerboseErrors surfaces the real error message of a recovered action
+// panic to the browser instead of the generic "Something went wrong". The
+// typed error already reaches a custom WithActionErrorHandler and the server
+// log regardless; this only controls what the DEFAULT client notification
+// shows. Off by default — leaking raw panic text to clients is an
+// information-disclosure risk. Turn it on in development for faster feedback.
+func WithVerboseErrors() Option { return func(c *config) { c.verboseErrors = true } }
 
 // WithActionErrorHandler replaces the default browser-alert with a custom
 // callback for action errors and panics. The error from a panic is wrapped

--- a/panic_verbose_test.go
+++ b/panic_verbose_test.go
@@ -1,0 +1,55 @@
+package via_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-via/via"
+	"github.com/go-via/via/h"
+	"github.com/go-via/via/on"
+	"github.com/go-via/via/vt"
+	"github.com/stretchr/testify/assert"
+)
+
+type boomPage struct{}
+
+func (p *boomPage) Boom(ctx *via.Ctx)      { panic(errors.New("boom-detail-42")) }
+func (p *boomPage) View(ctx *via.CtxR) h.H { return h.Div(on.Click(p.Boom)) }
+
+// By default a recovered action panic must surface only a generic message to
+// the browser — leaking the raw panic text (paths, query fragments, internal
+// detail) to every client is an information-disclosure risk.
+func TestActionPanic_defaultHidesRawMessageFromClient(t *testing.T) {
+	t.Parallel()
+
+	app := via.New()
+	server := vt.Serve(t, app)
+	via.Mount[boomPage](app, "/")
+
+	c := vt.NewClient(t, server, "/")
+	frames, cancel := c.SSEReady()
+	defer cancel()
+
+	c.Action("Boom").Fire()
+	body := vt.AwaitFrame(t, frames, 2*time.Second, "Something went wrong")
+	assert.NotContains(t, body, "boom-detail-42",
+		"the raw panic message must not reach the client by default")
+}
+
+// In development, surfacing the real panic message to the browser is the
+// fast-feedback the generic message destroys. WithVerboseErrors opts into it.
+func TestActionPanic_verboseErrorsSurfacesRealMessage(t *testing.T) {
+	t.Parallel()
+
+	app := via.New(via.WithVerboseErrors())
+	server := vt.Serve(t, app)
+	via.Mount[boomPage](app, "/")
+
+	c := vt.NewClient(t, server, "/")
+	frames, cancel := c.SSEReady()
+	defer cancel()
+
+	c.Action("Boom").Fire()
+	vt.AwaitFrame(t, frames, 2*time.Second, "boom-detail-42")
+}


### PR DESCRIPTION
Critic panel finding #6 (major; raised 3×) — scope corrected after reading the code.

The fix the critic described ("type-assert the recovered panic value") is **already present**: `action.go:227-230` preserves `panic(err)` as a typed error for a custom `WithActionErrorHandler`, and the real message is logged server-side (`:224`). The only remaining gap is the **default client surface**, which masks panics as generic "Something went wrong" — correct for prod (no info disclosure), needlessly opaque in dev.

## Change
`WithVerboseErrors()`: opt the default client notification into showing the real panic error message. Off by default.

## Tests
- default: raw panic message (`boom-detail-42`) does NOT reach the client; "Something went wrong" does
- WithVerboseErrors: the real message reaches the client over SSE

Full `ci-check.sh` green.