### PR TITLE
feat: client-side SSE reconnect manager with visible banner

### DIFF
--- a/config.go
+++ b/config.go
@@ -45,6 +45,7 @@ type config struct {
 	maxContexts        int
 	maxSessions        int
 	noHealth           bool
+	noReconnect        bool
 	verboseErrors      bool
 	devChecks          bool
 	strictDecode       bool
@@ -288,6 +289,15 @@ func WithMaxSessions(n int) Option { return func(c *config) { c.maxSessions = n 
 // and /healthz report 200 while the process is up; /readyz reports 503 once
 // Shutdown begins draining. Opt out when the app needs to own those paths.
 func WithoutHealthEndpoints() Option { return func(c *config) { c.noHealth = true } }
+
+// WithoutSSEReconnect removes the small client-side reconnect manager via
+// injects into every page. By default that manager watches Datastar's fetch
+// lifecycle: it shows a "Reconnecting…" banner while the SSE stream is retrying
+// and, once Datastar's retries are exhausted (a graceful-deploy clean close or
+// a persistent failure that would otherwise leave the tab silently frozen),
+// reloads the page to re-bootstrap a fresh stream and session — bounded by a
+// reload-loop guard. Opt out to supply your own reconnect handling.
+func WithoutSSEReconnect() Option { return func(c *config) { c.noReconnect = true } }
 
 // WithVerboseErrors surfaces the real error message of a recovered action
 // panic to the browser instead of the generic "Something went wrong". The

--- a/docs/production.md
+++ b/docs/production.md
@@ -195,6 +195,15 @@ recovers on its own:
   instead of freezing (`via.sse.recover` with `mode=reload`).
 - A `via_tab` whose route prefix was never mounted is treated as forged and
   still 404s — junk traffic can't mint contexts.
+- **Retries exhausted (clean-close deploy, or a persistent failure):** the
+  server-side recovery above can only run once a reconnect *reaches* the
+  server. If Datastar's own retries are exhausted first — a graceful
+  clean-close on deploy, or a session mismatch that keeps 403-ing — the tab
+  would otherwise freeze silently. via injects a small client-side reconnect
+  manager that shows a "Reconnecting…" banner while retrying and, on
+  `retries-failed`, reloads the page (jittered, and bounded to a few attempts
+  so a down server can't pin a reload loop) to re-bootstrap a fresh stream and
+  session. Disable it with `WithoutSSEReconnect()` to supply your own.
 - Sessions are also in-memory; logged-in users re-auth unless you back the
   session store with something durable. `OnInit` runs again on every
   re-bootstrap, so session-backed rehydration (below) applies there too.

--- a/internal/browsertest/reconnect_browser_test.go
+++ b/internal/browsertest/reconnect_browser_test.go
@@ -1,0 +1,103 @@
+//go:build browser
+
+package browsertest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+	"github.com/go-via/via"
+	"github.com/go-via/via/h"
+	"github.com/go-via/via/vt"
+)
+
+type plain struct{}
+
+func (p *plain) View(ctx *via.CtxR) h.H { return h.Main(h.ID("root"), h.Text("hi")) }
+
+// The reconnect manager via injects is a Datastar data-init expression. This
+// proves three things the server-side suite cannot: (1) Datastar actually
+// evaluates the injected IIFE in a real browser (window.__viaRC is set), (2) a
+// `retrying` fetch event surfaces the visible banner, and (3) `retries-failed`
+// arms the bounded reload (sessionStorage counter), which is the fix for the
+// silently-frozen tab after a clean-close deploy.
+func TestBrowserReconnectManager(t *testing.T) {
+	exec := chromePath()
+	if exec == "" {
+		t.Skip("no chromium/chrome binary found; set CHROME_PATH to run the browser test")
+	}
+
+	app := via.New(via.WithInsecureCookies())
+	via.Mount[plain](app, "/")
+	srv := vt.Serve(t, app)
+
+	allocCtx, cancelAlloc := chromedp.NewExecAllocator(context.Background(),
+		append(chromedp.DefaultExecAllocatorOptions[:],
+			chromedp.ExecPath(exec),
+			chromedp.Headless,
+			chromedp.DisableGPU,
+			chromedp.NoSandbox,
+		)...)
+	defer cancelAlloc()
+
+	ctx, cancel := chromedp.NewContext(allocCtx)
+	defer cancel()
+	ctx, cancelTO := context.WithTimeout(ctx, 30*time.Second)
+	defer cancelTO()
+
+	var installed bool
+	var bannerRetry, bannerFailed, reloadCount string
+	err := chromedp.Run(ctx,
+		chromedp.Navigate(srv.URL+"/"),
+		chromedp.WaitVisible("#root", chromedp.ByID),
+
+		// (1) Datastar evaluated the injected data-init IIFE.
+		waitJSTrue(`window.__viaRC===1`),
+		chromedp.Evaluate(`window.__viaRC===1`, &installed),
+
+		// (2) A retrying event shows the visible reconnect banner.
+		chromedp.Evaluate(`document.dispatchEvent(new CustomEvent('datastar-fetch',{detail:{type:'retrying'}}))`, nil),
+		waitJSTrue(`!!document.getElementById('via-reconnect-banner') && getComputedStyle(document.getElementById('via-reconnect-banner')).display!=='none'`),
+		chromedp.Evaluate(`document.getElementById('via-reconnect-banner').textContent`, &bannerRetry),
+
+		// (3) retries-failed arms the bounded reload (counter set, banner updated).
+		// Read the counter immediately, before the jittered reload timer fires.
+		chromedp.Evaluate(`document.dispatchEvent(new CustomEvent('datastar-fetch',{detail:{type:'retries-failed'}}))`, nil),
+		chromedp.Evaluate(`sessionStorage.getItem('__via_rc_reloads')`, &reloadCount),
+		chromedp.Evaluate(`document.getElementById('via-reconnect-banner').textContent`, &bannerFailed),
+	)
+	if err != nil {
+		t.Fatalf("chromedp run: %v", err)
+	}
+
+	if !installed {
+		t.Fatal("reconnect manager did not install — Datastar did not evaluate the injected data-init")
+	}
+	if bannerRetry != "Reconnecting..." {
+		t.Fatalf("retrying banner = %q, want %q", bannerRetry, "Reconnecting...")
+	}
+	if reloadCount != "1" {
+		t.Fatalf("retries-failed must arm a bounded reload: __via_rc_reloads = %q, want %q", reloadCount, "1")
+	}
+	if bannerFailed == "" || bannerFailed == "Reconnecting..." {
+		t.Fatalf("retries-failed banner should escalate; got %q", bannerFailed)
+	}
+}
+
+func waitJSTrue(expr string) chromedp.Action {
+	return chromedp.ActionFunc(func(ctx context.Context) error {
+		for {
+			var ok bool
+			if err := chromedp.Evaluate(expr, &ok).Do(ctx); err == nil && ok {
+				return nil
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(50 * time.Millisecond):
+			}
+		}
+	})
+}

--- a/reconnect.go
+++ b/reconnect.go
@@ -1,0 +1,35 @@
+package via
+
+// reconnectInit is the client-side reconnect manager injected into every page
+// as a Datastar data-init expression (unless WithoutSSEReconnect). It watches
+// the global `datastar-fetch` lifecycle events Datastar dispatches for its SSE
+// fetch:
+//
+//   - retrying       → the stream dropped and Datastar is re-attempting; show a
+//     "Reconnecting…" banner so the freeze is visible, not silent.
+//   - started/finished → a healthy fetch; clear the banner.
+//   - retries-failed → Datastar gave up (a graceful-deploy clean close, or a
+//     persistent failure / session mismatch that would otherwise leave the tab
+//     frozen forever). Reload to re-bootstrap a fresh stream + session, after a
+//     jittered delay so a fleet of tabs doesn't stampede the new pod at once.
+//
+// A sessionStorage counter bounds reloads to 3 per failure episode so a server
+// that stays down can't pin the tab in a reload loop; a successful load clears
+// it after the page has been stable for a few seconds. It is a single IIFE so a
+// double injection (e.g. a re-bootstrap) is a no-op via the window guard.
+const reconnectInit = `(()=>{if(window.__viaRC)return;window.__viaRC=1;` +
+	`var K='__via_rc_reloads',b;` +
+	`function show(m){if(!b){b=document.createElement('div');b.id='via-reconnect-banner';` +
+	`b.setAttribute('role','status');b.style.cssText='position:fixed;top:0;left:0;right:0;` +
+	`z-index:2147483647;padding:.5rem 1rem;text-align:center;font:14px system-ui,sans-serif;` +
+	`background:#b45309;color:#fff';(document.body||document.documentElement).appendChild(b)}` +
+	`b.textContent=m;b.style.display='block'}` +
+	`function hide(){if(b)b.style.display='none'}` +
+	`document.addEventListener('datastar-fetch',function(e){var t=e.detail&&e.detail.type;` +
+	`if(t==='retrying'){show('Reconnecting...')}` +
+	`else if(t==='started'||t==='finished'){hide()}` +
+	`else if(t==='retries-failed'){var n=0;try{n=+(sessionStorage.getItem(K)||0)}catch(_){}` +
+	`if(n>=3){show('Connection lost. Please refresh the page.');return}` +
+	`show('Connection lost - reconnecting...');try{sessionStorage.setItem(K,n+1)}catch(_){}` +
+	`setTimeout(function(){location.reload()},500+Math.floor(Math.random()*1500))}});` +
+	`addEventListener('load',function(){setTimeout(function(){try{sessionStorage.removeItem(K)}catch(_){}},5000)})})()`

--- a/reconnect_test.go
+++ b/reconnect_test.go
@@ -1,0 +1,48 @@
+package via_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-via/via"
+	"github.com/go-via/via/h"
+	"github.com/go-via/via/vt"
+	"github.com/stretchr/testify/assert"
+)
+
+type reconnectPage struct{}
+
+func (p *reconnectPage) View(ctx *via.CtxR) h.H { return h.Div(h.Text("hi")) }
+
+// Dropping the SSE stream (a graceful-deploy clean close, or retries exhausting)
+// leaves the tab silently frozen. The page must ship a reconnect manager that
+// listens for Datastar's fetch lifecycle and, once retries fail, reloads to
+// re-bootstrap a fresh stream + session — with a visible affordance.
+func TestReconnect_scriptInjectedByDefault(t *testing.T) {
+	t.Parallel()
+
+	app := via.New()
+	server := vt.Serve(t, app)
+	via.Mount[reconnectPage](app, "/")
+
+	html := vt.NewClient(t, server, "/").HTML()
+	assert.Contains(t, html, "datastar-fetch",
+		"the page must wire a datastar-fetch listener to observe SSE health")
+	assert.Contains(t, html, "retries-failed",
+		"it must react to Datastar's retries-failed (the stream is dead)")
+	assert.Contains(t, strings.ToLower(html), "reload",
+		"on retries-failed it must reload to re-bootstrap the stream")
+}
+
+// Apps that want to own reconnect behavior can opt out entirely.
+func TestReconnect_optOutRemovesScript(t *testing.T) {
+	t.Parallel()
+
+	app := via.New(via.WithoutSSEReconnect())
+	server := vt.Serve(t, app)
+	via.Mount[reconnectPage](app, "/")
+
+	html := vt.NewClient(t, server, "/").HTML()
+	assert.NotContains(t, html, "datastar-fetch",
+		"WithoutSSEReconnect must remove the injected reconnect manager")
+}

--- a/render.go
+++ b/render.go
@@ -140,6 +140,9 @@ func (a *App) writePageDocument(w http.ResponseWriter, ctx *Ctx, body h.H) {
 		h.Meta(h.Data("init",
 			`window.addEventListener('beforeunload',(e)=>{navigator.sendBeacon('/_sse/close','`+template.JSEscapeString(ctx.id)+`');});`)),
 	)
+	if !a.cfg.noReconnect {
+		head = append(head, h.Meta(h.Data("init", reconnectInit)))
+	}
 	head = append(head, a.documentHeadIncludes...)
 
 	bodyEls := make([]h.H, 0, 1+len(a.documentFootIncludes))


### PR DESCRIPTION
Critic panel finding #2 (blocker). Dropping the SSE stream left the tab **silently frozen**. The existing server-side re-bootstrap only runs once a reconnect *reaches* the server — but on a graceful clean-close deploy (or a persistent 403/session-mismatch) Datastar exhausts its retries first, so the tab never recovers and the user sees nothing.

## Change
Inject a small reconnect manager into every page (a Datastar `data-init` expression, same mechanism as the existing `beforeunload` hook — no nonce/CSP change). It watches the `datastar-fetch` lifecycle:
- `retrying` → show a visible "Reconnecting…" banner (the freeze is no longer silent)
- `started`/`finished` → clear the banner
- `retries-failed` → reload to re-bootstrap a fresh stream + session, **jittered** (500–2000ms, avoids a fleet stampeding the new pod) and **bounded to 3 attempts** via a `sessionStorage` counter so a down server can't pin a reload loop; after that it shows "Please refresh".

Default on; `WithoutSSEReconnect()` opts out. Covers both the clean-close deploy freeze and the session-403 case (both end in retries-failed).

## Why reload rather than re-arm the SSE from JS
Re-issuing Datastar's fetch-based SSE from a raw listener is fragile; a reload re-bootstraps the stream **and** the session deterministically — the robust path the design converged on.

## Tests
- server-side: the reconnect `data-init` is present with the `datastar-fetch`/`retries-failed`/reload branches; `WithoutSSEReconnect()` removes it.
- **browser** (chromedp, `-tags browser`, runs locally w/ Chromium — out of CI): verifies the injected IIFE actually evaluates in Datastar (`window.__viaRC`), the banner appears on `retrying`, and `retries-failed` arms the bounded reload. Verified green locally (stable across runs).
- docs/production.md recovery section documents the new behavior + opt-out.

Default `ci-check.sh` green (browser test excluded by build tag).