### PR TITLE
fix: Signal Attr/Class/Style emitted dead hyphen bindings

### DIFF
--- a/docs/reactive-state.md
+++ b/docs/reactive-state.md
@@ -104,8 +104,8 @@ s.Bind()              // <input data-bind="key"> two-way binding
 s.Text()              // data-text="$key" attribute — attach to a host element
 s.TextSpan()          // <span data-text="$key"></span> — standalone span
 s.Show()              // data-show="$key" — toggle display by truthiness
-s.Attr("disabled")    // data-attr-disabled="$key" — drives an HTML attr
-s.Style("color")      // data-style-color="$key" — drives an inline CSS prop
+s.Attr("disabled")    // data-attr:disabled="$key" — drives an HTML attr
+s.Style("color")      // data-style:color="$key" — drives an inline CSS prop
 ```
 
 `StateTab[T]` / `StateSess[T]` / `StateApp[T]` share `Text(ctx)`, which

--- a/internal/browsertest/binding_browser_test.go
+++ b/internal/browsertest/binding_browser_test.go
@@ -1,0 +1,79 @@
+//go:build browser
+
+package browsertest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+	"github.com/go-via/via"
+	"github.com/go-via/via/h"
+	"github.com/go-via/via/vt"
+)
+
+// bindPage drives the three reactive binding helpers off signals that start
+// truthy via init tags, so the bindings must take effect on first paint.
+type bindPage struct {
+	On  via.SignalBool     `via:"on,init=true"`
+	Hue via.Signal[string] `via:"hue,init=tomato"`
+}
+
+func (p *bindPage) View(ctx *via.CtxR) h.H {
+	return h.Main(h.ID("root"),
+		h.Button(h.ID("target"), h.Text("x"), p.On.Attr("disabled"), p.On.Class("active")),
+		h.Span(h.ID("styled"), p.Hue.Style("color"), h.Text("hue")),
+	)
+}
+
+// Signal.Attr/Class/Style emit Datastar attribute bindings. vt only sees the
+// rendered attribute string, so a wrong attribute syntax (e.g. the hyphen form
+// data-attr-disabled, which Datastar silently ignores) renders fine yet does
+// nothing. This drives the bindings in a real browser and asserts they ACTUALLY
+// apply — the regression guard for the colon-syntax fix.
+func TestBrowserSignalAttrClassStyleApply(t *testing.T) {
+	exec := chromePath()
+	if exec == "" {
+		t.Skip("no chromium/chrome binary found; set CHROME_PATH to run the browser test")
+	}
+
+	app := via.New(via.WithInsecureCookies())
+	via.Mount[bindPage](app, "/")
+	srv := vt.Serve(t, app)
+
+	allocCtx, cancelAlloc := chromedp.NewExecAllocator(context.Background(),
+		append(chromedp.DefaultExecAllocatorOptions[:],
+			chromedp.ExecPath(exec), chromedp.Headless, chromedp.DisableGPU, chromedp.NoSandbox,
+		)...)
+	defer cancelAlloc()
+	ctx, cancel := chromedp.NewContext(allocCtx)
+	defer cancel()
+	ctx, cancelTO := context.WithTimeout(ctx, 30*time.Second)
+	defer cancelTO()
+
+	var disabled, hasActive bool
+	var color string
+	err := chromedp.Run(ctx,
+		chromedp.Navigate(srv.URL+"/"),
+		chromedp.WaitVisible("#target", chromedp.ByID),
+		// Datastar applies the bindings on ready; wait until the attr binding lands.
+		waitJSTrue(`document.getElementById('target').hasAttribute('disabled')`),
+		chromedp.Evaluate(`document.getElementById('target').hasAttribute('disabled')`, &disabled),
+		chromedp.Evaluate(`document.getElementById('target').classList.contains('active')`, &hasActive),
+		chromedp.Evaluate(`getComputedStyle(document.getElementById('styled')).color`, &color),
+	)
+	if err != nil {
+		t.Fatalf("chromedp run: %v", err)
+	}
+	if !disabled {
+		t.Fatal("Signal.Attr(\"disabled\") did not apply — Datastar ignored the binding")
+	}
+	if !hasActive {
+		t.Fatal("Signal.Class(\"active\") did not apply — Datastar ignored the binding")
+	}
+	// tomato == rgb(255, 99, 71)
+	if color != "rgb(255, 99, 71)" {
+		t.Fatalf("Signal.Style(\"color\") did not apply: computed color = %q, want tomato", color)
+	}
+}

--- a/local.go
+++ b/local.go
@@ -63,7 +63,7 @@ func (l LocalSignal) ShowUnless() h.H { return h.Data("show", "!"+l.dollar) }
 
 // Class toggles the named CSS class by the signal's truthiness. See
 // [Signal.Class] for the lower-case attribute-name caveat.
-func (l LocalSignal) Class(name string) h.H { return h.Data("class-"+name, l.dollar) }
+func (l LocalSignal) Class(name string) h.H { return h.Data("class:"+name, l.dollar) }
 
 // Toggle returns an on:click attribute that flips a boolean local signal —
 // the canonical client-only toggle with no server round-trip.

--- a/local_test.go
+++ b/local_test.go
@@ -37,7 +37,7 @@ func TestLocal_rendersClientOnlySignalHelpers(t *testing.T) {
 		{"toggle flips the local signal", `data-on:click="$_open=!$_open"`},
 		{"show binds to $_open", `data-show="$_open"`},
 		{"show-unless negates", `data-show="!$_open"`},
-		{"class toggles by truthiness", `data-class-active="$_open"`},
+		{"class toggles by truthiness", `data-class:active="$_open"`},
 		{"text binds value", `data-text="$_open"`},
 		{"bind uses bare _name", `data-bind="_open"`},
 	}

--- a/signal.go
+++ b/signal.go
@@ -113,7 +113,7 @@ func (s *Signal[T]) ShowUnless() h.H {
 }
 
 // Class toggles the named CSS class on the host element by this signal's
-// truthiness, emitting Datastar's data-class-<name> attribute.
+// truthiness, emitting Datastar's data-class:<name> attribute.
 //
 // name must be lower-case (or kebab-case). HTML attribute names are folded to
 // lower-case by the browser parser, so a mixed-case name like "myThing"
@@ -121,10 +121,10 @@ func (s *Signal[T]) ShowUnless() h.H {
 // hyphen. For a camelCase class name use Datastar's object form via
 // h.DataClass with an explicit expression instead.
 func (s *Signal[T]) Class(name string) h.H {
-	return h.Data("class-"+name, s.dollar)
+	return h.Data("class:"+name, s.dollar)
 }
 
-// Attr returns a data-attr-<name> attribute that mirrors this signal's
+// Attr returns a data-attr:<name> attribute that mirrors this signal's
 // truthiness onto the host element's HTML attribute. Truthy → attribute
 // present (boolean form, e.g. `disabled`); falsy → attribute absent.
 // For string-valued attributes, the attribute value tracks the signal.
@@ -132,16 +132,16 @@ func (s *Signal[T]) Class(name string) h.H {
 //	h.Button(c.Saving.Attr("disabled"), h.Text("Save"))
 //	h.A(c.Target.Attr("href"), h.Text("Open"))
 func (s *Signal[T]) Attr(name string) h.H {
-	return h.Data("attr-"+name, s.dollar)
+	return h.Data("attr:"+name, s.dollar)
 }
 
-// Style returns a data-style-<prop> attribute that drives an inline CSS
+// Style returns a data-style:<prop> attribute that drives an inline CSS
 // property from this signal's stringified value. Pairs naturally with
 // `Signal[string]` carrying a colour, length, etc.
 //
 //	h.Div(c.Hue.Style("background-color"))
 func (s *Signal[T]) Style(prop string) h.H {
-	return h.Data("style-"+prop, s.dollar)
+	return h.Data("style:"+prop, s.dollar)
 }
 
 // Key returns the wire key (qualified field path). Useful in tests.

--- a/signal_test.go
+++ b/signal_test.go
@@ -139,8 +139,8 @@ func TestSignalClass_togglesNamedClassBySignalTruthiness(t *testing.T) {
 	via.Mount[signalToggleHelpersPage](app, "/")
 
 	body := getBody(t, server, "/")
-	assert.Contains(t, body, `data-class-active="$open"`,
-		"Class(name) should emit data-class-<name> bound to the signal")
+	assert.Contains(t, body, `data-class:active="$open"`,
+		"Class(name) should emit data-class:<name> bound to the signal")
 }
 
 type signalMixedCaseClassPage struct {
@@ -153,7 +153,7 @@ func (p *signalMixedCaseClassPage) View(ctx *via.CtxR) h.H {
 
 func TestSignalClass_emitsNameVerbatimButBrowserWillLowercaseIt(t *testing.T) {
 	t.Parallel()
-	// Class(name) emits data-class-<name> verbatim. The HTML attribute name is
+	// Class(name) emits data-class:<name> verbatim. The HTML attribute name is
 	// folded to lower-case by the browser parser before Datastar reads it, so a
 	// mixed-case name resolves to a lower-cased CSS class at runtime. This test
 	// pins the emitted attribute and documents that mixed-case names are a
@@ -163,7 +163,7 @@ func TestSignalClass_emitsNameVerbatimButBrowserWillLowercaseIt(t *testing.T) {
 	via.Mount[signalMixedCaseClassPage](app, "/")
 
 	body := getBody(t, server, "/")
-	assert.Contains(t, body, `data-class-myThing="$open"`,
+	assert.Contains(t, body, `data-class:myThing="$open"`,
 		"Class emits the name verbatim server-side; the browser lower-cases it to my-thing/mything at runtime")
 }
 
@@ -248,8 +248,8 @@ func TestSignal_Attr_rendersDataAttrSyntax(t *testing.T) {
 	server := vt.Serve(t, app)
 	via.Mount[attrStylePage](app, "/")
 	body := getBody(t, server, "/")
-	assert.Contains(t, body, `data-attr-disabled="$disabled"`,
-		"Signal.Attr(name) should emit Datastar's data-attr-<name>=\"$key\"")
+	assert.Contains(t, body, `data-attr:disabled="$disabled"`,
+		"Signal.Attr(name) should emit Datastar's data-attr:<name>=\"$key\"")
 }
 
 func TestSignal_Style_rendersDataStyleSyntax(t *testing.T) {
@@ -258,8 +258,8 @@ func TestSignal_Style_rendersDataStyleSyntax(t *testing.T) {
 	server := vt.Serve(t, app)
 	via.Mount[attrStylePage](app, "/")
 	body := getBody(t, server, "/")
-	assert.Contains(t, body, `data-style-color="$hue"`,
-		"Signal.Style(prop) should emit Datastar's data-style-<prop>=\"$key\"")
+	assert.Contains(t, body, `data-style:color="$hue"`,
+		"Signal.Style(prop) should emit Datastar's data-style:<prop>=\"$key\"")
 }
 
 type boolInitPage struct {


### PR DESCRIPTION
**Bug found by the in-browser verification campaign.**

`Signal.Attr`/`Class`/`Style` and `LocalSignal.Class` emitted `data-{attr,class,style}-NAME` (hyphen). Datastar v1.0.2 keys these plugins with a **colon** (`data-attr:disabled`) — the hyphen form is **silently ignored**, so the bindings rendered but never applied: `sig.Attr("disabled")` never disabled, `sig.Class("active")` never toggled, `sig.Style("color")` never colored.

`on.Click` already emits `data-on:click` (colon) and `h.DataClass` already emits `data-class:` — these four Signal helpers were the inconsistent odd ones out.

## How it escaped
`vt` only inspects the rendered attribute *string* and cannot execute Datastar, so the unit tests asserted the (wrong) hyphen output and stayed green on dead bindings — exactly the client-side blind spot the 1.0 council flagged.

## Verified in a real browser
Injected both forms into a live Datastar page: colon applied, hyphen ignored (attr **and** class **and** style). Fix + updated unit tests + a new browser-tagged regression test (`internal/browsertest`) that asserts attr/class/style **actually apply** in real Chromium — passes locally.

Go signatures unchanged (only emitted attribute string), so no apidiff baseline change. Full `ci-check.sh` green.