### PR TITLE
feat: WithStrictDecode to reject lossy client signal decodes

### DIFF
--- a/action.go
+++ b/action.go
@@ -232,7 +232,12 @@ func runAction(a *App, ctx *Ctx, slotIdx int, slot *actionSlot,
 	}()
 
 	ctx.lastSignals = sigs
-	injectSignals(ctx, sigs)
+	if err := injectSignals(ctx, sigs); err != nil {
+		// Strict decode rejected a client value — surface the error and skip
+		// the handler so corrupt input never reaches it.
+		a.dispatchActionError(ctx, err, false)
+		return
+	}
 	if form != nil {
 		bindFiles(ctx, form)
 		defer clearFiles(ctx)
@@ -258,14 +263,21 @@ func (a *App) dispatchActionError(ctx *Ctx, err error, fromPanic bool) {
 
 // injectSignals applies signals from a request body into the bound *C's
 // Signal[T] fields by wire key.
-func injectSignals(ctx *Ctx, sigs map[string]any) {
+func injectSignals(ctx *Ctx, sigs map[string]any) error {
+	strict := ctx.app != nil && ctx.app.cfg.strictDecode
 	for slot, ref := range ctx.signalRefs {
 		s := ctx.desc.signalSlots[slot]
 		if s.kind != kindSignal {
 			continue
 		}
 		if v, ok := sigs[s.wireKey]; ok {
-			ref.decodeRaw(v)
+			// decodeRaw still applies a best-effort value; the returned error is
+			// surfaced only under WithStrictDecode, where a lossy decode must
+			// reject the action rather than act on corrupt input.
+			if err := ref.decodeRaw(v); err != nil && strict {
+				return fmt.Errorf("via: signal %q: %w", s.wireKey, err)
+			}
 		}
 	}
+	return nil
 }

--- a/config.go
+++ b/config.go
@@ -46,6 +46,7 @@ type config struct {
 	maxSessions        int
 	noHealth           bool
 	verboseErrors      bool
+	strictDecode       bool
 	actionErrorHandler func(*Ctx, error)
 	logger             Logger
 	notFoundHandler    http.Handler
@@ -294,6 +295,15 @@ func WithoutHealthEndpoints() Option { return func(c *config) { c.noHealth = tru
 // shows. Off by default — leaking raw panic text to clients is an
 // information-disclosure risk. Turn it on in development for faster feedback.
 func WithVerboseErrors() Option { return func(c *config) { c.verboseErrors = true } }
+
+// WithStrictDecode rejects a client signal value that cannot be represented in
+// its Signal[T] type — a number that overflows the target int/uint/float width,
+// or a value whose JSON shape doesn't match the field — instead of silently
+// truncating it (the best-effort default). The offending action surfaces an
+// error and its handler does not run, so corrupt input can't reach server
+// state. Off by default; turn it on when client input is untrusted and a lossy
+// decode must fail loud rather than silently clamp.
+func WithStrictDecode() Option { return func(c *config) { c.strictDecode = true } }
 
 // WithActionErrorHandler replaces the default browser-alert with a custom
 // callback for action errors and panics. The error from a panic is wrapped

--- a/encoding.go
+++ b/encoding.go
@@ -2,6 +2,8 @@ package via
 
 import (
 	"encoding/json"
+	"fmt"
+	"math"
 	"reflect"
 	"strconv"
 )
@@ -60,14 +62,28 @@ func encodeScalar(v reflect.Value) ([]byte, error) {
 // you accept from the client; validate explicitly inside the action
 // handler if untrusted input might overflow.
 func decodeScalarInto(dst reflect.Value, raw any) {
+	// Best-effort: discard the shape/overflow error so server-side and
+	// non-strict client decodes keep their lenient contract. WithStrictDecode
+	// uses decodeScalarChecked directly to surface it.
+	_ = decodeScalarChecked(dst, raw)
+}
+
+// decodeScalarChecked is decodeScalarInto with reporting: it performs the same
+// best-effort Set (so a discarded error leaves behavior identical) but returns
+// a non-nil error when raw's JSON shape doesn't match dst's kind or a numeric
+// value overflows dst's width. The error never names the field — the caller
+// (injectSignals) wraps it with the wire key.
+func decodeScalarChecked(dst reflect.Value, raw any) error {
 	if raw == nil {
-		return
+		return nil
 	}
 	switch dst.Kind() {
 	case reflect.String:
-		if s, ok := raw.(string); ok {
-			dst.SetString(s)
+		s, ok := raw.(string)
+		if !ok {
+			return fmt.Errorf("expected string, got %T", raw)
 		}
+		dst.SetString(s)
 	case reflect.Bool:
 		switch v := raw.(type) {
 		case bool:
@@ -75,43 +91,88 @@ func decodeScalarInto(dst reflect.Value, raw any) {
 		case string:
 			// `via:"open,init=true"` arrives as a string from the struct
 			// tag; ParseBool covers "true"/"false"/"1"/"0" and friends.
-			if b, err := strconv.ParseBool(v); err == nil {
-				dst.SetBool(b)
+			b, err := strconv.ParseBool(v)
+			if err != nil {
+				return fmt.Errorf("cannot parse %q as bool", v)
 			}
+			dst.SetBool(b)
+		default:
+			return fmt.Errorf("expected bool, got %T", raw)
 		}
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		var val int64
 		switch n := raw.(type) {
 		case float64:
-			dst.SetInt(int64(n))
+			if n != math.Trunc(n) {
+				return fmt.Errorf("value %v is not an integer", n)
+			}
+			val = int64(n)
 		case int64:
-			dst.SetInt(n)
+			val = n
 		case int:
-			dst.SetInt(int64(n))
+			val = int64(n)
 		case string:
-			if i, err := strconv.ParseInt(n, 10, 64); err == nil {
-				dst.SetInt(i)
+			i, err := strconv.ParseInt(n, 10, 64)
+			if err != nil {
+				return fmt.Errorf("cannot parse %q as integer", n)
 			}
+			val = i
+		default:
+			return fmt.Errorf("expected integer, got %T", raw)
 		}
+		if dst.OverflowInt(val) {
+			dst.SetInt(val) // truncates — preserves best-effort for non-strict
+			return fmt.Errorf("value %d overflows %s", val, dst.Kind())
+		}
+		dst.SetInt(val)
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		var val uint64
 		switch n := raw.(type) {
 		case float64:
-			dst.SetUint(uint64(n))
+			if n != math.Trunc(n) {
+				return fmt.Errorf("value %v is not an integer", n)
+			}
+			if n < 0 {
+				dst.SetUint(uint64(int64(n)))
+				return fmt.Errorf("value %v overflows unsigned %s", n, dst.Kind())
+			}
+			val = uint64(n)
 		case uint64:
-			dst.SetUint(n)
+			val = n
 		case string:
-			if i, err := strconv.ParseUint(n, 10, 64); err == nil {
-				dst.SetUint(i)
+			i, err := strconv.ParseUint(n, 10, 64)
+			if err != nil {
+				return fmt.Errorf("cannot parse %q as unsigned integer", n)
 			}
+			val = i
+		default:
+			return fmt.Errorf("expected unsigned integer, got %T", raw)
 		}
+		if dst.OverflowUint(val) {
+			dst.SetUint(val)
+			return fmt.Errorf("value %d overflows %s", val, dst.Kind())
+		}
+		dst.SetUint(val)
 	case reflect.Float32, reflect.Float64:
+		var f float64
 		switch n := raw.(type) {
 		case float64:
-			dst.SetFloat(n)
+			f = n
 		case string:
-			if f, err := strconv.ParseFloat(n, 64); err == nil {
-				dst.SetFloat(f)
+			x, err := strconv.ParseFloat(n, 64)
+			if err != nil {
+				return fmt.Errorf("cannot parse %q as number", n)
 			}
+			f = x
+		default:
+			return fmt.Errorf("expected number, got %T", raw)
 		}
+		if dst.OverflowFloat(f) {
+			dst.SetFloat(f)
+			return fmt.Errorf("value %v overflows %s", f, dst.Kind())
+		}
+		dst.SetFloat(f)
+		return nil
 	case reflect.Slice, reflect.Map, reflect.Struct, reflect.Array:
 		// Composite signals (SignalSlice/SignalMap) mirror the encodeScalar
 		// json fallback: round-trip the already-decoded value back through
@@ -125,9 +186,14 @@ func decodeScalarInto(dst reflect.Value, raw any) {
 		// json.Unmarshal into a non-nil map keeps pre-existing keys, so a
 		// client that removed a SignalMap key would otherwise leave the stale
 		// key alive server-side — diverging from the scalar replace contract.
-		if b, err := json.Marshal(raw); err == nil {
-			dst.Set(reflect.Zero(dst.Type()))
-			_ = json.Unmarshal(b, dst.Addr().Interface())
+		b, err := json.Marshal(raw)
+		if err != nil {
+			return fmt.Errorf("cannot marshal value: %v", err)
+		}
+		dst.Set(reflect.Zero(dst.Type()))
+		if err := json.Unmarshal(b, dst.Addr().Interface()); err != nil {
+			return fmt.Errorf("cannot decode into %s: %v", dst.Type(), err)
 		}
 	}
+	return nil
 }

--- a/runtime.go
+++ b/runtime.go
@@ -192,7 +192,9 @@ func bindSlots(ctx *Ctx, cmpVal reflect.Value, d *cmpDescriptor) {
 		ref.bindSlot(uint16(i), s.wireKey)
 		ctx.signalRefs[i] = ref
 		if s.initRaw != "" {
-			ref.decodeRaw(s.initRaw)
+			// Author-supplied `init=` tag value: best-effort, never strict —
+			// a struct-tag default isn't untrusted client input.
+			_ = ref.decodeRaw(s.initRaw)
 		}
 	}
 }

--- a/signal.go
+++ b/signal.go
@@ -149,7 +149,7 @@ func (s *Signal[T]) Key() string { return s.key }
 type signalRef interface {
 	bindSlot(slot uint16, key string)
 	encode() ([]byte, error)
-	decodeRaw(raw any)
+	decodeRaw(raw any) error
 }
 
 // signalMarker tags Signal[T] (and types that embed it). Used by the
@@ -171,6 +171,6 @@ func (s *Signal[T]) encode() ([]byte, error) {
 	return encodeScalar(reflect.ValueOf(s.val))
 }
 
-func (s *Signal[T]) decodeRaw(raw any) {
-	decodeScalarInto(reflect.ValueOf(&s.val).Elem(), raw)
+func (s *Signal[T]) decodeRaw(raw any) error {
+	return decodeScalarChecked(reflect.ValueOf(&s.val).Elem(), raw)
 }

--- a/state.go
+++ b/state.go
@@ -107,8 +107,8 @@ func (s *StateTab[T]) encode() ([]byte, error) {
 	return encodeScalar(reflect.ValueOf(s.val))
 }
 
-func (s *StateTab[T]) decodeRaw(raw any) {
-	decodeScalarInto(reflect.ValueOf(&s.val).Elem(), raw)
+func (s *StateTab[T]) decodeRaw(raw any) error {
+	return decodeScalarChecked(reflect.ValueOf(&s.val).Elem(), raw)
 }
 
 // stateTabMarker tags StateTab[T] (and types that embed it). See

--- a/strict_decode_test.go
+++ b/strict_decode_test.go
@@ -1,0 +1,69 @@
+package via_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-via/via"
+	"github.com/go-via/via/h"
+	"github.com/go-via/via/on"
+	"github.com/go-via/via/vt"
+	"github.com/stretchr/testify/assert"
+)
+
+type strictPage struct {
+	N via.Signal[int8]
+}
+
+func (p *strictPage) Noop(ctx *via.Ctx)      {}
+func (p *strictPage) View(ctx *via.CtxR) h.H { return h.Div(on.Click(p.Noop)) }
+
+// By default decode is best-effort: a client value that overflows the signal's
+// narrower type is silently truncated and the action still runs. This is the
+// documented contract — the strict mode below is the opt-in that rejects it.
+func TestStrictDecode_offTruncatesSilently(t *testing.T) {
+	t.Parallel()
+
+	app := via.New()
+	server := vt.Serve(t, app)
+	via.Mount[strictPage](app, "/")
+
+	c := vt.NewClient(t, server, "/")
+	// 9999 does not fit int8; without strict decode the action must still run.
+	assert.Equal(t, 200, c.Action("Noop").WithSignal("n", 9999).Fire(),
+		"best-effort decode must not reject an overflowing value")
+}
+
+// WithStrictDecode turns a client value that overflows (or shape-mismatches)
+// the signal's type into a surfaced action error instead of a silent truncation
+// that corrupts server state — the typed Signal is only as safe as the decode.
+func TestStrictDecode_onRejectsOverflow(t *testing.T) {
+	t.Parallel()
+
+	app := via.New(via.WithStrictDecode())
+	server := vt.Serve(t, app)
+	via.Mount[strictPage](app, "/")
+
+	c := vt.NewClient(t, server, "/")
+	frames, cancel := c.SSEReady()
+	defer cancel()
+
+	c.Action("Noop").WithSignal("n", 9999).Fire()
+	body := vt.AwaitFrame(t, frames, 2*time.Second, "overflow")
+	assert.Contains(t, body, "n",
+		"the strict-decode error must name the offending signal")
+}
+
+// A value that fits must pass cleanly under strict decode — strictness rejects
+// only genuinely lossy input, never valid input.
+func TestStrictDecode_onAcceptsInRangeValue(t *testing.T) {
+	t.Parallel()
+
+	app := via.New(via.WithStrictDecode())
+	server := vt.Serve(t, app)
+	via.Mount[strictPage](app, "/")
+
+	c := vt.NewClient(t, server, "/")
+	assert.Equal(t, 200, c.Action("Noop").WithSignal("n", 42).Fire(),
+		"an in-range value must decode without error under strict mode")
+}


### PR DESCRIPTION
Critic panel finding #4 (major; raised 3×). A client value overflowing a `Signal[T]`'s narrower numeric type (e.g. `9999` into `Signal[int8]`) was silently truncated; a shape mismatch silently dropped. The typed Signal was only as safe as a best-effort decode.

## Change
`WithStrictDecode()`: a client value that overflows the target int/uint/float width, or whose JSON shape doesn't match the field, surfaces an action error and the handler does **not** run — corrupt input can't reach server state.

Decode is factored into `decodeScalarChecked` (reports the error); `decodeScalarInto` wraps + discards it so server-side store decodes (StateSess/StateTab from the backplane) keep the lenient contract. The struct-tag `init=` path stays best-effort (author input, not untrusted client). Off by default.

## Tests
- off: overflowing value (9999→int8) still runs the action (best-effort)
- on: overflow surfaces an error naming the signal (over SSE)
- on: in-range value (42) decodes cleanly

Full `ci-check.sh` green.