### PR TITLE
feat(onevent): bounded-retry + opt-in poison-record skip

### DIFF
--- a/docs/distributed-state.md
+++ b/docs/distributed-state.md
@@ -157,8 +157,45 @@ p.Orders.OnEvent("ship", func(ctx context.Context, ev orderPlaced, off via.Offse
 - Delivery is **at-least-once**; the committed offset is persisted, so a restart
   resumes instead of replaying from genesis. Derive an idempotency key from the
   offset.
-- A handler that returns an error is retried **head-of-line** — the consumer does
-  not advance past a failing event (surfaced as `via.consumer.error`).
+- A handler that returns an error is retried **head-of-line** with exponential
+  backoff + jitter — the consumer does not advance past a failing event
+  (surfaced as `via.consumer.error`). **By default it retries forever**: a
+  permanently-failing handler never drops the side effect, but it pins the
+  Compactor floor (so the log grows). The block is loud, not silent — each
+  retry emits a `via.consumer.stuck` gauge (the attempt count) and a `WARN`
+  fires once the attempts cross a threshold.
+
+A poison record (a handler that can never succeed) can wedge the consumer and
+pin the floor forever. Opt into skipping it with consumer options:
+
+```go
+p.Orders.OnEvent("ship",
+    func(ctx context.Context, ev orderPlaced, off via.Offset) error {
+        return shipper.Send(ctx, ev.OrderID)
+    },
+    via.WithMaxAttempts(10),                    // skip the record after 10 failed attempts
+    via.WithRetryBackoff(50*time.Millisecond, time.Minute), // backoff bounds (default 10ms → 30s)
+    via.WithDeadLetter(func(ctx context.Context, key string, off via.Offset, data []byte, cause error) error {
+        return dlq.Publish(ctx, key, off, data, cause) // archive the record before skipping
+    }),
+)
+```
+
+- `WithMaxAttempts(n)` — after `n` consecutive handler errors on the same record
+  the consumer treats it as **poison**: it emits `via.consumer.poisoned` and
+  advances past the record, un-wedging the consumer and unpinning the floor. The
+  **default is `0` = block forever** (above); skipping is strictly opt-in, so
+  dropping a side effect is never the default.
+- `WithRetryBackoff(base, max)` — exponential-backoff bounds (with jitter) between
+  head-of-line retries. Defaults `10ms → 30s`.
+- `WithDeadLetter(fn)` — invoked just before a record is poisoned. If it returns
+  `nil` the consumer advances past the record; if it returns an error the consumer
+  does **not** advance and keeps retrying, so a record you opted to dead-letter is
+  never silently lost while the sink is unavailable.
+- A **forward-incompatible** record (written by a newer binary) always blocks and
+  is **never** poisoned, regardless of `WithMaxAttempts` — it is a rollback guard,
+  not a bad record. An **undecodable** record is skipped via the decode path
+  (`via.consumer.undecodable`), distinct from the poison path.
 
 ## Snapshots, compaction, cold start
 

--- a/docs/production.md
+++ b/docs/production.md
@@ -107,7 +107,9 @@ State backplane (`StateAppEvents`, the clustered event-log path):
 | `via.fold.divergence` | counter | `key` | `WithFoldVerify` caught a non-deterministic fold; the key will not compact |
 | `via.snapshot.unbridgeable` | counter | `key` | compacted-key snapshot can't be migrated to the current codec; projector HALTS |
 | `via.snapshot.erasure_halt` | counter | `key` | a crypto-shred erasure invalidated a compacted (durable-genesis) snapshot; projector HALTS |
-| `via.consumer.error` | counter | `name`, `key` | `OnEvent` handler returned an error; retried head-of-line (does not advance) |
+| `via.consumer.error` | counter | `name`, `key` | `OnEvent` handler returned an error; retried head-of-line with exponential backoff + jitter (does not advance). By default retries forever; `WithMaxAttempts(n>0)` opts the record into being skipped (poisoned) after `n` attempts |
+| `via.consumer.stuck` | gauge | `name`, `key` | per-pod retry attempt count for the head-of-line record an `OnEvent` handler keeps failing; nonzero means the consumer is blocked and pinning the Compactor floor (loud even when blocking forever) |
+| `via.consumer.poisoned` | counter | `name`, `key` | `OnEvent` skipped (dead-lettered or dropped) a record whose handler failed `WithMaxAttempts` times; only fires when skipping is opted into |
 | `via.consumer.undecodable` | counter | `name`, `key` | `OnEvent` skipped a poison record |
 | `via.consumer.forward_incompatible` | counter | `name`, `key` | `OnEvent` blocked on a newer-binary record |
 | `via.consumer.erased` | counter | `name`, `key` | `OnEvent` skipped a crypto-shredded record |

--- a/onevent.go
+++ b/onevent.go
@@ -4,14 +4,94 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"math/rand"
 	"sync"
 	"time"
 )
 
-// consumerRetryBackoff paces a side-effect consumer's re-subscribe after a
-// handler error, so a persistently-failing handler retries (head-of-line)
-// without hot-spinning.
-const consumerRetryBackoff = 10 * time.Millisecond
+// Default retry backoff bounds for a side-effect consumer's re-subscribe after a
+// handler error: exponential from base to max, with jitter, so a persistently-
+// failing handler retries (head-of-line) without hot-spinning.
+const (
+	defaultRetryBackoffBase = 10 * time.Millisecond
+	defaultRetryBackoffMax  = 30 * time.Second
+)
+
+// stuckWarnThreshold is the per-pod attempt count at which a blocking
+// (still-retrying) consumer emits a one-shot WARN, so a floor-pin from a
+// permanently-failing handler is observable rather than silent.
+const stuckWarnThreshold = 8
+
+// consumerConfig is the per-consumer policy assembled from ConsumerOption.
+type consumerConfig struct {
+	maxAttempts int // 0 = block forever (never skip a record); >0 = poison after N handler-error attempts
+	backoffBase time.Duration
+	backoffMax  time.Duration
+	deadLetter  func(ctx context.Context, key string, off Offset, data []byte, cause error) error
+}
+
+func defaultConsumerConfig() consumerConfig {
+	return consumerConfig{
+		maxAttempts: 0,
+		backoffBase: defaultRetryBackoffBase,
+		backoffMax:  defaultRetryBackoffMax,
+	}
+}
+
+// ConsumerOption tunes a single OnEvent consumer's poison/retry policy.
+type ConsumerOption func(*consumerConfig)
+
+// WithMaxAttempts opts a consumer into skipping a poison record. After n
+// consecutive handler-error attempts on the same record the consumer treats it
+// as poison (dead-letters it if a hook is set, otherwise drops it) and advances
+// past it, un-wedging the consumer and unpinning the Compactor floor.
+//
+// The DEFAULT is 0 = block forever: a persistently-failing handler keeps the
+// record head-of-line and never drops the side effect (today's zero-data-loss
+// semantics). Skipping is strictly opt-in via n > 0. A forward-incompatible
+// record (a newer binary wrote it) is NEVER poisoned regardless of n — it always
+// blocks, since it is a rollback guard rather than a bad record.
+func WithMaxAttempts(n int) ConsumerOption {
+	return func(c *consumerConfig) { c.maxAttempts = n }
+}
+
+// WithRetryBackoff sets the exponential-backoff bounds (with jitter) the
+// consumer waits between head-of-line retries of a failing handler. Defaults are
+// 10ms → 30s.
+func WithRetryBackoff(base, max time.Duration) ConsumerOption {
+	return func(c *consumerConfig) {
+		if base > 0 {
+			c.backoffBase = base
+		}
+		if max > 0 {
+			c.backoffMax = max
+		}
+	}
+}
+
+// WithDeadLetter registers a hook invoked when a record is about to be poisoned
+// (only reachable with WithMaxAttempts(n>0)). It receives the wire key, offset,
+// raw record bytes, and the last handler error. If it returns nil the consumer
+// commits past the record; if it returns an error the consumer does NOT advance
+// and keeps retrying, so a record the operator opted to dead-letter is never
+// silently lost when the sink is unavailable.
+func WithDeadLetter(fn func(ctx context.Context, key string, off Offset, data []byte, cause error) error) ConsumerOption {
+	return func(c *consumerConfig) { c.deadLetter = fn }
+}
+
+// deliverOutcome is the result of attempting to deliver one record.
+type deliverOutcome int
+
+const (
+	// outcomeAdvance: the record was handled (or cleanly skipped) — commit + move on.
+	outcomeAdvance deliverOutcome = iota
+	// outcomeRetry: the handler returned an error — retry head-of-line. This is
+	// the only outcome eligible for poison/skip under WithMaxAttempts.
+	outcomeRetry
+	// outcomeBlock: the record is forward-incompatible (a newer binary wrote it).
+	// Block forever; NEVER count toward poison attempts — it is a rollback guard.
+	outcomeBlock
+)
 
 // consumerState is one (name,key) side-effect consumer's per-pod state: the
 // committed offset (durable in the Store cell consumerKey) and its CAS rev. The
@@ -22,12 +102,30 @@ type consumerState struct {
 
 	committed Offset // highest offset whose handler returned nil and was durably committed
 	cellRev   Rev    // CAS rev of the committed-offset Store cell
+
+	attempts    int  // per-pod consecutive handler-error attempts on the current head-of-line record
+	warnedStuck bool // whether the one-shot "stuck" WARN has fired for the current attempt run
 }
 
 func (cs *consumerState) snapshot() (Offset, Rev) {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
 	return cs.committed, cs.cellRev
+}
+
+// resetAttempts clears the per-pod retry counter after any advance.
+func (cs *consumerState) resetAttempts() {
+	cs.mu.Lock()
+	cs.attempts = 0
+	cs.warnedStuck = false
+	cs.mu.Unlock()
+}
+
+// attemptCount returns the current per-pod retry attempt count.
+func (cs *consumerState) attemptCount() int {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return cs.attempts
 }
 
 // consumerKey is the Store cell holding a named consumer's committed offset for
@@ -59,11 +157,17 @@ func consumerKey(name, wireKey string) string { return "consumer:" + name + ":" 
 // Error surface, by outcome:
 //   - handler returns nil      → commit + advance (effect ran exactly once on this pod)
 //   - handler returns an error → DO NOT advance; re-subscribe from committed and
-//     retry head-of-line (preserves order); via.consumer.error.
+//     retry head-of-line (preserves order) with exponential backoff + jitter;
+//     via.consumer.error each attempt; via.consumer.stuck gauge tracks the
+//     attempt count so a floor-pin is observable. With WithMaxAttempts(n>0) the
+//     record is treated as poison after n attempts (dead-lettered or dropped) and
+//     the consumer advances; the DEFAULT (maxAttempts 0) blocks forever, never
+//     dropping a side effect.
 //   - undecodable record       → skip + advance (drop-on-undecodable, like the
 //     fold); via.consumer.undecodable.
 //   - forward-incompatible      → BLOCK (do not advance), so a rolled-back deploy
-//     never silently skips an event it cannot yet understand; via.consumer.forward_incompatible.
+//     never silently skips an event it cannot yet understand;
+//     via.consumer.forward_incompatible. NEVER poisoned regardless of WithMaxAttempts.
 //
 // A registered consumer also pins the Compactor floor to its committed offset,
 // so compaction never discards an event it has not yet processed.
@@ -73,50 +177,55 @@ func consumerKey(name, wireKey string) string { return "consumer:" + name + ":" 
 // records from any pod, with no originating tab/session. Registration is
 // idempotent: the consumer starts once per (name,key) however many times OnEvent
 // is called. No-op before Mount (the handle isn't bound yet).
-func (l *StateAppEvents[E, V]) OnEvent(name string, fn func(ctx context.Context, ev E, off Offset) error) {
+func (l *StateAppEvents[E, V]) OnEvent(name string, fn func(ctx context.Context, ev E, off Offset) error, opts ...ConsumerOption) {
 	if l.app == nil {
 		return
 	}
 	app, key := l.app, l.wireKey
+	cfg := defaultConsumerConfig()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
 	// deliver decodes one record (same envelope path as the fold) and invokes the
-	// handler. The bool is whether the consumer may ADVANCE past this record: a
-	// clean handle or an undecodable (poison/forward-incompatible) record advances;
-	// a handler error does NOT (the record is retried).
-	deliver := func(ctx context.Context, data []byte, off Offset) bool {
+	// handler, reporting one of three outcomes: advance (clean handle or clean
+	// skip), retry (handler error — poison-eligible, carries the error), or block
+	// (forward-incompatible — never poison). When the handler errors it returns
+	// outcomeRetry plus the cause so the tailer can dead-letter/skip under policy.
+	deliver := func(ctx context.Context, data []byte, off Offset) (deliverOutcome, error) {
 		ev, err := decodeEvent[E](data, app.eventDecryptor())
 		if errors.Is(err, ErrForwardIncompatible) {
 			// A newer binary wrote this event. Roll-forward-only: do NOT advance —
-			// skipping would silently drop the side effect. Block here (the record
-			// is retried) until a rolled-forward binary can decode it, mirroring the
-			// projector's halt.
+			// skipping would silently drop the side effect. Block here until a
+			// rolled-forward binary can decode it, mirroring the projector's halt.
+			// NEVER poison: this is a rollback guard, not a bad record.
 			app.metricsOrNoop().Counter("via.consumer.forward_incompatible", "name", name, "key", key)
-			return false
+			return outcomeBlock, nil
 		}
 		if errors.Is(err, ErrErased) {
 			// The subject was erased (crypto-shred): the effect can never run on
 			// shredded data. Skip + advance (like a poison record) — do NOT block,
 			// or erasure would wedge the consumer forever.
 			app.metricsOrNoop().Counter("via.consumer.erased", "name", name, "key", key)
-			return true
+			return outcomeAdvance, nil
 		}
 		if err != nil {
 			// Poison / undecodable: this binary can never process it, so skip +
 			// advance rather than wedge the consumer forever.
 			app.metricsOrNoop().Counter("via.consumer.undecodable", "name", name, "key", key)
-			return true
+			return outcomeAdvance, nil
 		}
 		if err := fn(ctx, ev, off); err != nil {
 			app.metricsOrNoop().Counter("via.consumer.error", "name", name, "key", key)
-			return false // retry; do not advance
+			return outcomeRetry, err // poison-eligible; do not advance yet
 		}
-		return true
+		return outcomeAdvance, nil
 	}
-	app.registerConsumer(name, key, deliver)
+	app.registerConsumer(name, key, cfg, deliver)
 }
 
 // registerConsumer records the (name,key) consumer (cold-loading its committed
 // offset from the Store) and starts its tailer exactly once.
-func (a *App) registerConsumer(name, key string, deliver func(context.Context, []byte, Offset) bool) {
+func (a *App) registerConsumer(name, key string, cfg consumerConfig, deliver func(context.Context, []byte, Offset) (deliverOutcome, error)) {
 	ck := consumerKey(name, key)
 	a.consumersMu.Lock()
 	if a.consumers == nil {
@@ -138,14 +247,16 @@ func (a *App) registerConsumer(name, key string, deliver func(context.Context, [
 	}
 	a.consumersMu.Unlock()
 
-	cs.once.Do(func() { a.startConsumer(name, key, cs, deliver) })
+	cs.once.Do(func() { a.startConsumer(name, key, cs, cfg, deliver) })
 }
 
 // startConsumer tails the key from the committed offset, delivering each new
 // record to the handler and committing on success. On a handler error it
-// re-subscribes from the committed offset (head-of-line retry). It exits when
-// the backplane closes (Subscribe returns ErrClosed or the channel closes).
-func (a *App) startConsumer(name, key string, cs *consumerState, deliver func(context.Context, []byte, Offset) bool) {
+// re-subscribes from the committed offset (head-of-line retry) with exponential
+// backoff + jitter, optionally poisoning the record under WithMaxAttempts. It
+// exits when the backplane closes (Subscribe returns ErrClosed or the channel
+// closes).
+func (a *App) startConsumer(name, key string, cs *consumerState, cfg consumerConfig, deliver func(context.Context, []byte, Offset) (deliverOutcome, error)) {
 	go func() {
 		for {
 			from, _ := cs.snapshot()
@@ -156,15 +267,26 @@ func (a *App) startConsumer(name, key string, cs *consumerState, deliver func(co
 				return // backplane closed
 			}
 			retry := false
+		consume:
 			for rec := range ch {
 				if committed, _ := cs.snapshot(); rec.Offset <= committed {
 					continue // already handled (a peer advanced the shared offset)
 				}
-				if deliver(subCtx, rec.Data, rec.Offset) {
+				outcome, cause := deliver(subCtx, rec.Data, rec.Offset)
+				switch outcome {
+				case outcomeAdvance:
 					a.commitConsumer(cs, name, key, rec.Offset)
-				} else {
-					retry = true // handler error → re-subscribe from committed
-					break
+					cs.resetAttempts()
+				case outcomeBlock:
+					// Forward-incompatible: never poison, block forever.
+					retry = true
+					break consume
+				case outcomeRetry:
+					if a.handleRetry(cs, name, key, cfg, rec, cause) {
+						continue // poisoned (dead-lettered or dropped) → advanced past it
+					}
+					retry = true
+					break consume
 				}
 			}
 			cancel()
@@ -172,12 +294,76 @@ func (a *App) startConsumer(name, key string, cs *consumerState, deliver func(co
 				return // graceful stop: backplane closing, nothing pending
 			}
 			// Either a handler error (retry) OR a transient disconnect (channel
-			// closed while still running) → re-subscribe from the committed
-			// offset and rehydrate. At-least-once is preserved: a dropped
-			// subscription must never silently drop side effects.
-			time.Sleep(consumerRetryBackoff)
+			// closed while still running) → re-subscribe from the committed offset
+			// and rehydrate. At-least-once is preserved: a dropped subscription must
+			// never silently drop side effects.
+			a.sleepBackoff(cfg, cs.attemptCount())
 		}
 	}()
+}
+
+// handleRetry records one handler-error attempt and decides whether the record
+// is now poison (advance past it, returning true) or should keep blocking
+// (return false). It emits via.consumer.stuck each attempt and a one-shot WARN
+// once attempts cross the stuck threshold, so a floor-pin is loud even while
+// blocking.
+func (a *App) handleRetry(cs *consumerState, name, key string, cfg consumerConfig, rec Record, cause error) bool {
+	cs.mu.Lock()
+	cs.attempts++
+	attempts := cs.attempts
+	crossedThreshold := !cs.warnedStuck && attempts >= stuckWarnThreshold
+	if crossedThreshold {
+		cs.warnedStuck = true
+	}
+	cs.mu.Unlock()
+
+	a.metricsOrNoop().Gauge("via.consumer.stuck", float64(attempts), "name", name, "key", key)
+	if crossedThreshold {
+		a.logWarn(nil, "via: consumer %q key %q stuck on offset %d after %d attempts (floor pinned): %v",
+			name, key, rec.Offset, attempts, cause)
+	}
+
+	if cfg.maxAttempts <= 0 || attempts < cfg.maxAttempts {
+		return false // block forever (default) or not yet at the skip threshold
+	}
+
+	// Poison: maxAttempts reached on a handler error.
+	if cfg.deadLetter != nil {
+		if err := cfg.deadLetter(a.backplaneCtx, key, rec.Offset, rec.Data, cause); err != nil {
+			// The operator opted to dead-letter but the sink is unavailable: do NOT
+			// advance — keep retrying rather than silently lose the record.
+			return false
+		}
+	}
+	a.metricsOrNoop().Counter("via.consumer.poisoned", "name", name, "key", key)
+	a.logWarn(nil, "via: consumer %q key %q poisoned offset %d after %d attempts: %v",
+		name, key, rec.Offset, attempts, cause)
+	a.commitConsumer(cs, name, key, rec.Offset)
+	cs.resetAttempts()
+	return true
+}
+
+// sleepBackoff waits an exponentially-growing, jittered interval before the next
+// re-subscribe. attempts<=1 (a transient disconnect, or the first handler error)
+// uses the base delay.
+func (a *App) sleepBackoff(cfg consumerConfig, attempts int) {
+	d := cfg.backoffBase
+	for i := 1; i < attempts && d < cfg.backoffMax; i++ {
+		d *= 2
+	}
+	if d > cfg.backoffMax {
+		d = cfg.backoffMax
+	}
+	// Full jitter in [d/2, d]: spreads a thundering herd of pods retrying the same
+	// poison record without ever busy-waiting below half the computed delay.
+	if d > 0 {
+		half := d / 2
+		d = half + time.Duration(rand.Int63n(int64(half)+1))
+	}
+	select {
+	case <-time.After(d):
+	case <-a.backplaneCtx.Done():
+	}
 }
 
 // commitConsumer durably advances the consumer's committed offset via CAS. On a

--- a/onevent_internal_test.go
+++ b/onevent_internal_test.go
@@ -401,3 +401,367 @@ func TestCompactionAdvancesWhenConsumerKeepsUp(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond,
 		"a keeping-up consumer must not pin the compaction floor at genesis")
 }
+
+// gaugeSpyMetrics records both Counter names and Gauge names so a test can
+// assert the loud-by-default observability signals (counters + the
+// via.consumer.stuck gauge) without verifying call counts.
+type gaugeSpyMetrics struct {
+	mu       sync.Mutex
+	counters []string
+	gauges   []string
+}
+
+func (m *gaugeSpyMetrics) Counter(name string, _ ...string) {
+	m.mu.Lock()
+	m.counters = append(m.counters, name)
+	m.mu.Unlock()
+}
+func (m *gaugeSpyMetrics) Gauge(name string, _ float64, _ ...string) {
+	m.mu.Lock()
+	m.gauges = append(m.gauges, name)
+	m.mu.Unlock()
+}
+func (m *gaugeSpyMetrics) Histogram(string, float64, ...string) {}
+func (m *gaugeSpyMetrics) sawCounter(name string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, c := range m.counters {
+		if c == name {
+			return true
+		}
+	}
+	return false
+}
+func (m *gaugeSpyMetrics) sawGauge(name string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, g := range m.gauges {
+		if g == name {
+			return true
+		}
+	}
+	return false
+}
+
+// DEFAULT (maxAttempts 0): an always-erroring handler must block forever — the
+// committed offset never advances past the poison record, via.consumer.error
+// keeps firing, and via.consumer.stuck is emitted so the floor-pin is loud
+// rather than silent. Dropping a side effect by default is the wrong default.
+//
+//nolint:paralleltest // timing-sensitive consumer convergence; serialized to avoid load-induced flakes
+func TestOnEvent_blocksForeverByDefaultOnPersistentHandlerError(t *testing.T) {
+	spy := &gaugeSpyMetrics{}
+	app := New(WithMetrics(spy), WithLogLevel(LogError)) // suppress the intentional stuck WARN noise
+	server := httptest.NewServer(app)
+	t.Cleanup(server.Close)
+	defer server.Close()
+	defer app.backplane.Close()
+	ctx := context.Background()
+
+	var h StateAppEvents[envEv, []int]
+	h.bindWireKey("k")
+	h.bindApp(app)
+	h.OnEvent("rec", func(_ context.Context, _ envEv, _ Offset) error {
+		return fmt.Errorf("permanent failure")
+	}, WithRetryBackoff(time.Millisecond, 5*time.Millisecond))
+
+	_, err := app.backplane.Append(ctx, "k", goodEnv(t, envEv{N: 1}))
+	require.NoError(t, err)
+	_, err = app.backplane.Append(ctx, "k", goodEnv(t, envEv{N: 2}))
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool { return spy.sawGauge("via.consumer.stuck") },
+		2*time.Second, 10*time.Millisecond, "a blocking consumer emits the stuck gauge")
+	require.True(t, spy.sawCounter("via.consumer.error"), "each handler-error attempt emits via.consumer.error")
+
+	// Never advances past the head-of-line poison record (block-forever preserved).
+	require.Never(t, func() bool {
+		data, _, ok, _ := app.backplane.LoadSnapshot(ctx, consumerKey("rec", "k"))
+		if !ok {
+			return false
+		}
+		var off Offset
+		return json.Unmarshal(data, &off) == nil && off >= 1
+	}, 400*time.Millisecond, 50*time.Millisecond,
+		"the default consumer never commits past a record its handler keeps failing")
+	require.False(t, spy.sawCounter("via.consumer.poisoned"),
+		"the default must never poison/skip — dropping a side effect is opt-in")
+}
+
+// WithMaxAttempts(N): an always-erroring handler advances PAST the record after
+// N attempts (emitting via.consumer.poisoned) and then delivers the subsequent
+// record — proving the consumer is no longer wedged and the floor unpins.
+//
+//nolint:paralleltest // timing-sensitive consumer convergence; serialized to avoid load-induced flakes
+func TestOnEvent_poisonsAndAdvancesAfterMaxAttempts(t *testing.T) {
+	spy := &gaugeSpyMetrics{}
+	app := New(WithMetrics(spy), WithLogLevel(LogError))
+	server := httptest.NewServer(app)
+	t.Cleanup(server.Close)
+	defer server.Close()
+	defer app.backplane.Close()
+	ctx := context.Background()
+
+	var mu sync.Mutex
+	var handled []int
+	var h StateAppEvents[envEv, []int]
+	h.bindWireKey("k")
+	h.bindApp(app)
+	h.OnEvent("rec", func(_ context.Context, ev envEv, off Offset) error {
+		if off == 1 {
+			return fmt.Errorf("permanent failure on offset 1")
+		}
+		mu.Lock()
+		handled = append(handled, ev.N)
+		mu.Unlock()
+		return nil
+	}, WithMaxAttempts(3), WithRetryBackoff(time.Millisecond, 5*time.Millisecond))
+
+	_, err := app.backplane.Append(ctx, "k", goodEnv(t, envEv{N: 1}))
+	require.NoError(t, err)
+	_, err = app.backplane.Append(ctx, "k", goodEnv(t, envEv{N: 2}))
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(handled) == 1 && handled[0] == 2
+	}, 2*time.Second, 10*time.Millisecond,
+		"after N attempts the poison record is skipped and the next record is delivered")
+	require.True(t, spy.sawCounter("via.consumer.poisoned"), "skipping a poison record emits via.consumer.poisoned")
+	awaitConsumerCommitted(t, app.backplane, "rec", "k", 2)
+}
+
+// A handler that errors a few times then succeeds advances normally and the
+// per-pod attempt counter resets — so a transient failure never trips the poison
+// threshold prematurely on a LATER record.
+//
+//nolint:paralleltest // timing-sensitive consumer convergence; serialized to avoid load-induced flakes
+func TestOnEvent_resetsAttemptsAfterTransientErrorThenSucceeds(t *testing.T) {
+	spy := &gaugeSpyMetrics{}
+	app := New(WithMetrics(spy), WithLogLevel(LogError))
+	server := httptest.NewServer(app)
+	t.Cleanup(server.Close)
+	defer server.Close()
+	defer app.backplane.Close()
+	ctx := context.Background()
+
+	var attemptsOn1 int32
+	var mu sync.Mutex
+	var handled []int
+	var h StateAppEvents[envEv, []int]
+	h.bindWireKey("k")
+	h.bindApp(app)
+	// maxAttempts 5; offset 1 fails twice then succeeds, offset 2 fails twice then
+	// succeeds. If attempts did NOT reset between records, offset 2's two failures
+	// would stack onto offset 1's and could trip the threshold.
+	h.OnEvent("rec", func(_ context.Context, ev envEv, off Offset) error {
+		if off == 1 && atomic.AddInt32(&attemptsOn1, 1) < 3 {
+			return fmt.Errorf("transient on 1")
+		}
+		mu.Lock()
+		handled = append(handled, ev.N)
+		mu.Unlock()
+		return nil
+	}, WithMaxAttempts(5), WithRetryBackoff(time.Millisecond, 5*time.Millisecond))
+
+	_, err := app.backplane.Append(ctx, "k", goodEnv(t, envEv{N: 10}))
+	require.NoError(t, err)
+	_, err = app.backplane.Append(ctx, "k", goodEnv(t, envEv{N: 20}))
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(handled) == 2
+	}, 2*time.Second, 10*time.Millisecond, "both records eventually handled")
+	mu.Lock()
+	require.Equal(t, []int{10, 20}, handled, "order preserved, none skipped")
+	mu.Unlock()
+	require.False(t, spy.sawCounter("via.consumer.poisoned"),
+		"a recovered transient failure must not poison any record")
+	awaitConsumerCommitted(t, app.backplane, "rec", "k", 2)
+}
+
+// WithDeadLetter returning nil: the hook receives the correct key/offset/raw
+// data/cause, the consumer then commits past the record, and via.consumer.poisoned
+// still fires.
+//
+//nolint:paralleltest // timing-sensitive consumer convergence; serialized to avoid load-induced flakes
+func TestOnEvent_deadLetterReceivesRecordThenAdvances(t *testing.T) {
+	spy := &gaugeSpyMetrics{}
+	app := New(WithMetrics(spy), WithLogLevel(LogError))
+	server := httptest.NewServer(app)
+	t.Cleanup(server.Close)
+	defer server.Close()
+	defer app.backplane.Close()
+	ctx := context.Background()
+
+	rawData := goodEnv(t, envEv{N: 1})
+	var mu sync.Mutex
+	var gotKey string
+	var gotOff Offset
+	var gotData []byte
+	var gotCause error
+	var dlqCalls int
+
+	var h StateAppEvents[envEv, []int]
+	h.bindWireKey("k")
+	h.bindApp(app)
+	h.OnEvent("rec", func(_ context.Context, _ envEv, off Offset) error {
+		if off == 1 {
+			return fmt.Errorf("boom")
+		}
+		return nil
+	}, WithMaxAttempts(2), WithRetryBackoff(time.Millisecond, 5*time.Millisecond),
+		WithDeadLetter(func(_ context.Context, key string, off Offset, data []byte, cause error) error {
+			mu.Lock()
+			gotKey, gotOff, gotData, gotCause = key, off, data, cause
+			dlqCalls++
+			mu.Unlock()
+			return nil
+		}))
+
+	_, err := app.backplane.Append(ctx, "k", rawData)
+	require.NoError(t, err)
+	_, err = app.backplane.Append(ctx, "k", goodEnv(t, envEv{N: 2}))
+	require.NoError(t, err)
+
+	awaitConsumerCommitted(t, app.backplane, "rec", "k", 2)
+	mu.Lock()
+	require.Equal(t, "k", gotKey, "dead-letter hook receives the wire key")
+	require.Equal(t, Offset(1), gotOff, "dead-letter hook receives the poison offset")
+	require.Equal(t, rawData, gotData, "dead-letter hook receives the raw record bytes")
+	require.Error(t, gotCause, "dead-letter hook receives the handler error cause")
+	require.GreaterOrEqual(t, dlqCalls, 1, "the dead-letter hook is invoked")
+	mu.Unlock()
+	require.True(t, spy.sawCounter("via.consumer.poisoned"),
+		"a dead-lettered record still emits via.consumer.poisoned")
+}
+
+// WithDeadLetter returning an error: the consumer must NOT advance — a record the
+// operator opted to dead-letter is never silently lost while the sink is down.
+//
+//nolint:paralleltest // timing-sensitive consumer convergence; serialized to avoid load-induced flakes
+func TestOnEvent_deadLetterErrorKeepsRetryingWithoutAdvancing(t *testing.T) {
+	app := New(WithLogLevel(LogError))
+	server := httptest.NewServer(app)
+	t.Cleanup(server.Close)
+	defer server.Close()
+	defer app.backplane.Close()
+	ctx := context.Background()
+
+	var dlqCalls int32
+	var h StateAppEvents[envEv, []int]
+	h.bindWireKey("k")
+	h.bindApp(app)
+	h.OnEvent("rec", func(_ context.Context, _ envEv, _ Offset) error {
+		return fmt.Errorf("boom")
+	}, WithMaxAttempts(2), WithRetryBackoff(time.Millisecond, 5*time.Millisecond),
+		WithDeadLetter(func(_ context.Context, _ string, _ Offset, _ []byte, _ error) error {
+			atomic.AddInt32(&dlqCalls, 1)
+			return fmt.Errorf("dlq sink unavailable")
+		}))
+
+	_, err := app.backplane.Append(ctx, "k", goodEnv(t, envEv{N: 1}))
+	require.NoError(t, err)
+
+	// The hook is retried (proving still-retrying) ...
+	require.Eventually(t, func() bool { return atomic.LoadInt32(&dlqCalls) >= 2 },
+		2*time.Second, 10*time.Millisecond, "a failing dead-letter sink is retried")
+	// ... and the offset never advances.
+	require.Never(t, func() bool {
+		data, _, ok, _ := app.backplane.LoadSnapshot(ctx, consumerKey("rec", "k"))
+		if !ok {
+			return false
+		}
+		var off Offset
+		return json.Unmarshal(data, &off) == nil && off >= 1
+	}, 400*time.Millisecond, 50*time.Millisecond,
+		"a record the operator opted to dead-letter is never dropped when the sink is down")
+}
+
+// A forward-incompatible record still BLOCKS even under WithMaxAttempts — it is a
+// rollback guard, never poison — and is never counted toward the poison
+// threshold. An undecodable record still skips with via.consumer.undecodable
+// (not poisoned).
+//
+//nolint:paralleltest // timing-sensitive consumer convergence; serialized to avoid load-induced flakes
+func TestOnEvent_forwardIncompatibleBlocksDespiteMaxAttempts(t *testing.T) {
+	spy := &gaugeSpyMetrics{}
+	app := New(WithMetrics(spy), WithLogLevel(LogError))
+	server := httptest.NewServer(app)
+	t.Cleanup(server.Close)
+	defer server.Close()
+	defer app.backplane.Close()
+	ctx := context.Background()
+
+	var handled int32
+	var h StateAppEvents[envEv, []int]
+	h.bindWireKey("k")
+	h.bindApp(app)
+	h.OnEvent("rec", func(_ context.Context, _ envEv, _ Offset) error {
+		atomic.AddInt32(&handled, 1)
+		return nil
+	}, WithMaxAttempts(1), WithRetryBackoff(time.Millisecond, 5*time.Millisecond))
+
+	_, err := app.backplane.Append(ctx, "k", futureEnv(t, envEv{N: 1})) // newer than this binary
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool { return spy.sawCounter("via.consumer.forward_incompatible") },
+		2*time.Second, 10*time.Millisecond, "a forward-incompatible record emits its own metric")
+	require.Never(t, func() bool {
+		if atomic.LoadInt32(&handled) > 0 {
+			return true
+		}
+		return spy.sawCounter("via.consumer.poisoned")
+	}, 400*time.Millisecond, 50*time.Millisecond,
+		"a forward-incompatible record is never handled and never poisoned, even with WithMaxAttempts")
+	_, _, ok, _ := app.backplane.LoadSnapshot(ctx, consumerKey("rec", "k"))
+	require.False(t, ok, "the consumer must not commit past a forward-incompatible record")
+}
+
+// An undecodable record still skips + advances under WithMaxAttempts, emitting
+// via.consumer.undecodable (not via.consumer.poisoned).
+//
+//nolint:paralleltest // timing-sensitive consumer convergence; serialized to avoid load-induced flakes
+func TestOnEvent_undecodableSkipsNotPoisonedUnderMaxAttempts(t *testing.T) {
+	spy := &gaugeSpyMetrics{}
+	app := New(WithMetrics(spy), WithLogLevel(LogError))
+	server := httptest.NewServer(app)
+	t.Cleanup(server.Close)
+	defer server.Close()
+	defer app.backplane.Close()
+	ctx := context.Background()
+
+	var mu sync.Mutex
+	var ns []int
+	var h StateAppEvents[envEv, []int]
+	h.bindWireKey("k")
+	h.bindApp(app)
+	h.OnEvent("rec", func(_ context.Context, ev envEv, _ Offset) error {
+		mu.Lock()
+		ns = append(ns, ev.N)
+		mu.Unlock()
+		return nil
+	}, WithMaxAttempts(2), WithRetryBackoff(time.Millisecond, 5*time.Millisecond))
+
+	_, err := app.backplane.Append(ctx, "k", goodEnv(t, envEv{N: 1}))
+	require.NoError(t, err)
+	_, err = app.backplane.Append(ctx, "k", []byte("not-a-valid-envelope")) // poison @offset 2
+	require.NoError(t, err)
+	_, err = app.backplane.Append(ctx, "k", goodEnv(t, envEv{N: 3}))
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(ns) == 2
+	}, 2*time.Second, 10*time.Millisecond, "the undecodable record is skipped, the good ones handled")
+	mu.Lock()
+	require.Equal(t, []int{1, 3}, ns, "the handler never sees the undecodable record")
+	mu.Unlock()
+	require.True(t, spy.sawCounter("via.consumer.undecodable"), "a skipped poison record emits via.consumer.undecodable")
+	require.False(t, spy.sawCounter("via.consumer.poisoned"),
+		"an undecodable record is skipped via the decode path, not the poison path")
+}


### PR DESCRIPTION
## Finding (critic #5)

An `OnEvent` side-effect consumer whose handler **permanently** fails retried head-of-line **forever** on a flat 10ms backoff. That wedges the consumer and pins the Compactor floor at the poison record's offset, so the event log grows unboundedly — a single bad record can take down a pod's disk over time.

## Fix

- **Exponential backoff + full jitter** (default 10ms → 30s) replaces the flat 10ms retry. Per-pod attempt counter, reset to 0 on any advance.
- **Block-forever stays the default.** `WithMaxAttempts(0)` (the default) preserves today's zero-data-loss semantics: a permanently-failing handler keeps the record head-of-line and never drops the side effect. **Skipping a poison record is strictly opt-in** — dropping a side effect by default is the wrong default.
- **Loud while blocking.** Each retry emits a `via.consumer.stuck` gauge (the attempt count); a one-shot `WARN` fires once attempts cross a threshold, so the floor-pin is observable rather than silent.

## New options (variadic — existing 2-arg call sites still compile)

- `WithMaxAttempts(n int)` — after `n` handler-error attempts on a record, treat it as poison: emit `via.consumer.poisoned` + `WARN`, dead-letter it (if a hook is set) or drop it, then commit/advance past it. Un-wedges the consumer and unpins the floor.
- `WithRetryBackoff(base, max time.Duration)` — backoff bounds (default 10ms → 30s).
- `WithDeadLetter(fn)` — invoked just before a record is poisoned. Returns `nil` → advance; returns an error → do **not** advance, keep retrying (a record the operator opted to DLQ is never lost when the sink is down).

`deliver()` was refactored to return a three-way outcome (**advance / retry / block**) so a **forward-incompatible** record always blocks and is **never** counted toward poison; an **undecodable** record still skips via the decode path (`via.consumer.undecodable`), distinct from the poison path.

## Tests (red→green, internal pkg, `-race`)

- default `maxAttempts=0`: always-erroring handler never advances; `via.consumer.error` + `via.consumer.stuck` keep firing; never poisons.
- `WithMaxAttempts(N)`: advances past the record after N attempts, emits `via.consumer.poisoned`, then delivers the next record (proves un-wedged).
- errors-then-succeeds: advances, attempts reset (no premature poison on a later record).
- `WithDeadLetter` returning nil: hook gets correct key/off/data/cause, then advances + `via.consumer.poisoned`.
- `WithDeadLetter` returning err: does not advance (stays retrying).
- forward-incompatible still blocks under `WithMaxAttempts` (never poisoned); undecodable still skips (not poisoned).

## Docs

`docs/production.md` metrics catalogue: added `via.consumer.poisoned` and `via.consumer.stuck` rows, amended the `via.consumer.error` note (bounded-retry/backoff + `WithMaxAttempts` opt-in skip). `docs/distributed-state.md` OnEvent section documents the new options.

`ci-check.sh` passes (gofmt, vet, golangci v2.12.2, govulncheck, `-race`, alloc benches).