### PR TITLE
fix: reconnect banner never cleared after SSE reconnect

### DIFF
--- a/internal/browsertest/reconnect_browser_test.go
+++ b/internal/browsertest/reconnect_browser_test.go
@@ -49,7 +49,7 @@ func TestBrowserReconnectManager(t *testing.T) {
 
 	var installed bool
 	var bannerRetry, bannerFailed, reloadCount string
-	var connInitial, connRetry, connFailed string
+	var connInitial, connRetry, connAfterPatch, connFailed string
 	err := chromedp.Run(ctx,
 		chromedp.Navigate(srv.URL+"/"),
 		chromedp.WaitVisible("#root", chromedp.ByID),
@@ -67,6 +67,13 @@ func TestBrowserReconnectManager(t *testing.T) {
 		chromedp.Evaluate(`document.getElementById('via-reconnect-banner').textContent`, &bannerRetry),
 		chromedp.Evaluate(`document.documentElement.getAttribute('data-via-connection')`, &connRetry),
 
+		// (2b) An incoming SSE patch (reconnect re-bootstrap / heartbeat) must
+		// clear the banner and mark online — a real reconnect emits patch events
+		// but NOT started/finished, so this is the only reliable recovery signal.
+		chromedp.Evaluate(`document.dispatchEvent(new CustomEvent('datastar-patch-signals',{detail:{}}))`, nil),
+		waitJSTrue(`getComputedStyle(document.getElementById('via-reconnect-banner')).display==='none'`),
+		chromedp.Evaluate(`document.documentElement.getAttribute('data-via-connection')`, &connAfterPatch),
+
 		// (3) retries-failed arms the bounded reload AND marks the connection offline.
 		// Read the counter immediately, before the jittered reload timer fires.
 		chromedp.Evaluate(`document.dispatchEvent(new CustomEvent('datastar-fetch',{detail:{type:'retries-failed'}}))`, nil),
@@ -81,9 +88,9 @@ func TestBrowserReconnectManager(t *testing.T) {
 	if !installed {
 		t.Fatal("reconnect manager did not install — Datastar did not evaluate the injected data-init")
 	}
-	if connInitial != "online" || connRetry != "connecting" || connFailed != "offline" {
-		t.Fatalf("data-via-connection lifecycle = %q/%q/%q, want online/connecting/offline",
-			connInitial, connRetry, connFailed)
+	if connInitial != "online" || connRetry != "connecting" || connAfterPatch != "online" || connFailed != "offline" {
+		t.Fatalf("data-via-connection lifecycle = %q/%q/%q/%q, want online/connecting/online/offline",
+			connInitial, connRetry, connAfterPatch, connFailed)
 	}
 	if bannerRetry != "Reconnecting..." {
 		t.Fatalf("retrying banner = %q, want %q", bannerRetry, "Reconnecting...")

--- a/reconnect.go
+++ b/reconnect.go
@@ -13,6 +13,12 @@ package via
 //     frozen forever). Reload to re-bootstrap a fresh stream + session, after a
 //     jittered delay so a fleet of tabs doesn't stampede the new pod at once.
 //
+// It also clears the banner on any incoming SSE patch (datastar-patch-elements
+// / datastar-patch-signals): a long-lived SSE stream fires 'retrying' on a drop
+// but emits NO 'started'/'finished' on a successful resume, so an arrived patch
+// (the reconnect re-bootstrap, or via's periodic heartbeat) is the only
+// reliable "stream is alive again" signal. Without it the banner stays stuck.
+//
 // It also publishes connection status as a data-via-connection attribute on the
 // <html> element — "online", "connecting", or "offline" — so an app can style
 // its OWN connection UI in CSS (e.g. html[data-via-connection="offline"] .banner
@@ -34,9 +40,16 @@ const reconnectInit = `(()=>{if(window.__viaRC)return;window.__viaRC=1;` +
 	`background:#b45309;color:#fff';(document.body||document.documentElement).appendChild(b)}` +
 	`b.textContent=m;b.style.display='block'}` +
 	`function hide(){if(b)b.style.display='none'}` +
+	`function ok(){conn('online');hide()}` +
+	// An incoming SSE patch (the re-bootstrap on reconnect, or via's periodic
+	// heartbeat) is the only reliable "stream is alive again" signal: a
+	// long-lived SSE @get fires 'retrying' on a drop but NO 'started'/'finished'
+	// on a successful resume, so clearing on those alone leaves the banner stuck.
+	`document.addEventListener('datastar-patch-elements',ok);` +
+	`document.addEventListener('datastar-patch-signals',ok);` +
 	`document.addEventListener('datastar-fetch',function(e){var t=e.detail&&e.detail.type;` +
 	`if(t==='retrying'){conn('connecting');show('Reconnecting...')}` +
-	`else if(t==='started'||t==='finished'){conn('online');hide()}` +
+	`else if(t==='started'||t==='finished'){ok()}` +
 	`else if(t==='retries-failed'){conn('offline');var n=0;try{n=+(sessionStorage.getItem(K)||0)}catch(_){}` +
 	`if(n>=3){show('Connection lost. Please refresh the page.');return}` +
 	`show('Connection lost - reconnecting...');try{sessionStorage.setItem(K,n+1)}catch(_){}` +

--- a/reconnect_test.go
+++ b/reconnect_test.go
@@ -32,6 +32,8 @@ func TestReconnect_scriptInjectedByDefault(t *testing.T) {
 		"it must react to Datastar's retries-failed (the stream is dead)")
 	assert.Contains(t, strings.ToLower(html), "reload",
 		"on retries-failed it must reload to re-bootstrap the stream")
+	assert.Contains(t, html, "datastar-patch-signals",
+		"it must clear on an incoming SSE patch — the only reliable reconnect signal")
 }
 
 // The reconnect manager must also publish connection status as a


### PR DESCRIPTION
**Second bug found by the in-browser verification campaign** (and worse than the first).

The reconnect manager (#122/#126) cleared the "Reconnecting…" banner / reset `data-via-connection` to `online` only on `datastar-fetch` **started/finished**. But a long-lived SSE `@get` stream fires **only `retrying`** when it drops — **no started/finished** on a successful resume. So after a *real* reconnect the banner stayed stuck "Reconnecting…" and the attribute stuck "connecting" **forever**, even though patches were flowing again. (Verified live: killed the server, watched it reconnect — `local` re-bootstrapped to fresh state while the banner never cleared.)

## Fix
Clear on incoming SSE **patch** events (`datastar-patch-elements` / `datastar-patch-signals`) — an arrived patch (the reconnect re-bootstrap, or via's 25s heartbeat) is the only reliable "stream alive again" signal for a streaming fetch.

## Why it escaped the chromedp test
The browser test dispatched **synthetic** started/finished events, so it exercised a path that doesn't occur on a real reconnect. The test now dispatches a patch event and asserts the banner clears + connection returns to online (online→connecting→online→offline lifecycle).

Full `ci-check.sh` green; browser test passes locally.