### PR TITLE
feat: via.tab.unknown metric to detect non-sticky routing

### DIFF
--- a/action.go
+++ b/action.go
@@ -120,6 +120,13 @@ func (a *App) handleAction(w http.ResponseWriter, r *http.Request) {
 
 	ctx, ok := a.getCtx(tabID)
 	if !ok {
+		// A well-formed tab id this pod doesn't hold is the symptom of a
+		// request routed to the wrong pod (no sticky sessions) — surface it so
+		// a non-sticky LB shows up as a metric, not just mute 404s. An empty id
+		// is a malformed probe and doesn't count.
+		if tabID != "" {
+			a.metricsOrNoop().Counter("via.tab.unknown", "kind", "action")
+		}
 		http.NotFound(w, r)
 		return
 	}

--- a/docs/production.md
+++ b/docs/production.md
@@ -91,6 +91,8 @@ and emits structured events for ops dashboards:
 | `via.sse.recover` | counter | `mode` |
 | `via.ctx.live` | gauge | |
 | `via.ctx.reap` | counter | `reason` |
+| `via.session.mismatch` | counter | |
+| `via.tab.unknown` | counter | `kind` |
 
 State backplane (`StateAppEvents`, the clustered event-log path):
 

--- a/sse.go
+++ b/sse.go
@@ -38,6 +38,12 @@ func (a *App) handleSSE(w http.ResponseWriter, r *http.Request) {
 
 	ctx, ok := a.getCtx(tabID)
 	if !ok {
+		// A well-formed tab id this pod doesn't hold also signals wrong-pod
+		// routing (no sticky sessions), not only a TTL sweep / restart — count
+		// it so a non-sticky LB is observable. Empty id = malformed probe.
+		if tabID != "" {
+			a.metricsOrNoop().Counter("via.tab.unknown", "kind", "sse")
+		}
 		// Stale-but-plausible tab id (TTL sweep, process restart):
 		// re-bootstrap a fresh Ctx over this same stream instead of
 		// 404ing into Datastar's infinite retry (a frozen tab).

--- a/sticky_detect_test.go
+++ b/sticky_detect_test.go
@@ -1,0 +1,59 @@
+package via_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/go-via/via"
+	"github.com/go-via/via/vt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// StateTab/Ctx live in this pod's memory, so an action routed to a pod that
+// doesn't hold the tab's Ctx 404s — the silent failure of running without
+// sticky sessions. A well-formed via_tab this pod never registered is that
+// exact symptom, and it must emit a metric so operators can detect non-sticky
+// load-balancer routing instead of staring at mysterious 404s.
+func TestStickyDetect_unknownTabEmitsMetric(t *testing.T) {
+	t.Parallel()
+
+	m := &captureMetrics{}
+	app := via.New(via.WithMetrics(m))
+	server := vt.Serve(t, app)
+	via.Mount[metricsPage](app, "/")
+
+	body := strings.NewReader(`{"via_tab":"0123456789abcdef0123456789abcdef"}`)
+	resp, err := server.Client().Post(server.URL+"/_action/Bump", "application/json", body)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusNotFound, resp.StatusCode,
+		"an action for a tab this pod doesn't hold must 404")
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	assert.Contains(t, m.counters, "via.tab.unknown:kind,action",
+		"an action for an unknown but well-formed tab must emit via.tab.unknown")
+}
+
+// A request with no via_tab at all is a malformed probe, not a routing
+// symptom — it must NOT inflate the sticky-routing signal.
+func TestStickyDetect_missingTabDoesNotEmitMetric(t *testing.T) {
+	t.Parallel()
+
+	m := &captureMetrics{}
+	app := via.New(via.WithMetrics(m))
+	server := vt.Serve(t, app)
+	via.Mount[metricsPage](app, "/")
+
+	body := strings.NewReader(`{}`)
+	resp, err := server.Client().Post(server.URL+"/_action/Bump", "application/json", body)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	assert.NotContains(t, m.counters, "via.tab.unknown:kind,action",
+		"a request with no via_tab must not be counted as a wrong-pod routing event")
+}


### PR DESCRIPTION
Critic panel finding #3 (major; raised 4×). Sticky sessions are mandatory for correctness (Ctx/StateTab are pod-local), but a non-sticky LB just produced mysterious 404s with no signal to alert on.

## Change
Emit `via.tab.unknown` (label `kind=action|sse`) when a well-formed `via_tab` this pod never registered arrives — the exact symptom of a request routed to the wrong pod. Under sticky routing it tracks only normal TTL churn; under round-robin it scales with traffic. Empty/malformed tab ids (probes) aren't counted. Added to the metrics catalogue (with `via.session.mismatch`, the cookie-clobber signal).

## Tests
- unknown well-formed tab → 404 + `via.tab.unknown:kind,action`
- missing tab → not counted

Full `ci-check.sh` green.