### PR TITLE
Add 'built with via' badges to branding

### DIFF
--- a/branding/README.md
+++ b/branding/README.md
@@ -48,6 +48,23 @@ App-icon badges carry their own background, so they need no theme variant:
 <img alt="VIA" src="branding/icon-ink-amber.svg" width="96">
 ```
 
+## Badge
+
+"Built with via" badges for READMEs. Both carry their own background, so
+they need no theme variant.
+
+For-the-badge style (amber label, ink value with the cream bolt):
+
+```html
+<img alt="built with via" src="branding/badge-built-with-via.svg" height="28">
+```
+
+Shield style (compact flat badge, amber `via` chip with the amber bolt):
+
+```html
+<img alt="built with: via" src="branding/badge-built-with-via-shield.svg" height="20">
+```
+
 ## Files
 
 | Asset | Light | Dark |
@@ -62,3 +79,5 @@ App-icon badges carry their own background, so they need no theme variant:
 | App icon · amber/ink | `icon-amber-ink.svg` | — |
 | App icon · cream/ink | `icon-cream-ink.svg` | — |
 | App icon · ink/amber outline | `icon-ink-amber-outline.svg` | — |
+| Badge · built with via | `badge-built-with-via.svg` | — |
+| Badge · built with via (shield) | `badge-built-with-via-shield.svg` | — |

--- a/branding/badge-built-with-via-shield.svg
+++ b/branding/badge-built-with-via-shield.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="102" height="20" role="img" aria-label="built with: via">
+<title>built with: via</title>
+<clipPath id="r"><rect width="102" height="20" rx="3" fill="#fff"></rect></clipPath>
+<g clip-path="url(#r)">
+<rect width="74" height="20" fill="#555"></rect>
+<rect x="74" width="28" height="20" fill="#ffbf00"></rect>
+</g>
+<svg x="7" y="4.5" width="10.21" height="11" viewBox="38 45 130 140"><path fill="#ffbf00" d="M 109,45 L 119,45 L 92,97 L 168,97 L 100,185 L 91,185 L 116,142 L 38,142 Z"></path></svg>
+<g font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
+<text x="22.21" y="15" fill="#010101" fill-opacity=".3">built with</text>
+<text x="22.21" y="14" fill="#fff">built with</text>
+<text x="88" y="14" fill="#0b0b0f" text-anchor="middle" font-weight="500">via</text>
+</g>
+</svg>

--- a/branding/badge-built-with-via.svg
+++ b/branding/badge-built-with-via.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="28" role="img" aria-label="built with via">
+<title>built with via</title>
+<clipPath id="r2"><rect width="140" height="28" rx="4" fill="#fff"></rect></clipPath>
+<g clip-path="url(#r2)">
+<rect width="87" height="28" fill="#ffbf00"></rect>
+<rect x="87" width="53" height="28" fill="#101015"></rect>
+</g>
+<text x="12" y="18.5" fill="#0b0b0f" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-weight="700" font-size="10" letter-spacing="0.9">BUILT WITH</text>
+<svg x="100" y="9.5" width="27" height="9" viewBox="5 52 294 98"><path fill="#efece4" d="M 5.18 52 L 28.58 52 L 71.70 150 L 48.30 150 Z"></path><path fill="#efece4" d="M 91.42 52 L 114.82 52 L 71.70 150 L 48.30 150 Z"></path><path fill="#efece4" d="M 232.30 52 L 255.70 52 L 212.58 150 L 189.18 150 Z"></path><path fill="#efece4" d="M 232.30 52 L 255.70 52 L 298.82 150 L 275.42 150 Z"></path><path fill="#ffbf00" d="M 162.36 52 L 184.76 52 L 141.64 150 L 119.24 150 Z"></path></svg>
+</svg>

--- a/docs/assets/branding/badge-built-with-via-shield.svg
+++ b/docs/assets/branding/badge-built-with-via-shield.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="102" height="20" role="img" aria-label="built with: via">
+<title>built with: via</title>
+<clipPath id="r"><rect width="102" height="20" rx="3" fill="#fff"></rect></clipPath>
+<g clip-path="url(#r)">
+<rect width="74" height="20" fill="#555"></rect>
+<rect x="74" width="28" height="20" fill="#ffbf00"></rect>
+</g>
+<svg x="7" y="4.5" width="10.21" height="11" viewBox="38 45 130 140"><path fill="#ffbf00" d="M 109,45 L 119,45 L 92,97 L 168,97 L 100,185 L 91,185 L 116,142 L 38,142 Z"></path></svg>
+<g font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
+<text x="22.21" y="15" fill="#010101" fill-opacity=".3">built with</text>
+<text x="22.21" y="14" fill="#fff">built with</text>
+<text x="88" y="14" fill="#0b0b0f" text-anchor="middle" font-weight="500">via</text>
+</g>
+</svg>

--- a/docs/assets/branding/badge-built-with-via.svg
+++ b/docs/assets/branding/badge-built-with-via.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="28" role="img" aria-label="built with via">
+<title>built with via</title>
+<clipPath id="r2"><rect width="140" height="28" rx="4" fill="#fff"></rect></clipPath>
+<g clip-path="url(#r2)">
+<rect width="87" height="28" fill="#ffbf00"></rect>
+<rect x="87" width="53" height="28" fill="#101015"></rect>
+</g>
+<text x="12" y="18.5" fill="#0b0b0f" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-weight="700" font-size="10" letter-spacing="0.9">BUILT WITH</text>
+<svg x="100" y="9.5" width="27" height="9" viewBox="5 52 294 98"><path fill="#efece4" d="M 5.18 52 L 28.58 52 L 71.70 150 L 48.30 150 Z"></path><path fill="#efece4" d="M 91.42 52 L 114.82 52 L 71.70 150 L 48.30 150 Z"></path><path fill="#efece4" d="M 232.30 52 L 255.70 52 L 212.58 150 L 189.18 150 Z"></path><path fill="#efece4" d="M 232.30 52 L 255.70 52 L 298.82 150 L 275.42 150 Z"></path><path fill="#ffbf00" d="M 162.36 52 L 184.76 52 L 141.64 150 L 119.24 150 Z"></path></svg>
+</svg>


### PR DESCRIPTION
Imports the "built with via" badges from Claude Design into the branding assets.

## Changes

- `branding/badge-built-with-via.svg` — for-the-badge style (140×28), amber label / ink value with the cream bolt.
- `branding/badge-built-with-via-shield.svg` — shield/flat style (102×20), amber `via` chip with the amber bolt.
- Mirrored both into `docs/assets/branding/`.
- `branding/README.md` — new **Badge** section documenting both styles, plus Files-table rows.

Both badges carry their own background, so — like the app icon — they need no light/dark theme variant. All SVGs validate as well-formed.

---
_Generated by [Claude Code](https://claude.ai/code/session_015YAhq7X4S3Hi8e2kCvuNAY)_