### PR TITLE
fix: cancellation/teardown hardening sweep

### DIFF
--- a/app.go
+++ b/app.go
@@ -86,6 +86,13 @@ type App struct {
 	stopSweep     chan struct{}
 	stopSweepOnce sync.Once
 
+	// bgWG tracks every long-lived background goroutine the app spawns — the
+	// projector, consumer, changes/broadcast tailers, and the TTL sweepers.
+	// Shutdown waits on it (bounded by the shutdown ctx) AFTER cancelling the
+	// backplane context and closing stopSweep, so a graceful drain does not
+	// return while those goroutines are still touching app state.
+	bgWG sync.WaitGroup
+
 	// backplaneDone is closed at the START of Shutdown, BEFORE backplane.Close,
 	// so the projector/consumer tailers can tell a graceful stop (exit) from a
 	// transient mid-stream disconnect (re-subscribe from the cursor and
@@ -449,12 +456,15 @@ func New(opts ...Option) *App {
 	if a.cfg.sessionTTL > 0 || a.cfg.contextTTL > 0 || a.cfg.reconcileInterval > 0 {
 		a.stopSweep = make(chan struct{})
 		if a.cfg.sessionTTL > 0 {
+			a.bgWG.Add(1)
 			go a.runSweep(a.cfg.sessionTTL/2, time.Millisecond, a.removeExpiredSessions)
 		}
 		if a.cfg.contextTTL > 0 {
+			a.bgWG.Add(1)
 			go a.runSweep(a.cfg.contextTTL/2, time.Second, a.removeExpiredContexts)
 		}
 		if a.cfg.reconcileInterval > 0 {
+			a.bgWG.Add(1)
 			go a.runSweep(a.cfg.reconcileInterval, a.cfg.reconcileInterval, a.reconcileValues)
 		}
 	}

--- a/appval.go
+++ b/appval.go
@@ -135,7 +135,10 @@ func (a *App) reconcileSessionKey(sess *session, key string) {
 	if decode == nil {
 		return
 	}
-	data, storeRev, ok, _ := a.backplane.LoadSnapshot(a.backplaneCtx, sessValKey(sess.id, key))
+	data, storeRev, ok, err := a.backplane.LoadSnapshot(a.backplaneCtx, sessValKey(sess.id, key))
+	if err != nil {
+		a.logWarn(nil, "via: backplane LoadSnapshot failed reconciling session key %q: %v", key, err)
+	}
 	if !ok || storeRev <= sess.loadRev(key) {
 		return
 	}
@@ -158,7 +161,10 @@ func (a *App) reconcileKey(key string) {
 	if vc == nil {
 		return
 	}
-	data, storeRev, ok, _ := a.backplane.LoadSnapshot(a.backplaneCtx, valKey(key))
+	data, storeRev, ok, err := a.backplane.LoadSnapshot(a.backplaneCtx, valKey(key))
+	if err != nil {
+		a.logWarn(nil, "via: backplane LoadSnapshot failed reconciling key %q: %v", key, err)
+	}
 	vc.mu.Lock()
 	changed := false
 	if ok && storeRev > vc.l1Rev {
@@ -180,18 +186,29 @@ func (a *App) reconcileKey(key string) {
 func (a *App) startChangesTailer() {
 	ch, err := a.backplane.Subscribe(a.backplaneCtx, changesKey, 0)
 	if err != nil {
+		a.logWarn(nil, "via: backplane subscribe failed for changes tailer: %v", err)
 		return
 	}
+	a.bgWG.Add(1)
 	go func() {
-		for rec := range ch {
-			var c change
-			if json.Unmarshal(rec.Data, &c) != nil {
-				continue
-			}
-			if c.Sid == "" {
-				a.applyChange(c) // app-scoped value
-			} else {
-				a.applySessionChange(c) // session-scoped value
+		defer a.bgWG.Done()
+		for {
+			select {
+			case rec, ok := <-ch:
+				if !ok {
+					return
+				}
+				var c change
+				if json.Unmarshal(rec.Data, &c) != nil {
+					continue
+				}
+				if c.Sid == "" {
+					a.applyChange(c) // app-scoped value
+				} else {
+					a.applySessionChange(c) // session-scoped value
+				}
+			case <-a.backplaneDone:
+				return // graceful stop: don't wait for a slow backend to close ch
 			}
 		}
 	}()
@@ -217,7 +234,10 @@ func (a *App) applySessionChange(c change) {
 	if decode == nil {
 		return
 	}
-	data, storeRev, dok, _ := a.backplane.LoadSnapshot(a.backplaneCtx, sessValKey(c.Sid, c.Key))
+	data, storeRev, dok, err := a.backplane.LoadSnapshot(a.backplaneCtx, sessValKey(c.Sid, c.Key))
+	if err != nil {
+		a.logWarn(nil, "via: backplane LoadSnapshot failed applying session change for key %q: %v", c.Key, err)
+	}
 	if !dok || storeRev < c.Rev {
 		return // stale replica: never surface a value older than the hint promised
 	}
@@ -259,7 +279,10 @@ func (a *App) applyChangeL1(c change) bool {
 	if c.Rev <= vc.l1Rev {
 		return false
 	}
-	data, storeRev, ok, _ := a.backplane.LoadSnapshot(a.backplaneCtx, valKey(c.Key))
+	data, storeRev, ok, err := a.backplane.LoadSnapshot(a.backplaneCtx, valKey(c.Key))
+	if err != nil {
+		a.logWarn(nil, "via: backplane LoadSnapshot failed applying change for key %q: %v", c.Key, err)
+	}
 	if !ok || storeRev < c.Rev || storeRev <= vc.l1Rev {
 		return false
 	}

--- a/backoff.go
+++ b/backoff.go
@@ -1,6 +1,7 @@
 package via
 
 import (
+	"context"
 	"math/rand/v2"
 	"time"
 )
@@ -33,11 +34,18 @@ func casBackoffCeiling(attempt int) time.Duration {
 }
 
 // casSleep waits a jittered duration in [0, ceiling) before the next CAS retry,
-// so concurrent retriers de-correlate instead of colliding in lockstep.
-func casSleep(attempt int) {
+// so concurrent retriers de-correlate instead of colliding in lockstep. It
+// returns early if ctx is cancelled — a contended Update mid-retry must not add
+// up to the ceiling to a shutdown drain.
+func casSleep(ctx context.Context, attempt int) {
 	ceiling := casBackoffCeiling(attempt)
 	if ceiling <= 0 {
 		return
 	}
-	time.Sleep(time.Duration(rand.Int64N(int64(ceiling))))
+	t := time.NewTimer(time.Duration(rand.Int64N(int64(ceiling))))
+	defer t.Stop()
+	select {
+	case <-t.C:
+	case <-ctx.Done():
+	}
 }

--- a/backoff_internal_test.go
+++ b/backoff_internal_test.go
@@ -1,6 +1,7 @@
 package via
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -43,7 +44,24 @@ func TestCasSleep_staysWithinCeiling(t *testing.T) {
 	// casSleep must never block longer than the cap — bound the worst case so
 	// a contended Update can't stall an action for an unbounded time.
 	start := time.Now()
-	casSleep(99)
+	casSleep(context.Background(), 99)
 	assert.Less(t, time.Since(start), casBackoffCap+50*time.Millisecond,
 		"a single backoff sleep stays bounded by the cap (plus scheduler slack)")
+}
+
+// A contended Update backs off between CAS retries; if the app is shutting down
+// mid-retry that backoff must abort the instant the backplane context is
+// cancelled rather than adding up to the cap to the drain. casSleep selects on
+// ctx.Done so the worst case under cancellation is ~scheduler slack, not the
+// jittered ceiling.
+func TestCasSleep_returnsPromptlyWhenCtxCancelled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled before the call
+
+	start := time.Now()
+	casSleep(ctx, 99)
+	assert.Less(t, time.Since(start), 5*time.Millisecond,
+		"an already-cancelled context must short-circuit the backoff sleep, not wait out the ceiling")
 }

--- a/backplane_context_test.go
+++ b/backplane_context_test.go
@@ -2,6 +2,8 @@ package via_test
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -102,6 +104,97 @@ func TestShutdownCancelsInflightBackplaneContext(t *testing.T) {
 		"Shutdown must cancel the context handed to in-flight EventLog.Subscribe")
 	assert.ErrorIs(t, snap.Err(), context.Canceled,
 		"Shutdown must cancel the context handed to in-flight Store.LoadSnapshot")
+}
+
+// blockingSubBackplane wraps a real in-memory backplane but hands out a
+// Subscribe channel that never closes on its own — it only unblocks the reader
+// when the call's context is cancelled. This models a backend that does NOT
+// promptly close the channel on shutdown, the case a naive `for rec := range ch`
+// projector would hang on. The runtime must (a) wake the loop on ctx.Done and
+// (b) bound the Shutdown wait so a stuck goroutine can never wedge the drain.
+type blockingSubBackplane struct {
+	via.Backplane
+}
+
+func (b *blockingSubBackplane) Subscribe(ctx context.Context, _ string, _ via.Offset) (<-chan via.Record, error) {
+	ch := make(chan via.Record)
+	go func() {
+		<-ctx.Done()
+		// Deliberately do NOT close(ch): a `range ch` would block forever here.
+	}()
+	return ch, nil
+}
+
+// A backend whose Subscribe channel never closes must not be able to wedge
+// Shutdown: the projector loop wakes on its context being cancelled and exits,
+// and Shutdown's wait for background goroutines is bounded by the shutdown ctx
+// regardless. Either property alone keeps the drain prompt; this asserts the
+// observable contract — Shutdown returns well within its deadline.
+func TestShutdownDoesNotHangOnNonClosingSubscribe(t *testing.T) {
+	t.Parallel()
+
+	bp := &blockingSubBackplane{Backplane: via.InMemory()}
+	app := via.New(via.WithBackplane(bp))
+	server := vt.Serve(t, app)
+	via.Mount[bpCtxPage](app, "/")
+	_ = vt.NewClient(t, server, "/") // spawns the per-key projector
+
+	// Give the projector a moment to enter its Subscribe range loop.
+	time.Sleep(50 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		_ = app.Shutdown(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Shutdown hung on a non-closing Subscribe channel; the bounded wait did not fire")
+	}
+	require.NoError(t, ctx.Err(),
+		"Shutdown must return before its own deadline, proving the wait is prompt not merely bounded")
+}
+
+// subscribeErrBackplane fails every Subscribe so the projector's
+// subscribe-failure branch fires. Other calls delegate to a real in-memory
+// backplane so the page still mounts.
+type subscribeErrBackplane struct {
+	via.Backplane
+}
+
+func (b *subscribeErrBackplane) Subscribe(context.Context, string, via.Offset) (<-chan via.Record, error) {
+	return nil, errors.New("boom: subscribe rejected")
+}
+
+// A dropped backplane error used to vanish silently, so an operator saw state
+// divergence with no cause in the logs. The runtime must WARN-log a Subscribe
+// failure (with a stable, greppable prefix) before the goroutine returns.
+func TestProjectorLogsSubscribeFailure(t *testing.T) {
+	t.Parallel()
+
+	logger := &captureLogger{}
+	bp := &subscribeErrBackplane{Backplane: via.InMemory()}
+	app := via.New(via.WithBackplane(bp), via.WithLogger(logger), via.WithLogLevel(via.LogWarn))
+	server := vt.Serve(t, app)
+	via.Mount[bpCtxPage](app, "/")
+	_ = vt.NewClient(t, server, "/") // spawns the projector → Subscribe fails
+
+	require.Eventually(t, func() bool {
+		for _, r := range logger.snapshot() {
+			if r.level == via.LogWarn && strings.Contains(r.msg, "via: backplane subscribe failed") {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 5*time.Millisecond,
+		"a swallowed Subscribe error must surface as a greppable WARN, not vanish")
+
+	require.NoError(t, app.Shutdown(context.Background()))
 }
 
 type bpWritePage struct {

--- a/broadcast.go
+++ b/broadcast.go
@@ -100,7 +100,9 @@ func (a *App) BroadcastSignals(values map[string]any) int {
 func (a *App) dispatchBroadcast(rec broadcastRecord) int {
 	if a.cfg.backplane != nil {
 		if b, err := json.Marshal(rec); err == nil {
-			_, _ = a.backplane.Append(a.backplaneCtx, broadcastKey, b)
+			if _, err := a.backplane.Append(a.backplaneCtx, broadcastKey, b); err != nil {
+				a.logWarn(nil, "via: backplane Append failed dispatching broadcast: %v", err)
+			}
 		}
 		return len(a.snapshotContexts())
 	}
@@ -134,19 +136,31 @@ func (a *App) startBroadcastTailer() {
 	bg := a.backplaneCtx
 	head, _, err := a.backplane.Head(bg, broadcastKey)
 	if err != nil {
+		a.logWarn(nil, "via: backplane Head failed starting broadcast tailer: %v", err)
 		return
 	}
 	ch, err := a.backplane.Subscribe(bg, broadcastKey, head)
 	if err != nil {
+		a.logWarn(nil, "via: backplane subscribe failed for broadcast tailer: %v", err)
 		return
 	}
+	a.bgWG.Add(1)
 	go func() {
-		for rec := range ch {
-			var r broadcastRecord
-			if json.Unmarshal(rec.Data, &r) != nil {
-				continue
+		defer a.bgWG.Done()
+		for {
+			select {
+			case rec, ok := <-ch:
+				if !ok {
+					return
+				}
+				var r broadcastRecord
+				if json.Unmarshal(rec.Data, &r) != nil {
+					continue
+				}
+				a.applyBroadcast(r)
+			case <-a.backplaneDone:
+				return // graceful stop: don't wait for a slow backend to close ch
 			}
-			a.applyBroadcast(r)
 		}
 	}()
 }

--- a/onevent.go
+++ b/onevent.go
@@ -257,18 +257,34 @@ func (a *App) registerConsumer(name, key string, cfg consumerConfig, deliver fun
 // exits when the backplane closes (Subscribe returns ErrClosed or the channel
 // closes).
 func (a *App) startConsumer(name, key string, cs *consumerState, cfg consumerConfig, deliver func(context.Context, []byte, Offset) (deliverOutcome, error)) {
+	a.bgWG.Add(1)
 	go func() {
+		defer a.bgWG.Done()
 		for {
 			from, _ := cs.snapshot()
 			subCtx, cancel := context.WithCancel(a.backplaneCtx)
 			ch, err := a.backplane.Subscribe(subCtx, key, from)
 			if err != nil {
 				cancel()
+				a.logWarn(nil, "via: backplane subscribe failed for consumer %q key %q: %v", name, key, err)
 				return // backplane closed
 			}
 			retry := false
 		consume:
-			for rec := range ch {
+			for {
+				var rec Record
+				var ok bool
+				// Wake on backplaneDone so teardown is prompt even against a
+				// backend that does not close the channel on ctx cancel.
+				select {
+				case rec, ok = <-ch:
+					if !ok {
+						break consume // channel closed: transient disconnect or graceful stop
+					}
+				case <-a.backplaneDone:
+					cancel()
+					return // graceful stop: don't wait for a slow backend to close ch
+				}
 				if committed, _ := cs.snapshot(); rec.Offset <= committed {
 					continue // already handled (a peer advanced the shared offset)
 				}

--- a/runtime.go
+++ b/runtime.go
@@ -287,6 +287,7 @@ func enqueueScript(ctx *Ctx, s string) {
 // and context expirers — the only thing that varies is the cadence and
 // the per-tick action. interval ≤ 0 falls back to the supplied default.
 func (a *App) runSweep(interval, fallback time.Duration, sweep func()) {
+	defer a.bgWG.Done()
 	if interval <= 0 {
 		interval = fallback
 	}

--- a/server.go
+++ b/server.go
@@ -145,7 +145,27 @@ func (a *App) Shutdown(ctx context.Context) error {
 		a.backplaneCancel()
 	}
 	if a.backplane != nil {
-		_ = a.backplane.Close()
+		if err := a.backplane.Close(); err != nil {
+			a.logWarn(nil, "via: backplane Close failed during shutdown: %v", err)
+		}
+	}
+
+	// Wait for every long-lived background goroutine (projector, consumer,
+	// changes/broadcast tailers, TTL sweepers) to observe the stop and exit, so
+	// Shutdown does not return while they still touch app state. The cancel +
+	// Close + stopSweep close above MUST precede this wait or it would deadlock.
+	// The wait is bounded by ctx: a goroutine wedged on a backend that ignores
+	// cancellation cannot hang the drain past its deadline — a leaked goroutine
+	// is strictly better than a hung shutdown.
+	bgDone := make(chan struct{})
+	go func() {
+		a.bgWG.Wait()
+		close(bgDone)
+	}()
+	select {
+	case <-bgDone:
+	case <-ctx.Done():
+		a.logWarn(nil, "via: shutdown deadline reached before background goroutines drained: %v", ctx.Err())
 	}
 
 	return srvErr

--- a/stateapp.go
+++ b/stateapp.go
@@ -116,8 +116,8 @@ func (a *StateApp[T]) Update(ctx *Ctx, fn func(T) (T, error)) error {
 		}
 		newRev, err := app.backplane.CAS(bg, valKey(a.wireKey), rev, enc)
 		if errors.Is(err, ErrCASConflict) {
-			casSleep(try) // jittered backoff so contenders don't spin in lockstep
-			continue      // someone else wrote; reload and re-run fn
+			casSleep(bg, try) // jittered backoff so contenders don't spin in lockstep
+			continue          // someone else wrote; reload and re-run fn
 		}
 		if err != nil {
 			return err

--- a/stateappevents_projector.go
+++ b/stateappevents_projector.go
@@ -80,7 +80,9 @@ func (a *App) registerLog(key string, seed any, fold func(any, []byte) (any, err
 // Shutdown).
 func (a *App) startProjector(key string, ls *logState) {
 	from := a.coldStartFrom(ls, key)
+	a.bgWG.Add(1)
 	go func() {
+		defer a.bgWG.Done()
 		// Reconnect loop: each Subscribe tails until its channel closes. A close
 		// while the app is still running is a TRANSIENT disconnect (the backend
 		// dropped the consumer, the stream survives) — re-subscribe from the
@@ -90,16 +92,30 @@ func (a *App) startProjector(key string, ls *logState) {
 		for {
 			ch, err := a.backplane.Subscribe(a.backplaneCtx, key, from)
 			if err != nil {
+				a.logWarn(nil, "via: backplane subscribe failed for projector key %q: %v", key, err)
 				return // ErrClosed (or unrecoverable) → stop
 			}
-			// Keep ranging the channel even once halted, so the backplane's
-			// Subscribe sender never blocks (no goroutine leak); just stop folding.
-			for rec := range ch {
-				if a.applyRecord(ls, key, rec) {
-					// skip=nil: the projector holds no action ctx. sess=nil: app-wide.
-					a.broadcastRender(nil, nil, key)
-					a.emitFoldDigest(ls, key)
-					a.maybeSnapshot(ls, key)
+			// Range the channel, but also wake on backplaneDone so teardown is
+			// prompt even against a backend that does not close the channel on
+			// ctx cancel. On a graceful stop we exit immediately; the inmemory
+			// backend still closes ch so its sender never blocks.
+			halted := false
+			for {
+				select {
+				case rec, ok := <-ch:
+					if !ok {
+						halted = true
+					} else if a.applyRecord(ls, key, rec) {
+						// skip=nil: the projector holds no action ctx. sess=nil: app-wide.
+						a.broadcastRender(nil, nil, key)
+						a.emitFoldDigest(ls, key)
+						a.maybeSnapshot(ls, key)
+					}
+				case <-a.backplaneDone:
+					return // graceful stop: don't wait for a slow backend to close ch
+				}
+				if halted {
+					break
 				}
 			}
 			if a.shuttingDown() {

--- a/statesess.go
+++ b/statesess.go
@@ -120,7 +120,7 @@ func (s *StateSess[T]) Update(ctx *Ctx, fn func(T) (T, error)) error {
 		}
 		newRev, err := app.backplane.CAS(bg, cellKey, rev, enc)
 		if errors.Is(err, ErrCASConflict) {
-			casSleep(try) // jittered backoff so contenders don't spin in lockstep
+			casSleep(bg, try) // jittered backoff so contenders don't spin in lockstep
 			continue
 		}
 		if err != nil {


### PR DESCRIPTION
Four related hardening items from an adversarial re-review of the shutdown/teardown path. Conservative throughout — a teardown that hangs is worse than the issues fixed, so every new wait is **bounded** and the cancel/close happens **before** the wait (no new deadlock).

## Items

1. **S4 — wait for background goroutines on shutdown.** New `App.bgWG`. The projector, consumer, changes/broadcast tailers and the three TTL sweepers each `bgWG.Add(1)` at spawn + `defer bgWG.Done()`. `Shutdown` waits on `bgWG` **after** `backplaneCancel()` + `backplane.Close()` + closing `stopSweep` (so the goroutines observe the stop and exit), and the wait is **bounded by the shutdown ctx** via a `done`-chan + `select { case <-done: case <-ctx.Done(): }`. A goroutine wedged on a backend that ignores cancellation cannot hang the drain past its deadline — a leaked goroutine is strictly better than a hung shutdown.

2. **S3 — prompt Subscribe teardown regardless of backend.** The projector/consumer/changes/broadcast loops now `select` on the record channel **and** `backplaneDone`, so teardown is prompt even against a backend that doesn't close the channel on ctx cancel. Reconnect-on-transient-close semantics are unchanged (a real channel close still re-subscribes from the cursor).

3. **S10 — ctx-aware CAS backoff.** `casSleep` now takes a `context.Context` and `select`s on `ctx.Done()`, so a contended `StateApp`/`StateSess.Update` mid-retry aborts the backoff the instant the backplane ctx is cancelled instead of adding up to ~10ms to the drain. Threaded `app.backplaneCtx` from both Update call sites.

4. **Theme-1 — surface swallowed backplane errors.** WARN-log (greppable `via: backplane …` prefix) the previously dropped errors: `backplane.Close` in Shutdown; Subscribe/Head failure before a tailer goroutine returns; the broadcast `Append` error; the reconcile/applyChange `LoadSnapshot` errors in appval.go. Control flow unchanged; the `ok=false` non-error case still does **not** log.

## Tested vs. couldn't

Covered by tests:
- **S10** — `casSleep` returns promptly when the ctx is already cancelled (internal test); existing within-ceiling bound test updated to the new signature.
- **S4** — `Shutdown` does not hang on a backend whose Subscribe channel never closes, and returns before its own deadline (proves the bounded wait + the S3 ctx.Done wake).
- **Theme-1** — a failing-Subscribe stub backplane surfaces the greppable WARN through a capturing Logger.
- Existing backplane-context cancellation tests (`TestShutdownCancelsInflight…`, `…WritePathContext`) stay green.

Implemented but not directly unit-tested (asserted via the full -race suite + existing conformance/backplanetest, not a bespoke test): the per-loop `backplaneDone` wake on the consumer/changes/broadcast tailers in isolation, and each individual LoadSnapshot/Append/Close WARN site beyond the projector-subscribe one. These are log-only / control-flow-preserving changes verified by the existing suite staying green.

## No deadlock + bounded shutdown

`backplaneCancel()` + `Close()` + `close(stopSweep)` all run **before** `bgWG.Wait()`, so every tracked goroutine can observe its stop signal first; the wait itself is wrapped in a ctx-bounded `select`. Verified `Shutdown(context.Background())` (no deadline) still completes because all goroutines exit on `backplaneDone`/`stopSweep`.

## CI

`./ci-check.sh` green: gofmt, vet, golangci-lint, govulncheck, API-compat baselines, `-race` across all packages, and the allocation gates (CounterRender 183/185, Action 137/149, ActionWithLogger 137/149 — unchanged).