### PR TITLE
fix: recover wrong-pod actions instead of 404 (action/SSE symmetry)

### DIFF
--- a/action.go
+++ b/action.go
@@ -127,6 +127,21 @@ func (a *App) handleAction(w http.ResponseWriter, r *http.Request) {
 		if tabID != "" {
 			a.metricsOrNoop().Counter("via.tab.unknown", "kind", "action")
 		}
+		// If the id is recoverable (well-formed and names a mounted route — a
+		// wrong-pod hit, TTL sweep, or restart), push a reload so a fresh page
+		// GET re-bootstraps the tab instead of silently dropping the click. The
+		// SSE handshake already recovers the same stale id (recoverSSE); this
+		// removes the action/SSE asymmetry. Run the descriptor's group
+		// middleware first so an auth guard vetoes recovery exactly as it
+		// vetoes the page. A forged id (no mounted route) keeps the 404.
+		if d := a.descriptorForStaleTab(tabID); d != nil {
+			reload := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				a.metricsOrNoop().Counter("via.action.recover", "mode", "reload")
+				a.streamReloadScript(w, r)
+			})
+			applyMiddleware(d.groupMW, reload).ServeHTTP(w, r)
+			return
+		}
 		http.NotFound(w, r)
 		return
 	}

--- a/action_recover_test.go
+++ b/action_recover_test.go
@@ -1,0 +1,71 @@
+package via_test
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/go-via/via"
+	"github.com/go-via/via/h"
+	"github.com/go-via/via/on"
+	"github.com/go-via/via/vt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type actRecoverPage struct{}
+
+func (p *actRecoverPage) Bump(ctx *via.Ctx)      {}
+func (p *actRecoverPage) View(ctx *via.CtxR) h.H { return h.Div(on.Click(p.Bump)) }
+
+const hex64 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+// An action routed to a pod that doesn't hold the tab's Ctx (non-sticky LB, TTL
+// sweep, restart) used to 404 — silently dropping the click — while the SSE path
+// already re-bootstraps the same stale tab. That asymmetry leaves a wrong-pod
+// click dead. A recoverable (well-formed, mounted-route) tab must instead get a
+// reload directive so a fresh page GET re-bootstraps it, matching the SSE path.
+func TestActionRecover_unknownButRecoverableTabReloads(t *testing.T) {
+	t.Parallel()
+
+	m := &captureMetrics{}
+	app := via.New(via.WithMetrics(m))
+	server := vt.Serve(t, app)
+	via.Mount[actRecoverPage](app, "/")
+
+	// "/_<64hex>" is genTabID's shape for the "/" route: well-formed and
+	// owned by a mounted route, but never registered on this fresh app.
+	body := strings.NewReader(`{"via_tab":"/_` + hex64 + `"}`)
+	resp, err := server.Client().Post(server.URL+"/_action/Bump", "application/json", body)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"a recoverable wrong-pod action must not 404")
+	assert.Contains(t, string(raw), "location.reload",
+		"it must push a reload so a fresh page GET re-bootstraps the tab")
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	assert.Contains(t, m.counters, "via.action.recover:mode,reload",
+		"the action recovery must be observable as a metric")
+}
+
+// A forged / garbage tab id (no mounted route prefix) must keep the historical
+// 404 — junk traffic must never trigger recovery work or mint contexts.
+func TestActionRecover_forgedTabStill404s(t *testing.T) {
+	t.Parallel()
+
+	app := via.New()
+	server := vt.Serve(t, app)
+	via.Mount[actRecoverPage](app, "/")
+
+	body := strings.NewReader(`{"via_tab":"no/such/route_` + hex64 + `"}`)
+	resp, err := server.Client().Post(server.URL+"/_action/Bump", "application/json", body)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode,
+		"a tab id naming no mounted route is forged — still 404")
+}

--- a/docs/production.md
+++ b/docs/production.md
@@ -93,6 +93,7 @@ and emits structured events for ops dashboards:
 | `via.ctx.reap` | counter | `reason` |
 | `via.session.mismatch` | counter | |
 | `via.tab.unknown` | counter | `kind` |
+| `via.action.recover` | counter | `mode` |
 
 State backplane (`StateAppEvents`, the clustered event-log path):
 


### PR DESCRIPTION
Top item from the 1.0 design council: the only remaining cross-pod **correctness** gap.

## Problem
An action POST whose `via_tab` this pod doesn't hold returned a bare `404` — silently dropping the click — while the **SSE handshake already re-bootstraps the same stale tab** (`recoverSSE`). Without sticky sessions, an action round-robined to the wrong pod just died, with no recovery and no feedback. SSE recovers; actions didn't — a strictly-worse asymmetry.

## Fix
A **recoverable** id (well-formed and naming a mounted route — wrong-pod routing, TTL sweep, or restart) now gets a reload directive over the datastar action response (reusing `streamReloadScript`, the SSE path's degraded-recovery), so a fresh page GET re-bootstraps the tab. The descriptor's group middleware runs first (auth vetoes recovery as it vetoes the page); a **forged** id (no mounted route) keeps the historical 404 so junk can't mint contexts. Emits `via.action.recover{mode=reload}` (added to the metrics catalogue).

## Tests
- recoverable unknown tab → 200 + `location.reload` script + `via.action.recover` metric (not 404)
- forged tab (no mounted route) → still 404

Full `ci-check.sh` green.