### PR TITLE
docs: mark experimental surface + API-stability contract

### DIFF
--- a/backplane.go
+++ b/backplane.go
@@ -79,6 +79,10 @@ type EventLog interface {
 // fuses a durable per-key CAS Store and a durable ordered EventLog, plus a
 // graceful drain on App.Shutdown. After Close, Append/Subscribe return
 // ErrClosed and never block.
+//
+// EXPERIMENTAL: the clustered/distributed path is pre-GA. The default InMemory
+// (single-pod) backplane is stable, but this interface and the surrounding
+// guarantees may change before 1.0 — 1.0 does not promise a distributed GA.
 type Backplane interface {
 	Store
 	EventLog

--- a/broadcast.go
+++ b/broadcast.go
@@ -36,6 +36,10 @@ type broadcastRecord struct {
 // pod-local. Either way the returned count is THIS pod's live-tab count at call
 // time — the cluster-wide total is unknowable synchronously. Empty script is a
 // no-op.
+//
+// EXPERIMENTAL: the single-process behavior is stable; the cross-pod semantics
+// (the BroadcastNotify / BroadcastSignals family included) ride the pre-GA
+// backplane and may change before 1.0.
 func (a *App) Broadcast(script string) int {
 	if script == "" {
 		return 0

--- a/config.go
+++ b/config.go
@@ -305,6 +305,8 @@ func WithoutSSEReconnect() Option { return func(c *config) { c.noReconnect = tru
 // log regardless; this only controls what the DEFAULT client notification
 // shows. Off by default — leaking raw panic text to clients is an
 // information-disclosure risk. Turn it on in development for faster feedback.
+//
+// EXPERIMENTAL: a diagnostic knob; its name or default may change before 1.0.
 func WithVerboseErrors() Option { return func(c *config) { c.verboseErrors = true } }
 
 // WithoutDevChecks disables via's by-default runtime binding check. That check
@@ -314,6 +316,8 @@ func WithVerboseErrors() Option { return func(c *config) { c.verboseErrors = tru
 // zeroes the runtime's by-address binding and leaves the page rendering once
 // then going dead. It's on by default because that footgun is silent and
 // expensive to debug; opt out only if it ever false-positives in your build.
+//
+// EXPERIMENTAL: a diagnostic knob; its name or default may change before 1.0.
 func WithoutDevChecks() Option { return func(c *config) { c.devChecks = false } }
 
 // WithStrictDecode rejects a client signal value that cannot be represented in
@@ -323,6 +327,8 @@ func WithoutDevChecks() Option { return func(c *config) { c.devChecks = false } 
 // error and its handler does not run, so corrupt input can't reach server
 // state. Off by default; turn it on when client input is untrusted and a lossy
 // decode must fail loud rather than silently clamp.
+//
+// EXPERIMENTAL: a diagnostic knob; its name or default may change before 1.0.
 func WithStrictDecode() Option { return func(c *config) { c.strictDecode = true } }
 
 // WithActionErrorHandler replaces the default browser-alert with a custom
@@ -368,9 +374,17 @@ func WithMetrics(m Metrics) Option { return func(c *config) { c.metrics = m } }
 // or a nil b) resolves internally to [InMemory], so the Backplane interface is
 // exercised on every single-pod run and there is no nil-special-case path. Wire
 // it once at boot; it is never swapped at runtime.
+//
+// EXPERIMENTAL: the clustered/distributed path is pre-GA. Single-pod use (the
+// default InMemory backplane) is stable, but the [Backplane] interface and its
+// cross-pod consistency semantics may change before 1.0 — 1.0 does not promise
+// a distributed GA. Wire a custom backplane knowing the contract can shift.
 func WithBackplane(b Backplane) Option { return func(c *config) { c.backplane = b } }
 
 // Plugin extends the App at registration time.
+//
+// EXPERIMENTAL: the plugin system (this interface and the bundled picocss /
+// echarts / maplibre packages) is young and may change before 1.0.
 type Plugin interface {
 	Register(*App)
 }

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -9,6 +9,8 @@ has_children: true
 
 - [Testing](testing) — drive compositions over HTTP with `vt`.
 - [Production & ops](production) — wiring, config, metrics, security, deploys.
+- [API stability](stability) — what's frozen vs experimental, and what counts
+  as a breaking change pre-1.0.
 - [h helpers reference](h-helpers) — every symbol in the `h` DSL.
 - [Troubleshooting](troubleshooting) — symptom → cause → fix.
 - [Glossary](glossary) — the vocabulary (signals, compositions, flush, morph).

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -1,0 +1,74 @@
+---
+title: API stability
+layout: default
+parent: Reference & ops
+nav_order: 6
+---
+
+# API stability (pre-1.0)
+
+{: .no_toc }
+
+Via is pre-1.0: APIs can still shift. This page is the contract for what is
+stable, what is experimental, and — because Via binds state by struct field and
+routes actions by method name — what counts as a breaking change.
+
+1. TOC
+{:toc}
+
+## Two tiers
+
+**Stable core.** The surface you build every app on. It will be frozen at 1.0
+and changed only under semver-major after:
+
+- the four reactive handles and their methods — `Signal[T]`, `StateTab[T]`,
+  `StateSess[T]`, `StateApp[T]` (`Read` / `Write` / `Update` / `Text` / …);
+- the typed `Num` / `Bool` / `Str` / `Slice` / `Map` wrappers and their
+  `Op(ctx)` verbs;
+- the `on.*` event helpers and the `h` HTML builders;
+- `via.New`, `via.Mount`, `App.Group`, `App.Use`, and the non-experimental
+  `WithX` options;
+- the composition model: a struct with a `View`, `OnInit` / `OnConnect` /
+  `OnDispose` hooks, and action methods.
+
+**Experimental.** Younger surface that may change before 1.0. Each is marked
+`EXPERIMENTAL:` in its godoc:
+
+- the state backplane — the `Backplane` interface and `WithBackplane`. The
+  default single-pod (`InMemory`) behavior is stable; the clustered/distributed
+  path is pre-GA and **1.0 does not promise a distributed GA**;
+- cross-pod broadcast — `Broadcast`, `BroadcastNotify`, `BroadcastSignals`
+  (single-process behavior is stable; cross-pod rides the backplane);
+- the plugin system — the `Plugin` interface and the bundled `picocss` /
+  `echarts` / `maplibre` packages;
+- the notification surface — `Ctx.Notify` (the contract is stable; the rendered
+  toast markup/styling is not);
+- young convenience helpers — `Signal.TextSpan`, `Signal.ShowUnless`,
+  `LocalSignal.ShowUnless`;
+- diagnostic knobs — `WithStrictDecode`, `WithVerboseErrors`,
+  `WithoutDevChecks`.
+
+## What counts as a breaking change
+
+Via resolves state by **reflection over your struct fields** and dispatches
+actions by **method name**. Two consequences for the wire protocol:
+
+- A composition's **exported field names and their order**, and the **wire key**
+  each resolves to, are part of the contract. Renaming a state field (or
+  changing the `via:"name"` tag) changes the signal key the browser binds to —
+  a breaking change for any live tab mid-session.
+- A **root action method's name** is its wire identifier (`on.Click(p.Save)`
+  routes to `"Save"`). Renaming it breaks every rendered button that targets it.
+
+So at 1.0 these are semver-load-bearing: **field names/order + tags, and root
+method names**. Internal field layout you don't export, and anything unexported,
+is never part of the contract.
+
+## The evolution seam
+
+The **URL route is where you evolve without breaking in place.** A new page
+shape ships at a new route (or a versioned one) and the old route keeps serving
+the old contract until you retire it — the same way you'd version any HTTP
+endpoint. Rename a Go field without moving its wire key by pinning the key with
+a `via:"name"` tag. Add fields and methods freely; that is additive. Remove or
+rename exported state/actions only across a route (or major) boundary.

--- a/local.go
+++ b/local.go
@@ -57,6 +57,8 @@ func (l LocalSignal) Text() h.H { return h.Data("text", l.dollar) }
 func (l LocalSignal) Show() h.H { return h.Data("show", l.dollar) }
 
 // ShowUnless is the negation of [LocalSignal.Show].
+//
+// EXPERIMENTAL: a young convenience helper; may change before 1.0.
 func (l LocalSignal) ShowUnless() h.H { return h.Data("show", "!"+l.dollar) }
 
 // Class toggles the named CSS class by the signal's truthiness. See

--- a/push.go
+++ b/push.go
@@ -135,6 +135,10 @@ func (ctx *Ctx) Reload() {
 // encoded into the snippet so it can neither break out of the JS string
 // nor inject markup — Go's json HTML-escaping also neutralises a
 // </script> breakout of the surrounding datastar script element.
+//
+// EXPERIMENTAL: the contract (show a transient message) is stable, but the
+// rendered SURFACE — the toast markup, styling, and stacking — may change
+// before 1.0; don't depend on the emitted DOM.
 func (ctx *Ctx) Notify(message string) {
 	if ctx == nil || message == "" {
 		return

--- a/signal.go
+++ b/signal.go
@@ -92,6 +92,8 @@ func (s *Signal[T]) Text() h.H {
 
 // TextSpan wraps [Signal.Text] in its own span: <span data-text="$key"></span>.
 // Use it where no host element is available to carry the binding.
+//
+// EXPERIMENTAL: a young convenience helper; may change before 1.0.
 func (s *Signal[T]) TextSpan() h.H {
 	return h.Span(h.Data("text", s.dollar))
 }
@@ -104,6 +106,8 @@ func (s *Signal[T]) Show() h.H {
 // ShowUnless is the negation of [Signal.Show]: the element is hidden while
 // the signal is truthy and shown while falsy. Saves hand-writing the "!$key"
 // expression (and re-juggling the $ prefix the typed helpers exist to hide).
+//
+// EXPERIMENTAL: a young convenience helper; may change before 1.0.
 func (s *Signal[T]) ShowUnless() h.H {
 	return h.Data("show", "!"+s.dollar)
 }


### PR DESCRIPTION
Council 1.0 cut-line #5: the pre-1.0 two-tier message.

## Change (docs/comments only — no behavior)
- **EXPERIMENTAL godoc markers** on the young surface: `WithBackplane` + the `Backplane` interface (distributed path pre-GA; **1.0 promises no distributed GA**), the `Broadcast*` family (cross-pod), the `Plugin` interface + bundled plugins, `Ctx.Notify` (the toast *surface*, not its contract), `Signal.TextSpan`/`ShowUnless` + `LocalSignal.ShowUnless`, and the diagnostic knobs `WithStrictDecode`/`WithVerboseErrors`/`WithoutDevChecks`. Markers are trailing paragraphs so synopses stay clean.
- **New `docs/stability.md`** (linked from Reference & ops): stable-core vs experimental tiers, and — because via binds state by struct field and routes actions by method name — exactly what counts as a breaking change (exported field names/order + `via:` tags, root method names) and that the URL route is the in-place evolution seam.

Full `ci-check.sh` green.