### PR TITLE
feat: catch by-value child-clobber by default (alloc-safe)

### DIFF
--- a/app.go
+++ b/app.go
@@ -402,6 +402,10 @@ func New(opts ...Option) *App {
 			// admin dashboards) is exactly where a non-Secure cookie leaks
 			// on an http downgrade. WithInsecureCookies opts out for dev.
 			secureCookies: true,
+			// The by-value child-clobber check is on by default — it's a real
+			// footgun and the cost amortizes to ~zero (once per descriptor).
+			// WithoutDevChecks opts out.
+			devChecks: true,
 		},
 	}
 	for _, opt := range opts {

--- a/composition.go
+++ b/composition.go
@@ -154,6 +154,7 @@ func buildDescriptor[C any]() *cmpDescriptor {
 		initIdx:      -1,
 		connectIdx:   -1,
 		disposeIdx:   -1,
+		bind:         &bindGuard{},
 	}
 
 	walkStruct(desc, typ, nil, "")

--- a/config.go
+++ b/config.go
@@ -307,13 +307,14 @@ func WithoutSSEReconnect() Option { return func(c *config) { c.noReconnect = tru
 // information-disclosure risk. Turn it on in development for faster feedback.
 func WithVerboseErrors() Option { return func(c *config) { c.verboseErrors = true } }
 
-// WithDevChecks enables development-only runtime assertions that cost a little
-// per render and so are off in production. Currently it re-walks a page's bound
-// state handles after OnInit and fails the render if one was orphaned by
+// WithoutDevChecks disables via's by-default runtime binding check. That check
+// runs once per composition descriptor (the cost amortizes to ~zero across
+// renders): after OnInit it verifies no bound state handle was orphaned by
 // replacing a child composition by value (p.Child = T{...}), which silently
-// zeroes the runtime's by-address binding — the page would otherwise render
-// once and then go dead. Run it in dev/CI to catch the footgun early.
-func WithDevChecks() Option { return func(c *config) { c.devChecks = true } }
+// zeroes the runtime's by-address binding and leaves the page rendering once
+// then going dead. It's on by default because that footgun is silent and
+// expensive to debug; opt out only if it ever false-positives in your build.
+func WithoutDevChecks() Option { return func(c *config) { c.devChecks = false } }
 
 // WithStrictDecode rejects a client signal value that cannot be represented in
 // its Signal[T] type — a number that overflows the target int/uint/float width,

--- a/dead_bind_test.go
+++ b/dead_bind_test.go
@@ -34,25 +34,10 @@ type ddGoodPage struct {
 
 func (p *ddGoodPage) View(ctx *via.CtxR) h.H { return h.Div() }
 
-// With WithDevChecks a by-value child clobber must be caught loudly at render
-// instead of silently producing dead client bindings that fail only later.
-func TestDeadBind_devChecksCatchByValueClobber(t *testing.T) {
-	t.Parallel()
-
-	app := via.New(via.WithDevChecks())
-	server := vt.Serve(t, app)
-	via.Mount[ddClobberPage](app, "/")
-
-	resp, err := server.Client().Get(server.URL + "/")
-	require.NoError(t, err)
-	defer resp.Body.Close()
-	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode,
-		"a by-value child clobber under dev checks must fail the render loudly")
-}
-
-// Without the dev flag, production pays nothing — the (buggy) page still
-// renders, matching today's behavior.
-func TestDeadBind_offByDefault(t *testing.T) {
+// A by-value child clobber must be caught loudly at render BY DEFAULT —
+// silently producing dead client bindings that fail only later is the footgun;
+// the check is cheap (amortized once per descriptor) so it's on without a flag.
+func TestDeadBind_caughtByDefault(t *testing.T) {
 	t.Parallel()
 
 	app := via.New()
@@ -62,15 +47,31 @@ func TestDeadBind_offByDefault(t *testing.T) {
 	resp, err := server.Client().Get(server.URL + "/")
 	require.NoError(t, err)
 	defer resp.Body.Close()
-	assert.Equal(t, http.StatusOK, resp.StatusCode,
-		"without WithDevChecks the render is unaffected (prod pays nothing)")
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode,
+		"a by-value child clobber must fail the render loudly by default")
 }
 
-// Dev checks must not false-positive on a correctly-bound composition.
-func TestDeadBind_devChecksPassIntactBindings(t *testing.T) {
+// WithoutDevChecks is the escape hatch: disable the check (e.g. if it ever
+// false-positives) and the buggy page renders as it did before.
+func TestDeadBind_withoutDevChecksRenders(t *testing.T) {
 	t.Parallel()
 
-	app := via.New(via.WithDevChecks())
+	app := via.New(via.WithoutDevChecks())
+	server := vt.Serve(t, app)
+	via.Mount[ddClobberPage](app, "/")
+
+	resp, err := server.Client().Get(server.URL + "/")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"WithoutDevChecks disables the check — the render is unaffected")
+}
+
+// The default check must not false-positive on a correctly-bound composition.
+func TestDeadBind_intactBindingsPass(t *testing.T) {
+	t.Parallel()
+
+	app := via.New()
 	server := vt.Serve(t, app)
 	via.Mount[ddGoodPage](app, "/")
 
@@ -78,5 +79,5 @@ func TestDeadBind_devChecksPassIntactBindings(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode,
-		"an intact composition must render cleanly under dev checks")
+		"an intact composition must render cleanly under the default check")
 }

--- a/descriptor.go
+++ b/descriptor.go
@@ -70,6 +70,18 @@ type cmpDescriptor struct {
 	disposeIdx   int // method index of OnDispose or -1
 
 	groupMW []Middleware // middleware from the owning Group, if any
+
+	// bind runs validateBindings a single time per composition type (the
+	// by-value child clobber is deterministic per type), caching the verdict so
+	// the per-render cost amortizes to ~zero. A POINTER so per-mount clones
+	// (clone := *desc) share one guard — and so the descriptor stays copyable
+	// (a sync.Once value would trip vet copylocks on the clone).
+	bind *bindGuard
+}
+
+type bindGuard struct {
+	once sync.Once
+	err  error
 }
 
 var (

--- a/render.go
+++ b/render.go
@@ -65,9 +65,13 @@ func (a *App) renderPage(d *cmpDescriptor, w http.ResponseWriter, r *http.Reques
 	}
 
 	if a.cfg.devChecks {
-		if err := validateBindings(ctx, cmpVal, d); err != nil {
-			a.logErr(ctx, "%v", err)
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+		// Run the binding check once per descriptor and cache the verdict — the
+		// by-value clobber is deterministic per composition type, so a single
+		// post-OnInit walk catches it and every later render pays nothing.
+		d.bind.once.Do(func() { d.bind.err = validateBindings(ctx, cmpVal, d) })
+		if d.bind.err != nil {
+			a.logErr(ctx, "%v", d.bind.err)
+			http.Error(w, d.bind.err.Error(), http.StatusInternalServerError)
 			return
 		}
 	}


### PR DESCRIPTION
Council 1.0 cut-line #2a: flip the dead-bind check on by default + sand it before the API freeze.

## Change
The by-value child-clobber check (PR #119) was opt-in behind `WithDevChecks`. The footgun is **silent** (page renders once, then bindings go dead) and expensive to debug — it should be caught without a flag.

Made it **on by default, alloc-safe**: the clobber is deterministic per composition *type*, so `validateBindings` runs **once per descriptor** (`sync.Once` on a shared `*bindGuard` — a pointer so per-mount clones share it and the descriptor stays copyable past `vet` copylocks) and the verdict is cached. Every later render pays nothing — **CounterRender alloc count unchanged (179/180)**.

`WithDevChecks()` (unreleased, same-day) → replaced by `WithoutDevChecks()`, the opt-out if it ever false-positives.

## Tests
- clobber caught by default → 500
- `WithoutDevChecks()` → renders (escape hatch)
- intact composition → 200 (no false positive)
- full -race suite green (no existing page trips the now-default check)

Full `ci-check.sh` green (vet copylocks clear, alloc gate held).