### PR TITLE
feat: WithDevChecks catches by-value child-composition clobber

### DIFF
--- a/config.go
+++ b/config.go
@@ -46,6 +46,7 @@ type config struct {
 	maxSessions        int
 	noHealth           bool
 	verboseErrors      bool
+	devChecks          bool
 	strictDecode       bool
 	actionErrorHandler func(*Ctx, error)
 	logger             Logger
@@ -295,6 +296,14 @@ func WithoutHealthEndpoints() Option { return func(c *config) { c.noHealth = tru
 // shows. Off by default — leaking raw panic text to clients is an
 // information-disclosure risk. Turn it on in development for faster feedback.
 func WithVerboseErrors() Option { return func(c *config) { c.verboseErrors = true } }
+
+// WithDevChecks enables development-only runtime assertions that cost a little
+// per render and so are off in production. Currently it re-walks a page's bound
+// state handles after OnInit and fails the render if one was orphaned by
+// replacing a child composition by value (p.Child = T{...}), which silently
+// zeroes the runtime's by-address binding — the page would otherwise render
+// once and then go dead. Run it in dev/CI to catch the footgun early.
+func WithDevChecks() Option { return func(c *config) { c.devChecks = true } }
 
 // WithStrictDecode rejects a client signal value that cannot be represented in
 // its Signal[T] type — a number that overflows the target int/uint/float width,

--- a/dead_bind_test.go
+++ b/dead_bind_test.go
@@ -1,0 +1,82 @@
+package via_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/go-via/via"
+	"github.com/go-via/via/h"
+	"github.com/go-via/via/vt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type ddChild struct {
+	Count via.Signal[int]
+}
+
+func (c *ddChild) View(ctx *via.CtxR) h.H { return h.Div() }
+
+// ddClobberPage reproduces the silent dead-bind footgun: OnInit replaces the
+// child composition by value, which zeroes the runtime's by-address handle
+// binding — the page renders once but client bindings go dead afterward.
+type ddClobberPage struct {
+	Child ddChild
+}
+
+func (p *ddClobberPage) OnInit(ctx *via.Ctx) error { p.Child = ddChild{}; return nil }
+func (p *ddClobberPage) View(ctx *via.CtxR) h.H    { return h.Div() }
+
+// ddGoodPage seeds nothing by value — its bindings stay intact.
+type ddGoodPage struct {
+	Child ddChild
+}
+
+func (p *ddGoodPage) View(ctx *via.CtxR) h.H { return h.Div() }
+
+// With WithDevChecks a by-value child clobber must be caught loudly at render
+// instead of silently producing dead client bindings that fail only later.
+func TestDeadBind_devChecksCatchByValueClobber(t *testing.T) {
+	t.Parallel()
+
+	app := via.New(via.WithDevChecks())
+	server := vt.Serve(t, app)
+	via.Mount[ddClobberPage](app, "/")
+
+	resp, err := server.Client().Get(server.URL + "/")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode,
+		"a by-value child clobber under dev checks must fail the render loudly")
+}
+
+// Without the dev flag, production pays nothing — the (buggy) page still
+// renders, matching today's behavior.
+func TestDeadBind_offByDefault(t *testing.T) {
+	t.Parallel()
+
+	app := via.New()
+	server := vt.Serve(t, app)
+	via.Mount[ddClobberPage](app, "/")
+
+	resp, err := server.Client().Get(server.URL + "/")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"without WithDevChecks the render is unaffected (prod pays nothing)")
+}
+
+// Dev checks must not false-positive on a correctly-bound composition.
+func TestDeadBind_devChecksPassIntactBindings(t *testing.T) {
+	t.Parallel()
+
+	app := via.New(via.WithDevChecks())
+	server := vt.Serve(t, app)
+	via.Mount[ddGoodPage](app, "/")
+
+	resp, err := server.Client().Get(server.URL + "/")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"an intact composition must render cleanly under dev checks")
+}

--- a/render.go
+++ b/render.go
@@ -64,6 +64,14 @@ func (a *App) renderPage(d *cmpDescriptor, w http.ResponseWriter, r *http.Reques
 		}()
 	}
 
+	if a.cfg.devChecks {
+		if err := validateBindings(ctx, cmpVal, d); err != nil {
+			a.logErr(ctx, "%v", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
 	body, ok := a.renderView(ctx, w)
 	if !ok {
 		return

--- a/runtime.go
+++ b/runtime.go
@@ -2,6 +2,7 @@ package via
 
 import (
 	"bytes"
+	"fmt"
 	"reflect"
 	"strings"
 	"sync"
@@ -197,6 +198,34 @@ func bindSlots(ctx *Ctx, cmpVal reflect.Value, d *cmpDescriptor) {
 			_ = ref.decodeRaw(s.initRaw)
 		}
 	}
+}
+
+// validateBindings re-walks the bound signal handles after OnInit and returns
+// an error if any was orphaned — the dominant cause being a by-value child
+// reassignment in OnInit (p.Child = Card{...}), which overwrites the field with
+// an unbound copy whose wire key is empty while the runtime still references the
+// orphaned memory. bindSlot set each live handle's key to its wire key; a
+// post-OnInit key that no longer matches proves the binding was lost. Dev-only
+// (WithDevChecks) because it costs a reflective re-walk per render.
+func validateBindings(ctx *Ctx, cmpVal reflect.Value, d *cmpDescriptor) error {
+	elem := cmpVal.Elem()
+	for _, s := range d.signalSlots {
+		live := fieldByPath(elem, s.fieldPath).Addr().Interface()
+		// A future signalRef impl without Key() can't be verified — skip it
+		// rather than misreport, so the check never false-panics.
+		keyer, ok := live.(interface{ Key() string })
+		if !ok {
+			continue
+		}
+		if keyer.Key() != s.wireKey {
+			return fmt.Errorf("via: state binding for %q (field path %v) was lost — "+
+				"a child composition was replaced by value in OnInit "+
+				"(p.Child = T{...}), which zeroes the runtime's by-address handle "+
+				"binding. Seed state in place instead (e.g. p.Child.Field.Write(ctx, v)); "+
+				"never reassign a child struct by value", s.wireKey, s.fieldPath)
+		}
+	}
+	return nil
 }
 
 // bindScopeKeys writes the wire key into every StateSess[T] / StateApp[T]


### PR DESCRIPTION
Critic panel finding #9 (major→minor; raised 3×). Replacing a child composition by value in OnInit (`p.Child = Card{...}`) silently zeroes the runtime's by-address handle binding — the page renders once, then client bindings go dead and updates mis-route. Invisible because the first paint looks correct.

## Change
`WithDevChecks()`: after OnInit, re-walk the bound state handles and fail the render with a clear diagnostic (wire key + field path) if any was orphaned — detected because the live handle's wire key no longer matches what `bindSlot` set (a by-value clobber leaves an unbound copy with an empty key at the same address). Intact handles pass, so no false positives. A future `signalRef` without `Key()` is skipped, not mis-flagged. Dev-only — production pays nothing.

## Tests
- clobber under WithDevChecks → 500 (loud)
- off by default → renders (prod unaffected)
- intact composition under WithDevChecks → 200 (no false positive)

Full `ci-check.sh` green.