### PR TITLE
fix: reconnect-banner aria-live + nil-CtxR Read guard

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -122,7 +122,16 @@ type readCtx interface {
 }
 
 func (ctx *Ctx) rctx() *Ctx { return ctx }
-func (r *CtxR) rctx() *Ctx  { return r.ctx }
+
+// rctx guards a nil receiver so a hand-constructed typed-nil *CtxR passed to a
+// Read returns the zero value (every Read nil-checks the result) rather than
+// panicking here — consistent with CtxR's other accessors that already guard.
+func (r *CtxR) rctx() *Ctx {
+	if r == nil {
+		return nil
+	}
+	return r.ctx
+}
 
 // ID returns the tab id (the wire key for via_tab). Mirrors Ctx.ID.
 func (r *CtxR) ID() string {

--- a/ctxr_nilguard_test.go
+++ b/ctxr_nilguard_test.go
@@ -1,0 +1,25 @@
+package via_test
+
+import (
+	"testing"
+
+	"github.com/go-via/via"
+	"github.com/stretchr/testify/assert"
+)
+
+// A hand-constructed typed-nil *CtxR handed to a Read must return the zero value,
+// not panic — CtxR's accessors guard a nil receiver consistently.
+func TestRead_nilCtxRReturnsZeroWithoutPanic(t *testing.T) {
+	t.Parallel()
+
+	var app via.StateApp[int]
+	var sess via.StateSess[string]
+	nilR := (*via.CtxR)(nil)
+
+	assert.NotPanics(t, func() { _ = app.Read(nilR) },
+		"StateApp.Read(nil *CtxR) must not panic")
+	assert.NotPanics(t, func() { _ = sess.Read(nilR) },
+		"StateSess.Read(nil *CtxR) must not panic")
+	assert.Equal(t, 0, app.Read(nilR), "nil CtxR yields the zero value")
+	assert.Equal(t, "", sess.Read(nilR), "nil CtxR yields the zero value")
+}

--- a/reconnect.go
+++ b/reconnect.go
@@ -35,7 +35,7 @@ const reconnectInit = `(()=>{if(window.__viaRC)return;window.__viaRC=1;` +
 	`function conn(s){document.documentElement.setAttribute('data-via-connection',s)}` +
 	`conn('online');` +
 	`function show(m){if(!b){b=document.createElement('div');b.id='via-reconnect-banner';` +
-	`b.setAttribute('role','status');b.style.cssText='position:fixed;top:0;left:0;right:0;` +
+	`b.setAttribute('role','status');b.setAttribute('aria-live','polite');b.style.cssText='position:fixed;top:0;left:0;right:0;` +
 	`z-index:2147483647;padding:.5rem 1rem;text-align:center;font:14px system-ui,sans-serif;` +
 	`background:#b45309;color:#fff';(document.body||document.documentElement).appendChild(b)}` +
 	`b.textContent=m;b.style.display='block'}` +

--- a/reconnect_test.go
+++ b/reconnect_test.go
@@ -34,6 +34,8 @@ func TestReconnect_scriptInjectedByDefault(t *testing.T) {
 		"on retries-failed it must reload to re-bootstrap the stream")
 	assert.Contains(t, html, "datastar-patch-signals",
 		"it must clear on an incoming SSE patch — the only reliable reconnect signal")
+	assert.Contains(t, html, "aria-live",
+		"the reconnect banner must announce to assistive tech")
 }
 
 // The reconnect manager must also publish connection status as a


### PR DESCRIPTION
Re-review minor items **S11** + **S6**, plus a justified descope of S5.

- **S11:** reconnect banner had `role=status` but no `aria-live` → add `aria-live=polite` so AT announces a drop.
- **S6:** `(*CtxR).rctx()` derefs `r.ctx` with no nil guard → a typed-nil `*CtxR` panicked before `Read`'s `ctx==nil` check. Guarded at the single chokepoint (consistent with CtxR's other accessors). Defensive — never hit on framework paths.

## Descoped from S5 (with reasons — both are foot-guns)
- **`/readyz` fail on halted projector:** a forward-incompat halt is roll-forward-only and usually hits *every* pod for that key, so failing readiness would pull the whole fleet → cascading outage. Halts are already observable via `via.events.forward_incompatible` / `via.snapshot.*_halt` + the alerting-hints doc. Net: adds outage risk, no new visibility.
- **"set draining last":** `draining` is set *first* on purpose — `/readyz` must report not-ready at the *start* of shutdown so the LB stops routing while you drain. Setting it last defeats the whole point.

## Tests
- `Read(nil *CtxR)` → no panic, zero value (StateApp + StateSess)
- reconnect script carries `aria-live`; browser reconnect test still green

Full `ci-check.sh` green.