### PR TITLE
docs: correct Broadcast cross-pod claim + event-versioning deploy note

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,11 @@ typed `Op(ctx)` verbs (`Add`, `Toggle`, `Append`, …).
   best for internal tools, dashboards, and line-of-business apps you'd
   otherwise build with LiveView, Hotwire, or htmx + hand-written JS.
 - **Is not** an SPA framework — the browser receives HTML, not a JSON bundle.
-- **Single-process by default** — `StateApp[T]` and `Broadcast` are per-pod;
-  horizontal scaling needs sticky sessions. Cross-instance state convergence
-  (`WithBackplane`) is in preview; `Broadcast` stays pod-local.
+- **Single-process by default** — without a backplane `StateApp[T]` and
+  `Broadcast` are per-pod and horizontal scaling needs sticky sessions.
+  `WithBackplane` (in preview) converges `StateApp` state across pods and fans
+  `Broadcast` out to every pod's tabs; both inherit the backplane's pre-1.0
+  status.
 - **Is not** offline-first or stable yet — drop the SSE stream and the tab
   freezes until the client reconnects (transient drops retry automatically; a
   clean-close deploy may fall back to a reload), and APIs can still shift pre-1.0.

--- a/docs/distributed-state.md
+++ b/docs/distributed-state.md
@@ -20,9 +20,10 @@ every pod *and* survives a restart — the typed API from
 
 {: .warning }
 The backplane is in **preview** on the way to 1.0. It is **eventually
-consistent**: no global ordering across keys, no cross-key transactions, and
-cross-tab [`Broadcast`](production#cross-tab-broadcast) stays pod-local. Treat
-single-process as the supported topology until it ships.
+consistent**: no global ordering across keys and no cross-key transactions.
+With a backplane wired, cross-tab [`Broadcast`](production#cross-tab-broadcast)
+fans out to every pod (ephemeral, best-effort); without one it is pod-local.
+Treat single-process as the supported topology until the backplane ships.
 
 ## The two patterns
 
@@ -218,8 +219,11 @@ log never truncates a slow peer.
 - **No global ordering.** Events are totally ordered *per key*, not across keys.
 - **Not strongly consistent.** Reads can lag the latest append by a reconcile
   hop. Don't gate a safety-critical invariant on it.
-- **Broadcast stays pod-local.** `Broadcast` / `BroadcastSignals` reach only the
-  tabs on the calling pod.
+- **Broadcast is pod-local without a backplane.** `Broadcast` /
+  `BroadcastSignals` reach only the calling pod's tabs unless `WithBackplane` is
+  wired, in which case they ride the shared feed to every pod (ephemeral and
+  best-effort — no replay, no convergence). The returned count is always just
+  the calling pod's live-tab count.
 - **Tabs and sessions are still in-memory.** The backplane converges *state*; a
   process restart still re-bootstraps live tabs — see
   [Restart and tab survivability](production#restart-and-tab-survivability).

--- a/docs/production.md
+++ b/docs/production.md
@@ -230,6 +230,19 @@ For session survivability, persist the `sess.Put`-stored payload (e.g. a JWT
 or opaque token) to a database keyed by the `via_session` cookie value, and
 rehydrate inside an `OnInit` hook.
 
+### Rolling deploys and event versioning
+
+`StateAppEvents` is roll-forward-only. During a rolling deploy two binaries read
+the same log: the new one writes events at a new envelope version, and the old
+one **halts** that key's projector rather than mis-fold an event it doesn't
+understand (`via.events.forward_incompatible`). That's a deliberate guard, not a
+bug — but it means you don't roll *back* past a new event version. To evolve an
+event's shape safely, add a new version with `via.RegisterEvent` + an upcaster
+so every binary can decode old and new records, deploy that everywhere, and only
+then start writing the new shape. A projector that halts on
+`via.events.forward_incompatible` clears once the lagging binary is rolled
+forward.
+
 ## Performance
 
 Benchmarks: `bench_test.go` (full request → SSE turn) and


### PR DESCRIPTION
Re-review sore spot **S1** (the #1 trust fix) + **S9**.

- **S1:** README:116 and distributed-state.md:24,221 said Broadcast "stays pod-local", but `broadcast.go` fans it out cross-pod when `WithBackplane` is wired (its own godoc was already correct). Fixed all three to the true conditional: pod-local without a backplane, cross-pod (ephemeral/best-effort) with one.
- **S9:** added a "Rolling deploys and event versioning" note — `StateAppEvents` is roll-forward-only (forward-incompat HALT is by design); evolve via `RegisterEvent`+upcaster deployed everywhere first.
- Verified the **metrics catalogue is already complete** — the panel's "missing 4 metrics" was stale (all present; `via.broadcast`/`via.changes` are stream keys, not metrics). No change.

Docs only.