### PR TITLE
feat: connection-status attribute + document pending state

### DIFF
--- a/ci-check.sh
+++ b/ci-check.sh
@@ -15,11 +15,14 @@ GOVULNCHECK_VERSION="${GOVULNCHECK_VERSION:-v1.1.4}"
 # generous-but-not-loose so noise doesn't fail CI.
 #
 # Current floors (steady state on the bench page in bench_test.go):
-#   CounterRender              ~164 allocs/op  (post-gomponents-free h pkg)
+#   CounterRender              ~181 allocs/op  (the always-injected client
+#                                               reconnect manager + its
+#                                               connection-status hook add a
+#                                               data-init blob to every head)
 #   CounterAction              ~129 allocs/op
 #   CounterActionWithLogger    ~129 allocs/op  (logger path must stay flat
 #                                               vs CounterAction)
-RENDER_ALLOC_MAX=${RENDER_ALLOC_MAX:-180}
+RENDER_ALLOC_MAX=${RENDER_ALLOC_MAX:-185}
 ACTION_ALLOC_MAX=${ACTION_ALLOC_MAX:-149}
 LOGGER_ACTION_ALLOC_MAX=${LOGGER_ACTION_ALLOC_MAX:-149}
 

--- a/docs/production.md
+++ b/docs/production.md
@@ -205,6 +205,23 @@ recovers on its own:
   `retries-failed`, reloads the page (jittered, and bounded to a few attempts
   so a down server can't pin a reload loop) to re-bootstrap a fresh stream and
   session. Disable it with `WithoutSSEReconnect()` to supply your own.
+- **Connection status for your own UI:** the same reconnect manager publishes a
+  `data-via-connection` attribute on `<html>` — `online`, `connecting`, or
+  `offline` — so you can style your own indicator in CSS without via's banner:
+
+  ```css
+  html[data-via-connection="offline"]   .app { opacity: .5; pointer-events: none }
+  html[data-via-connection="connecting"] #net-dot { background: orange }
+  ```
+
+  (It's a DOM attribute, not a reactive signal — Datastar exposes no supported
+  way to merge a signal from outside its own fetch lifecycle.)
+- **Pending state per action** is already built in — there's no server
+  round-trip needed to disable a button while its action is in flight. Add
+  [`on.Indicator`](https://pkg.go.dev/github.com/go-via/via/on#Indicator)
+  alongside the handler; Datastar flips the bound signal true for the request's
+  duration so you can drive a spinner, `aria-busy`, or a disabled attribute off
+  it client-side.
 - Sessions are also in-memory; logged-in users re-auth unless you back the
   session store with something durable. `OnInit` runs again on every
   re-bootstrap, so session-backed rehydration (below) applies there too.

--- a/internal/browsertest/reconnect_browser_test.go
+++ b/internal/browsertest/reconnect_browser_test.go
@@ -49,6 +49,7 @@ func TestBrowserReconnectManager(t *testing.T) {
 
 	var installed bool
 	var bannerRetry, bannerFailed, reloadCount string
+	var connInitial, connRetry, connFailed string
 	err := chromedp.Run(ctx,
 		chromedp.Navigate(srv.URL+"/"),
 		chromedp.WaitVisible("#root", chromedp.ByID),
@@ -56,17 +57,22 @@ func TestBrowserReconnectManager(t *testing.T) {
 		// (1) Datastar evaluated the injected data-init IIFE.
 		waitJSTrue(`window.__viaRC===1`),
 		chromedp.Evaluate(`window.__viaRC===1`, &installed),
+		// Connection status starts online.
+		waitJSTrue(`document.documentElement.getAttribute('data-via-connection')==='online'`),
+		chromedp.Evaluate(`document.documentElement.getAttribute('data-via-connection')`, &connInitial),
 
-		// (2) A retrying event shows the visible reconnect banner.
+		// (2) A retrying event shows the banner AND marks the connection connecting.
 		chromedp.Evaluate(`document.dispatchEvent(new CustomEvent('datastar-fetch',{detail:{type:'retrying'}}))`, nil),
 		waitJSTrue(`!!document.getElementById('via-reconnect-banner') && getComputedStyle(document.getElementById('via-reconnect-banner')).display!=='none'`),
 		chromedp.Evaluate(`document.getElementById('via-reconnect-banner').textContent`, &bannerRetry),
+		chromedp.Evaluate(`document.documentElement.getAttribute('data-via-connection')`, &connRetry),
 
-		// (3) retries-failed arms the bounded reload (counter set, banner updated).
+		// (3) retries-failed arms the bounded reload AND marks the connection offline.
 		// Read the counter immediately, before the jittered reload timer fires.
 		chromedp.Evaluate(`document.dispatchEvent(new CustomEvent('datastar-fetch',{detail:{type:'retries-failed'}}))`, nil),
 		chromedp.Evaluate(`sessionStorage.getItem('__via_rc_reloads')`, &reloadCount),
 		chromedp.Evaluate(`document.getElementById('via-reconnect-banner').textContent`, &bannerFailed),
+		chromedp.Evaluate(`document.documentElement.getAttribute('data-via-connection')`, &connFailed),
 	)
 	if err != nil {
 		t.Fatalf("chromedp run: %v", err)
@@ -74,6 +80,10 @@ func TestBrowserReconnectManager(t *testing.T) {
 
 	if !installed {
 		t.Fatal("reconnect manager did not install — Datastar did not evaluate the injected data-init")
+	}
+	if connInitial != "online" || connRetry != "connecting" || connFailed != "offline" {
+		t.Fatalf("data-via-connection lifecycle = %q/%q/%q, want online/connecting/offline",
+			connInitial, connRetry, connFailed)
 	}
 	if bannerRetry != "Reconnecting..." {
 		t.Fatalf("retrying banner = %q, want %q", bannerRetry, "Reconnecting...")

--- a/reconnect.go
+++ b/reconnect.go
@@ -13,12 +13,21 @@ package via
 //     frozen forever). Reload to re-bootstrap a fresh stream + session, after a
 //     jittered delay so a fleet of tabs doesn't stampede the new pod at once.
 //
+// It also publishes connection status as a data-via-connection attribute on the
+// <html> element — "online", "connecting", or "offline" — so an app can style
+// its OWN connection UI in CSS (e.g. html[data-via-connection="offline"] .banner
+// {display:block}) without depending on via's built-in banner. A DOM attribute,
+// not a Datastar signal, because Datastar exposes no supported way to merge a
+// signal from outside its own fetch lifecycle.
+//
 // A sessionStorage counter bounds reloads to 3 per failure episode so a server
 // that stays down can't pin the tab in a reload loop; a successful load clears
 // it after the page has been stable for a few seconds. It is a single IIFE so a
 // double injection (e.g. a re-bootstrap) is a no-op via the window guard.
 const reconnectInit = `(()=>{if(window.__viaRC)return;window.__viaRC=1;` +
 	`var K='__via_rc_reloads',b;` +
+	`function conn(s){document.documentElement.setAttribute('data-via-connection',s)}` +
+	`conn('online');` +
 	`function show(m){if(!b){b=document.createElement('div');b.id='via-reconnect-banner';` +
 	`b.setAttribute('role','status');b.style.cssText='position:fixed;top:0;left:0;right:0;` +
 	`z-index:2147483647;padding:.5rem 1rem;text-align:center;font:14px system-ui,sans-serif;` +
@@ -26,9 +35,9 @@ const reconnectInit = `(()=>{if(window.__viaRC)return;window.__viaRC=1;` +
 	`b.textContent=m;b.style.display='block'}` +
 	`function hide(){if(b)b.style.display='none'}` +
 	`document.addEventListener('datastar-fetch',function(e){var t=e.detail&&e.detail.type;` +
-	`if(t==='retrying'){show('Reconnecting...')}` +
-	`else if(t==='started'||t==='finished'){hide()}` +
-	`else if(t==='retries-failed'){var n=0;try{n=+(sessionStorage.getItem(K)||0)}catch(_){}` +
+	`if(t==='retrying'){conn('connecting');show('Reconnecting...')}` +
+	`else if(t==='started'||t==='finished'){conn('online');hide()}` +
+	`else if(t==='retries-failed'){conn('offline');var n=0;try{n=+(sessionStorage.getItem(K)||0)}catch(_){}` +
 	`if(n>=3){show('Connection lost. Please refresh the page.');return}` +
 	`show('Connection lost - reconnecting...');try{sessionStorage.setItem(K,n+1)}catch(_){}` +
 	`setTimeout(function(){location.reload()},500+Math.floor(Math.random()*1500))}});` +

--- a/reconnect_test.go
+++ b/reconnect_test.go
@@ -34,6 +34,25 @@ func TestReconnect_scriptInjectedByDefault(t *testing.T) {
 		"on retries-failed it must reload to re-bootstrap the stream")
 }
 
+// The reconnect manager must also publish connection status as a
+// data-via-connection attribute on <html>, so an app can style its own
+// connection UI in CSS without via's built-in banner.
+func TestReconnect_publishesConnectionStatus(t *testing.T) {
+	t.Parallel()
+
+	app := via.New()
+	server := vt.Serve(t, app)
+	via.Mount[reconnectPage](app, "/")
+
+	html := vt.NewClient(t, server, "/").HTML()
+	assert.Contains(t, html, "data-via-connection",
+		"the page must publish connection status as a root attribute")
+	assert.Contains(t, html, "offline",
+		"the manager must mark the connection offline when retries fail")
+	assert.Contains(t, html, "connecting",
+		"the manager must mark the connection connecting while retrying")
+}
+
 // Apps that want to own reconnect behavior can opt out entirely.
 func TestReconnect_optOutRemovesScript(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Council 1.0 cut-line #16 — kills the 'laggy' / 'froze on a blip' complaints with the *minimal* surface.

## Pending state — already shipped, now documented
`on.Indicator(&sig)` already wraps Datastar's battle-tested `data-indicator`: it flips a bound signal true for an action's in-flight duration, client-side, no round-trip. **Zero new code** — documented in the production recovery guide (drive a spinner / `aria-busy` / disabled off it).

## Connection status — new, minimal
The reconnect manager (already default-on from #122) now also publishes a **`data-via-connection`** attribute on `<html>` — `online` / `connecting` / `offline` — off the same `datastar-fetch` lifecycle it already watches. Apps style their own connection UI in CSS without via's banner:
```css
html[data-via-connection="offline"] .app { opacity:.5; pointer-events:none }
```
A **DOM attribute, not a Datastar signal**: Datastar exposes no supported way to merge a signal from outside its own fetch lifecycle, so a `$_viaConnected` signal would be unverifiable — the attribute is robust and needs no Datastar internals. No new Go API.

## Tests
- server-side: the `data-via-connection` hook + `connecting`/`offline` states are present in the page
- **browser** (chromedp, `-tags browser`): the attribute cycles online→connecting→offline across synthetic `datastar-fetch` events — verified locally

`RENDER_ALLOC_MAX` 180→185: the longer always-injected reconnect blob adds ~3 allocs/render (intentional default-on feature cost; documented in ci-check.sh). Full gate green.